### PR TITLE
Use logging in rotating archive

### DIFF
--- a/src/tarpit/rotating_archive.py
+++ b/src/tarpit/rotating_archive.py
@@ -4,10 +4,15 @@
 import os
 import glob
 import time
-import schedule # Using 'schedule' library for easy job scheduling
+import schedule  # Using 'schedule' library for easy job scheduling
 import sys
 import logging
 
+# Configure module-level logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
 logger = logging.getLogger(__name__)
 
 # --- Import the generator script ---
@@ -27,12 +32,14 @@ GENERATION_INTERVAL_MINUTES = 60 # Generate a new archive every hour
 
 def rotate_archives():
     """Generates a new archive and cleans up old ones."""
-    print(f"Running archive rotation task at {time.strftime('%Y-%m-%d %H:%M:%S')}...")
+    logger.info(
+        f"Running archive rotation task at {time.strftime('%Y-%m-%d %H:%M:%S')}..."
+    )
 
     # 1. Generate a new archive
     new_archive = create_fake_js_zip(output_dir=ARCHIVE_DIR)
     if not new_archive:
-        print("Archive generation failed. Skipping cleanup.")
+        logger.error("Archive generation failed. Skipping cleanup.")
         return
 
     # 2. Get list of existing archives, sorted by modification time (newest first)
@@ -43,7 +50,9 @@ def rotate_archives():
             reverse=True
         )
     except Exception as e:
-        print(f"ERROR: Failed to list existing archives in {ARCHIVE_DIR}: {e}")
+        logger.error(
+            f"Failed to list existing archives in {ARCHIVE_DIR}: {e}"
+        )
         return
 
     # 3. Determine archives to delete
@@ -51,36 +60,44 @@ def rotate_archives():
 
     # 4. Delete old archives
     if archives_to_delete:
-        print(f"Found {len(existing_archives)} archives. Keeping {MAX_ARCHIVES_TO_KEEP}, deleting {len(archives_to_delete)}.")
+        logger.info(
+            f"Found {len(existing_archives)} archives. Keeping {MAX_ARCHIVES_TO_KEEP}, deleting {len(archives_to_delete)}."
+        )
         for old_archive in archives_to_delete:
             try:
                 os.remove(old_archive)
-                print(f"  Deleted old archive: {old_archive}")
+                logger.info(f"  Deleted old archive: {old_archive}")
             except OSError as e:
                 logger.error(f"Failed to delete old archive {old_archive}: {e}")
     else:
-        print(f"Found {len(existing_archives)} archives. No old archives to delete.")
+        logger.info(
+            f"Found {len(existing_archives)} archives. No old archives to delete."
+        )
 
-    print("Archive rotation task finished.")
+    logger.info("Archive rotation task finished.")
 
 
 # --- Main Execution Logic ---
 if __name__ == "__main__":
-    print("--- Rotating Archive Scheduler ---")
-    print(f"Watching directory: {ARCHIVE_DIR}")
-    print(f"Keeping latest: {MAX_ARCHIVES_TO_KEEP} archives")
-    print(f"Generating new archive every: {GENERATION_INTERVAL_MINUTES} minutes")
-    print("---------------------------------")
+    logger.info("--- Rotating Archive Scheduler ---")
+    logger.info(f"Watching directory: {ARCHIVE_DIR}")
+    logger.info(f"Keeping latest: {MAX_ARCHIVES_TO_KEEP} archives")
+    logger.info(
+        f"Generating new archive every: {GENERATION_INTERVAL_MINUTES} minutes"
+    )
+    logger.info("---------------------------------")
 
     # Schedule the job
     schedule.every(GENERATION_INTERVAL_MINUTES).minutes.do(rotate_archives)
 
     # Run the first rotation immediately
-    print("Running initial rotation...")
+    logger.info("Running initial rotation...")
     rotate_archives()
 
     # Keep the script running to execute scheduled jobs
-    print(f"Scheduler started. Next run in approx {GENERATION_INTERVAL_MINUTES} minutes.")
+    logger.info(
+        f"Scheduler started. Next run in approx {GENERATION_INTERVAL_MINUTES} minutes."
+    )
     while True:
         schedule.run_pending()
         time.sleep(60) # Check every minute


### PR DESCRIPTION
## Summary
- configure logging in rotating_archive module
- replace `print` statements with `logger` calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1c2986348321b4af492d7efaed9f