### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/src/shared/redis_client.py
+++ b/src/shared/redis_client.py
@@ -16,7 +16,7 @@ def get_redis_connection(db_number=0):
             with open(password_file, 'r') as f:
                 password = f.read().strip()
         except FileNotFoundError:
-            logging.error(f"Redis password file not found at {password_file}")
+            logging.error("Redis password file not found.")
             return None
     
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/5](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/5)

To fix the issue, we should avoid logging the value of the `REDIS_PASSWORD_FILE` environment variable (`password_file`) directly. Instead, log a generic error message indicating that the password file could not be found, without revealing its path or name. This avoids leaking potentially sensitive information in logs, while still making the error clear for debugging purposes.

- Only change the logging statement on line 19.
- Do not log the path or filename; simply state that the Redis password file was not found.
- No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
