### PR TITLE
Switch admin UI to FastAPI

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ The AI Scraping Defense system is designed as a distributed, microservice-based 
   - **AI Service:** A simple webhook that receives suspicious request data from Nginx and queues it for analysis by the Escalation Engine.
   - **Escalation Engine:** The central analysis component. It runs a multi-stage pipeline to score requests, using heuristics, a machine learning model, and optionally a powerful LLM for a final verdict.
   - **Tarpit API:** Provides a set of "tarpits" (e.g., zip bombs, slow responses, nonsensical data) designed to waste the resources of confirmed malicious bots.
-  - **Admin UI:** A Flask-based web interface for monitoring system metrics, viewing the blocklist, and managing basic settings.
+  - **Admin UI:** A FastAPI-based web interface for monitoring system metrics, viewing the blocklist, and managing basic settings.
 
 - **Data Stores:**
   - **Redis:** An in-memory data store used for high-speed operations like caching, managing the IP blocklist, and tracking request frequencies.

--- a/docs/third_party_licenses.md
+++ b/docs/third_party_licenses.md
@@ -13,7 +13,6 @@ This project utilizes various open-source components and libraries. We gratefull
 | **GoAccess**                | MIT             | [https://github.com/allinurl/goaccess](https://github.com/allinurl/goaccess)                  |
 | **Ubuntu** (Base Image)     | Various Open Src| [https://ubuntu.com/licensing](https://ubuntu.com/licensing)                                  |
 | **--- Python Packages ---** |                 |                                                                                               |
-| Flask                       | BSD-3-Clause    | [https://github.com/pallets/flask](https://github.com/pallets/flask)                          |
 | FastAPI                     | MIT             | [https://github.com/tiangolo/fastapi](https://github.com/tiangolo/fastapi)                    |
 | Uvicorn                     | BSD-3-Clause    | [https://github.com/encode/uvicorn](https://github.com/encode/uvicorn)                        |
 | Requests                    | Apache-2.0      | [https://github.com/psf/requests](https://github.com/psf/requests)                            |

--- a/kubernetes/admin-ui-deployment.yaml
+++ b/kubernetes/admin-ui-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       - name: admin-ui
         # IMPORTANT: Replace with your actual container image registry and tag.
         image: your-registry/ai-scraping-defense:latest
-        # Updated command to run the Flask app from its new path.
+        # Command to run the FastAPI admin UI.
         command: ["python", "src/admin_ui/admin_ui.py"]
         ports:
         - containerPort: 5002

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 fastapi~=0.115
 uvicorn[standard]~=0.27
 gunicorn~=21.2
-flask~=3.0
 
 # Data and Database
 psycopg2-binary~=2.9

--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -82,7 +82,9 @@ async def metrics_endpoint():
     try:
         metrics_dict = _get_metrics_dict_func()
     except Exception as exc:  # pragma: no cover - defensive
-        return JSONResponse({"error": str(exc)}, status_code=500)
+        import logging
+        logging.error("An error occurred in the metrics endpoint", exc_info=True)
+        return JSONResponse({"error": "An internal error occurred"}, status_code=500)
 
     if isinstance(metrics_dict, dict) and metrics_dict.get("error"):
         return JSONResponse(metrics_dict, status_code=500)

--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -1,14 +1,18 @@
 # src/admin_ui/admin_ui.py
-"""Flask admin interface for monitoring and management.
+"""FastAPI admin interface for monitoring and management.
 
-This module exposes a small Flask application used by the defense stack's
+This module exposes a small FastAPI application used by the defense stack's
 administrators. It provides endpoints for viewing Prometheus metrics, managing
 IP block lists stored in Redis and adjusting basic settings. The application is
 designed to be run as a standalone service or within Docker.
 """
 import os
 import asyncio
-from flask import Flask, render_template, jsonify, request
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from jinja2 import pass_context
 from src.shared.redis_client import get_redis_connection
 from src.shared.metrics import get_metrics
 
@@ -45,103 +49,113 @@ def _get_metrics_dict() -> dict:
 # Exposed for tests so they can patch the behaviour
 _get_metrics_dict_func = _get_metrics_dict
 
-app = Flask(__name__)
+BASE_DIR = os.path.dirname(__file__)
+app = FastAPI()
+templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
+app.mount("/static", StaticFiles(directory=os.path.join(BASE_DIR, "static")), name="static")
 
 
-@app.route("/")
-def index():
+@pass_context
+def _jinja_url_for(context, name: str, **path_params) -> str:
+    """Support Flask-style 'filename' parameter for static files."""
+    request: Request = context["request"]
+    if "filename" in path_params:
+        path_params["path"] = path_params.pop("filename")
+    return request.url_for(name, **path_params)
+
+
+templates.env.globals["url_for"] = _jinja_url_for
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
     """Serves the main dashboard HTML page."""
-    return render_template("index.html")
+    return templates.TemplateResponse("index.html", {"request": request})
 
 
-@app.route("/metrics")
-def metrics_endpoint():
+@app.get("/metrics")
+async def metrics_endpoint():
     """Return metrics in JSON form for the admin dashboard."""
     if not METRICS_TRULY_AVAILABLE:
-        return jsonify({"error": "Metrics module not available"}), 503
+        return JSONResponse({"error": "Metrics module not available"}, status_code=503)
 
     try:
         metrics_dict = _get_metrics_dict_func()
     except Exception as exc:  # pragma: no cover - defensive
-        return jsonify({"error": str(exc)}), 500
+        return JSONResponse({"error": str(exc)}, status_code=500)
 
     if isinstance(metrics_dict, dict) and metrics_dict.get("error"):
-        return jsonify(metrics_dict), 500
+        return JSONResponse(metrics_dict, status_code=500)
 
-    return jsonify(metrics_dict), 200
+    return JSONResponse(metrics_dict, status_code=200)
 
 
-@app.route("/blocklist", methods=["GET"])
-def get_blocklist():
+@app.get("/blocklist")
+async def get_blocklist():
     redis_conn = get_redis_connection()
     if not redis_conn:
-        return jsonify({"error": "Redis service unavailable"}), 503
+        return JSONResponse({"error": "Redis service unavailable"}, status_code=503)
 
     blocklist_set = redis_conn.smembers("blocklist")
-    # If blocklist_set is awaitable (async), await it
     if asyncio.iscoroutine(blocklist_set):
-        blocklist_set = asyncio.run(blocklist_set)
+        blocklist_set = await blocklist_set
 
-    # Ensure blocklist_set is a set or list before converting to list
     if blocklist_set and isinstance(blocklist_set, (set, list)):
-        return jsonify(list(blocklist_set))
+        return JSONResponse(list(blocklist_set))
     else:
-        # If the set is empty or None, return an empty JSON array.
-        return jsonify([])
+        return JSONResponse([])
 
 
-@app.route("/block", methods=["POST"])
-def block_ip():
-    # Add a check to ensure request.json is not None.
-    json_data = request.get_json()
+@app.post("/block")
+async def block_ip(request: Request):
+    json_data = await request.json()
     if not json_data:
-        return jsonify({"error": "Invalid request, missing JSON body"}), 400
+        return JSONResponse({"error": "Invalid request, missing JSON body"}, status_code=400)
 
     ip = json_data.get("ip")
     if not ip:
-        return jsonify({"error": "Invalid request, missing ip"}), 400
+        return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
 
     redis_conn = get_redis_connection()
     if not redis_conn:
-        return jsonify({"error": "Redis service unavailable"}), 503
+        return JSONResponse({"error": "Redis service unavailable"}, status_code=503)
 
     redis_conn.sadd("blocklist", ip)
-    return jsonify({"status": "success", "ip": ip})
+    return JSONResponse({"status": "success", "ip": ip})
 
 
-@app.route("/unblock", methods=["POST"])
-def unblock_ip():
-    # Add a check to ensure request.json is not None.
-    json_data = request.get_json()
+@app.post("/unblock")
+async def unblock_ip(request: Request):
+    json_data = await request.json()
     if not json_data:
-        return jsonify({"error": "Invalid request, missing JSON body"}), 400
+        return JSONResponse({"error": "Invalid request, missing JSON body"}, status_code=400)
 
     ip = json_data.get("ip")
     if not ip:
-        return jsonify({"error": "Invalid request, missing ip"}), 400
+        return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
 
     redis_conn = get_redis_connection()
     if not redis_conn:
-        return jsonify({"error": "Redis service unavailable"}), 503
+        return JSONResponse({"error": "Redis service unavailable"}, status_code=503)
 
     redis_conn.srem("blocklist", ip)
-    return jsonify({"status": "success", "ip": ip})
+    return JSONResponse({"status": "success", "ip": ip})
 
 
-@app.route("/settings")
-def settings_page():
+@app.get("/settings", response_class=HTMLResponse)
+async def settings_page(request: Request):
     """Renders the system settings page."""
     current_settings = {
         "Model URI": os.getenv("MODEL_URI", "Not Set"),
         "Log Level": os.getenv("LOG_LEVEL", "INFO"),
         "Escalation Engine URL": os.getenv("ESCALATION_ENGINE_URL", "http://escalation_engine:8003/escalate"),
     }
-    return render_template("settings.html", settings=current_settings)
+    return templates.TemplateResponse("settings.html", {"request": request, "settings": current_settings})
 
 
 if __name__ == "__main__":
-    # Use environment variables for host and port, with defaults.
+    import uvicorn
     host = os.getenv("FLASK_RUN_HOST", "0.0.0.0")
     port = int(os.getenv("ADMIN_UI_PORT", 5002))
-    debug = os.getenv("FLASK_ENV", "development") == "development"
-    app.run(host=host, port=port, debug=debug)
+    log_level = os.getenv("LOG_LEVEL", "info").lower()
+    uvicorn.run("src.admin_ui.admin_ui:app", host=host, port=port, log_level=log_level)

--- a/src/admin_ui/static/admin.js
+++ b/src/admin_ui/static/admin.js
@@ -7,7 +7,7 @@ async function fetchMetrics() {
     errorMessageElement.style.display = 'none'; // Hide error on new fetch attempt
     try {
         // Use relative URL to fetch from the same origin
-        const response = await fetch('/metrics'); // Fetches from the Flask endpoint
+        const response = await fetch('/metrics'); // Fetches from the FastAPI endpoint
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## Summary
- rewrite admin UI with FastAPI
- remove Flask from dependencies
- update admin UI tests for FastAPI
- update documentation to reflect new framework
- minor cleanup in Kubernetes YAML and admin UI JS

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687a1c2fb4d48321a818754f73863011