### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yaml
+++ b/.github/workflows/ci-cd-pipeline.yaml
@@ -1,6 +1,8 @@
 # This GitHub Actions workflow defines the Continuous Integration (CI) and
 # Continuous Deployment (CD) pipeline for the project.
 name: CI-CD Pipeline
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:
@@ -50,6 +52,9 @@ jobs:
 
   # This job deploys the application to Kubernetes
   deploy:
+    permissions:
+      contents: read
+      deployments: write
     # This job will only run after the 'build_and_test' job completes successfully
     needs: build_and_test
     # This condition ensures the deployment only happens on a direct push to the 'main' branch,


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/2](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/2)

To resolve the issue, the following steps should be taken:
1. Add a `permissions` key at the root of the workflow to set default permissions for all jobs. Since the workflow does not appear to perform any operations requiring write access, `contents: read` is sufficient for most steps.
2. If specific jobs (e.g., deployment) require additional permissions, override the default permissions by adding a `permissions` block to those jobs.

This approach ensures that the `GITHUB_TOKEN` is limited to only the necessary permissions, enhancing security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
