### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 on:
   workflow_dispatch: # Allows manual triggering of the workflow from the GitHub UI
@@ -6,7 +8,6 @@ on:
   #   branches: [ "main" ]
   # pull_request:
   #   branches: [ "main" ]
-    
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/1](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/1)

To fix the problem, add a `permissions` key at the workflow level. This ensures that all jobs in the workflow inherit the least required permissions unless overridden. Based on the actions used in the workflow (e.g., `actions/checkout@v4`), the minimal required permission is `contents: read`. 

Specifically:
1. Add the `permissions` key at the top level of the workflow file.
2. Set `contents: read` to limit access to repository contents.
3. Avoid granting unnecessary write permissions unless explicitly required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
