### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/src/escalation/escalation_engine.py
+++ b/src/escalation/escalation_engine.py
@@ -686,7 +686,7 @@ async def get_metrics_endpoint_escalation():
         return Response(content=prometheus_metrics_bytes, media_type="text/plain; version=0.0.4")
     except Exception as e:
         logger.error(f"Error retrieving metrics: {e}", exc_info=True)
-        return Response(content=f"# Error retrieving metrics: {e}\n".encode('utf-8'), media_type="text/plain; version=0.0.4", status_code=500)
+        return Response(content=b"# Error retrieving metrics\n", media_type="text/plain; version=0.0.4", status_code=500)
 
 # --- Health Check Endpoint (Preserved) ---
 @app.get("/health")


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/11](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/11)

To resolve the information exposure issue in the `/metrics` endpoint, modify the code so that the detailed exception message is not included in the HTTP response to the client. Instead, log the detailed exception server-side using the existing `logger.error` call (already present with `exc_info=True` for stack trace logging), and send a generic error message in the response. Specifically, replace the construction of the response in the `except Exception as e` block (line 689) to use a generic message such as `"# Error retrieving metrics\n"`.

Only the lines constructing the response in the exception block need to be changed, within the `/metrics` endpoint function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
