### PR TITLE
Add browser fingerprint tracking and expiry for flagged IPs

### DIFF
--- a/src/tarpit/__init__.py
+++ b/src/tarpit/__init__.py
@@ -1,5 +1,8 @@
 from . import ip_flagger, js_zip_generator, markov_generator, rotating_archive, tarpit_api
-import tarpit_rs
+try:
+    import tarpit_rs
+except Exception:  # pragma: no cover - optional dependency
+    tarpit_rs = None
 try:
     import jszip_rs
 except Exception:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- track browser fingerprint reuse to help decide about escalation
- expire IP flags after a configurable TTL and make repeat offenders permanent
- adjust imports to avoid optional dependency failures
- update unit tests for new behaviour

## Testing
- `PYTHONPATH=src python -m pytest test/tarpit/test_ip_flagger.py -q`
- `PYTHONPATH=src python -m pytest test/escalation/test_escalation_engine.py::TestEscalationEngineComprehensive::test_escalate_endpoint_bot_high_score_webhook -q` *(fails: KeyError 'details')*

------
https://chatgpt.com/codex/tasks/task_e_6878bf46022c8321b18e944dba2173c3