### PR TITLE
Centralize secret loading and fix Redis imports

### DIFF
--- a/src/escalation/escalation_engine.py
+++ b/src/escalation/escalation_engine.py
@@ -17,6 +17,7 @@ import sys
 # --- Refactored Imports ---
 from src.shared.model_provider import load_model
 from src.shared.redis_client import get_redis_connection
+from src.shared.config import get_secret
 
 # --- Setup Logging ---
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -90,12 +91,10 @@ LOCAL_LLM_API_URL = os.getenv("LOCAL_LLM_API_URL")
 LOCAL_LLM_MODEL = os.getenv("LOCAL_LLM_MODEL")
 LOCAL_LLM_TIMEOUT = float(os.getenv("LOCAL_LLM_TIMEOUT", 45.0))
 EXTERNAL_API_URL = os.getenv("EXTERNAL_CLASSIFICATION_API_URL") if os.getenv("EXTERNAL_CLASSIFICATION_API_URL") else os.getenv("EXTERNAL_API_URL")
-EXTERNAL_API_KEY_FILE = os.getenv("EXTERNAL_CLASSIFICATION_API_KEY_FILE", "/run/secrets/external_api_key.txt")
 EXTERNAL_API_TIMEOUT = float(os.getenv("EXTERNAL_API_TIMEOUT", 15.0))
 
 ENABLE_IP_REPUTATION = os.getenv("ENABLE_IP_REPUTATION", "false").lower() == "true"
 IP_REPUTATION_API_URL = os.getenv("IP_REPUTATION_API_URL")
-IP_REPUTATION_API_KEY_FILE = os.getenv("IP_REPUTATION_API_KEY_FILE", "/run/secrets/ip_reputation_api_key.txt")
 IP_REPUTATION_TIMEOUT = float(os.getenv("IP_REPUTATION_TIMEOUT", 10.0))
 IP_REPUTATION_MALICIOUS_SCORE_BONUS = float(os.getenv("IP_REPUTATION_MALICIOUS_SCORE_BONUS", 0.3))
 IP_REPUTATION_MIN_MALICIOUS_THRESHOLD = float(os.getenv("IP_REPUTATION_MIN_MALICIOUS_THRESHOLD", 50))
@@ -123,16 +122,9 @@ KNOWN_BENIGN_CRAWLERS_UAS_ENV = os.getenv("KNOWN_BENIGN_CRAWLERS_UAS", 'googlebo
 KNOWN_BENIGN_CRAWLERS_UAS = [ua.strip() for ua in KNOWN_BENIGN_CRAWLERS_UAS_ENV.split(',') if ua.strip()]
 
 
-# --- Load Secrets (Preserved) ---
-def load_secret(file_path: Optional[str]) -> Optional[str]:
-    if file_path and os.path.exists(file_path):
-        try:
-            with open(file_path, 'r') as f: return f.read().strip()
-        except Exception as e: logger.error(f"Failed to read secret from {file_path}: {e}")
-    return None
-
-EXTERNAL_API_KEY = load_secret(EXTERNAL_API_KEY_FILE)
-IP_REPUTATION_API_KEY = load_secret(IP_REPUTATION_API_KEY_FILE)
+# --- Load Secrets ---
+EXTERNAL_API_KEY = get_secret("EXTERNAL_CLASSIFICATION_API_KEY_FILE")
+IP_REPUTATION_API_KEY = get_secret("IP_REPUTATION_API_KEY_FILE")
 
 # --- Setup Clients & Load Resources ---
 # The manual joblib loading and redis pool have been replaced by these abstractions.

--- a/src/tarpit/ip_flagger.py
+++ b/src/tarpit/ip_flagger.py
@@ -5,7 +5,7 @@ utility from the 'shared' module.
 """
 import sys
 import logging
-from shared.redis_client import get_redis_connection
+from src.shared.redis_client import get_redis_connection
 
 # Configure logging for this module
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/src/tarpit/tarpit_api.py
+++ b/src/tarpit/tarpit_api.py
@@ -81,7 +81,7 @@ BLOCKLIST_TTL_SECONDS = int(os.getenv("BLOCKLIST_TTL_SECONDS", 86400))
 
 # --- THIS IS THE SOLE REFACTORING CHANGE ---
 # Replaced the manual Redis Connection Pools with calls to the centralized client.
-from shared.redis_client import get_redis_connection
+from src.shared.redis_client import get_redis_connection
 redis_hops = get_redis_connection(db_number=REDIS_DB_TAR_PIT_HOPS)
 redis_blocklist = get_redis_connection(db_number=REDIS_DB_BLOCKLIST)
 

--- a/test/escalation/test_escalation_engine.py
+++ b/test/escalation/test_escalation_engine.py
@@ -21,7 +21,6 @@ class TestEscalationEngineComprehensive(unittest.IsolatedAsyncioTestCase):
         self.client = TestClient(app)
         # Patch all key functions and module-level objects to isolate the endpoint logic
         self.patchers = {
-            'load_secret': patch('escalation.escalation_engine.load_secret'),
             'load_robots_txt': patch('escalation.escalation_engine.load_robots_txt'),
             'get_redis_connection': patch('escalation.escalation_engine.get_redis_connection'),
             # Correctly patch the module-level variable, not the function that creates it


### PR DESCRIPTION
## Summary
- remove unused FastAPI import
- use `get_secret` from shared config for ai_service and escalation_engine
- defer Redis setup through shared client
- fix Redis client imports in tarpit modules
- update escalation engine tests for patch changes

## Testing
- `python test/run_all_tests.py` *(fails: ImportError and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68773f57cf80832191a995e00acb23df