### PR TITLE
Fix mermaid diagram syntax

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,8 @@ This diagram illustrates the high-level relationships between the system's compo
 
 ```mermaid
 graph TD
-    subgraph "User / Bot Traffic" direction LR
+    subgraph "User / Bot Traffic"
+        direction LR
         User[<font size=5>👤</font><br>User]
         Bot[<font size=5>🤖</font><br>Bot]
     end


### PR DESCRIPTION
## Summary
- correct mermaid `subgraph` block in architecture.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(failed to build llama-cpp-python)*

------
https://chatgpt.com/codex/tasks/task_e_68770769970c832182a44e18b3556c3d