### PR TITLE
Fix duplicate imports

### DIFF
--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -2,7 +2,6 @@ import os
 from typing import Dict, Any
 
 # In shared/config.py
-import os
 
 def get_secret(file_variable_name: str) -> str | None:
     """Reads a secret from the file path specified in an environment variable."""

--- a/test/escalation/test_escalation_engine.py
+++ b/test/escalation/test_escalation_engine.py
@@ -5,7 +5,6 @@ import httpx
 import datetime
 import json
 from fastapi.testclient import TestClient
-import httpx
 import sys
 import os
 


### PR DESCRIPTION
## Summary
- deduplicate imports in `src/shared/config.py`
- remove repeated `httpx` import in `test_escalation_engine.py`

## Testing
- `pytest -q` *(fails: AssertionError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6879fd9f589c8321a95cedcf68ac39ec