### PR TITLE
Fix labeler paths for src directories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,22 +8,22 @@ documentation:
 # Add 'tarpit' label for changes in the tarpit service
 tarpit:
   - changed-files:
-      - any-glob-to-any-file: ['tarpit/**']
+      - any-glob-to-any-file: ['src/tarpit/**']
 
 # Add 'escalation' label for changes in the escalation engine
 escalation:
   - changed-files:
-      - any-glob-to-any-file: ['escalation/**']
+      - any-glob-to-any-file: ['src/escalation/**']
 
 # Add 'ui' label for changes in the admin UI
 ui:
   - changed-files:
-      - any-glob-to-any-file: ['admin_ui/**']
+      - any-glob-to-any-file: ['src/admin_ui/**']
 
 # Add 'ai/rag' label for changes related to AI/LLM components
 ai/rag:
   - changed-files:
-      - any-glob-to-any-file: ['rag/**', 'ai_service/**']
+      - any-glob-to-any-file: ['src/rag/**', 'src/ai_service/**']
 
 # Add 'nginx' label for changes to NGINX or Lua configs
 nginx:


### PR DESCRIPTION
## Summary
- update `.github/labeler.yml` so path patterns map to `src/*` directories

## Testing
- `python3 test/run_all_tests.py` *(fails: Redis and other services unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6878aad0c5708321ab3933dc97fd797d