### PR TITLE
Use scan_iter for rate limit counts

### DIFF
--- a/src/util/adaptive_rate_limit_manager.py
+++ b/src/util/adaptive_rate_limit_manager.py
@@ -25,7 +25,7 @@ def get_recent_counts(redis_conn, window_seconds: int) -> List[int]:
     start = now - window_seconds
     counts: List[int] = []
     try:
-        for key in redis_conn.keys(f"{FREQUENCY_KEY_PREFIX}*"):
+        for key in redis_conn.scan_iter(match=f"{FREQUENCY_KEY_PREFIX}*"):
             count = redis_conn.zcount(key, start, now)
             if isinstance(count, int):
                 counts.append(count)

--- a/test/util/test_adaptive_rate_limit_manager.py
+++ b/test/util/test_adaptive_rate_limit_manager.py
@@ -8,7 +8,7 @@ from src.util import adaptive_rate_limit_manager as manager
 class TestAdaptiveRateLimitManager(unittest.TestCase):
     def test_get_recent_counts(self):
         redis = MagicMock()
-        redis.keys.return_value = ["freq:1", "freq:2"]
+        redis.scan_iter.return_value = iter(["freq:1", "freq:2"])
         redis.zcount.side_effect = [5, 8]
         counts = manager.get_recent_counts(redis, 60)
         self.assertEqual(counts, [5, 8])


### PR DESCRIPTION
## Summary
- avoid Redis blocking scans by iterating with `scan_iter`
- update unit test to patch `scan_iter`

## Testing
- `python3 test/run_all_tests.py` *(fails: test_log_honeypot_hit_logger_exception, test_log_honeypot_hit_success)*

------
https://chatgpt.com/codex/tasks/task_e_687a10fb558c8321be45ea70aec1fca6