### PR TITLE
Refactor ai_webhook to FastAPI

### DIFF
--- a/test/ai_webhook/test_ai_webhook.py
+++ b/test/ai_webhook/test_ai_webhook.py
@@ -1,15 +1,14 @@
 # test/ai_webhook/test_ai_webhook.py
 import unittest
 from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
 from src.ai_service import ai_webhook
-import json
 
 class TestAIWebhookComprehensive(unittest.TestCase):
 
     def setUp(self):
-        """Set up the Flask test client and patch dependencies."""
-        ai_webhook.app.config['TESTING'] = True
-        self.client = ai_webhook.app.test_client()
+        """Set up the FastAPI test client and patch dependencies."""
+        self.client = TestClient(ai_webhook.app)
 
         # The function is imported from shared.redis_client into the ai_webhook module.
         # Therefore, we must patch it where it is used.
@@ -32,9 +31,9 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         }
         self.mock_redis_client.sadd.return_value = 1
         response = self.client.post('/webhook', json=payload)
-        
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, {'status': 'success', 'message': 'IP 10.0.0.1 added to blocklist.'})
+        self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 10.0.0.1 added to blocklist.'})
         self.mock_redis_client.sadd.assert_called_once_with('blocklist', '10.0.0.1')
 
     def test_webhook_receiver_allow_ip_success(self):
@@ -42,9 +41,9 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         payload = {"action": "allow_ip", "ip": "20.0.0.2"}
         self.mock_redis_client.srem.return_value = 1
         response = self.client.post('/webhook', json=payload)
-        
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, {'status': 'success', 'message': 'IP 20.0.0.2 removed from blocklist.'})
+        self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 20.0.0.2 removed from blocklist.'})
         self.mock_redis_client.srem.assert_called_once_with('blocklist', '20.0.0.2')
         
     def test_webhook_receiver_flag_ip_success(self):
@@ -52,9 +51,9 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         payload = {"action": "flag_ip", "ip": "30.0.0.3", "reason": "Suspicious activity"}
         self.mock_redis_client.set.return_value = True
         response = self.client.post('/webhook', json=payload)
-        
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, {'status': 'success', 'message': 'IP 30.0.0.3 flagged.'})
+        self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 30.0.0.3 flagged.'})
         # The key name is defined inside the ai_webhook script
         self.mock_redis_client.set.assert_called_once_with('ip_flag:30.0.0.3', 'Suspicious activity')
 
@@ -63,9 +62,9 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         payload = {"action": "unflag_ip", "ip": "40.0.0.4"}
         self.mock_redis_client.delete.return_value = 1
         response = self.client.post('/webhook', json=payload)
-        
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, {'status': 'success', 'message': 'IP 40.0.0.4 unflagged.'})
+        self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 40.0.0.4 unflagged.'})
         self.mock_redis_client.delete.assert_called_once_with('ip_flag:40.0.0.4')
 
     def test_webhook_receiver_invalid_action(self):
@@ -73,14 +72,14 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         payload = {"action": "reboot_server", "ip": "1.2.3.4"}
         response = self.client.post('/webhook', json=payload)
         self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid action", response.json['error'])
+        self.assertIn("Invalid action", response.json()['detail'])
 
     def test_webhook_receiver_payload_missing_ip(self):
         """Test that a payload missing the 'ip' field returns a 400 error."""
         payload = {"action": "block_ip", "reason": "No IP here."}
         response = self.client.post('/webhook', json=payload)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['error'], "Missing 'ip' in payload for action 'block_ip'.")
+        self.assertEqual(response.json()['detail'], "Missing 'ip' in payload for action 'block_ip'.")
 
     def test_webhook_receiver_redis_unavailable(self):
         """Test that a 503 error is returned if the Redis connection fails."""
@@ -88,7 +87,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
         response = self.client.post('/webhook', json=payload)
         self.assertEqual(response.status_code, 503)
-        self.assertEqual(response.json['error'], 'Redis service unavailable')
+        self.assertEqual(response.json()['detail'], 'Redis service unavailable')
 
     @patch('src.ai_service.ai_webhook.logger.error')
     def test_webhook_receiver_redis_command_fails(self, mock_logger_error):
@@ -96,9 +95,9 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         self.mock_redis_client.sadd.side_effect = Exception("Redis command failed")
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
         response = self.client.post('/webhook', json=payload)
-        
+
         self.assertEqual(response.status_code, 500)
-        self.assertIn("Failed to execute action", response.json['error'])
+        self.assertIn("Failed to execute action", response.json()['detail'])
         mock_logger_error.assert_called_once()
 
     def test_health_check_healthy(self):
@@ -106,14 +105,14 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         self.mock_redis_client.ping.return_value = True
         response = self.client.get('/health')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, {'status': 'ok', 'redis_connected': True})
+        self.assertEqual(response.json(), {'status': 'ok', 'redis_connected': True})
 
     def test_health_check_unhealthy(self):
         """Test the health check endpoint when Redis is not connected."""
         self.mock_get_redis.return_value = None
         response = self.client.get('/health')
         self.assertEqual(response.status_code, 503)
-        self.assertEqual(response.json, {'status': 'error', 'redis_connected': False})
+        self.assertEqual(response.json(), {'status': 'error', 'redis_connected': False})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- refactor ai_webhook service from Flask to FastAPI
- update webhook and health routes accordingly
- adjust ai_webhook tests to use FastAPI's TestClient

## Testing
- `python test/run_all_tests.py` *(fails: test_log_honeypot_hit_logger_exception, test_log_honeypot_hit_success)*

------
https://chatgpt.com/codex/tasks/task_e_687a10fb6b808321834c58b6492b8217