### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yaml
+++ b/.github/workflows/ci-cd-pipeline.yaml
@@ -1,6 +1,8 @@
 # This GitHub Actions workflow defines the Continuous Integration (CI) and
 # Continuous Deployment (CD) pipeline for the project.
 name: CI-CD Pipeline
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/3](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/3)

To fix the problem, explicitly add a `permissions` block at the root of the workflow YAML file, just after the `name:` and before `on:`. This block will set the default permissions for all jobs in the workflow. Since the jobs in this workflow only check out code and deploy to Kubernetes (and do not require write access to the repository or pull requests), the safest minimal configuration is:

```yaml
permissions:
  contents: read
```

This will ensure that the `GITHUB_TOKEN` only has read access to repository contents, which is sufficient for checking out code. If future steps require additional permissions (for example, to create a release, comment on issues, etc.), those specific permissions should be granted explicitly. No other changes are required for this fix.

**Changes to make:**
- Insert the `permissions` block (as above) after the `name: CI-CD Pipeline` line (line 3) and before `on:` (line 6).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
