### PR TITLE
Improve webhook security and import handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ schedule~=1.2
 # HTTP and Web Scraping
 httpx~=0.27
 requests~=2.31
-beautifulsoup4~=4.12
 lxml>=4.9,<6.0
 wikipedia~=1.4
 prometheus-client~=0.18

--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -279,6 +279,9 @@ async def send_alert(event_data: WebhookEvent):
 # --- Simple Webhook Endpoint for tests ---
 @app.route("/webhook", methods=["POST"])
 def webhook_receiver():
+    api_key_required = os.getenv("WEBHOOK_API_KEY")
+    if api_key_required and request.headers.get("X-API-Key") != api_key_required:
+        return jsonify({"error": "Unauthorized"}), 401
     payload = request.get_json() or {}
     redis_conn = get_redis_connection()
     if not redis_conn:

--- a/src/tarpit/rotating_archive.py
+++ b/src/tarpit/rotating_archive.py
@@ -10,9 +10,11 @@ import sys
 # --- Import the generator script ---
 try:
     from js_zip_generator import create_fake_js_zip, DEFAULT_ARCHIVE_DIR
-except ImportError:
-    print("ERROR: Could not import create_fake_js_zip from js_zip_generator.py. Ensure it's in the same directory or PYTHONPATH.")
-    sys.exit(1)
+except ImportError as e:
+    # Raise a clearer error so importing modules (like tests) fail gracefully
+    raise ImportError(
+        "js_zip_generator.py is required for rotating_archive but could not be found"
+    ) from e
 
 # --- Configuration ---
 ARCHIVE_DIR = DEFAULT_ARCHIVE_DIR


### PR DESCRIPTION
## Summary
- remove unused `beautifulsoup4` dependency
- raise a clearer error instead of exiting when `js_zip_generator` is missing
- require `WEBHOOK_API_KEY` header for AI webhook

## Testing
- `python test/run_all_tests.py` *(fails: Test suite failed)*

------
https://chatgpt.com/codex/tasks/task_e_68784a8a5d8483218476e5672bf454f5