### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/src/rag/train_markov_postgres.py
+++ b/src/rag/train_markov_postgres.py
@@ -41,7 +41,7 @@ def get_pg_password():
             if os.path.exists(alt_path_proj):
                 secret_path = alt_path_proj
             else:
-                 logger.error(f"Password file not found at '{PG_PASSWORD_FILE}', '{alt_path_run}', or '{alt_path_proj}'")
+                 logger.error("Password file could not be found in the expected locations.")
                  return None
     try:
         with open(secret_path, 'r') as f:


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/6](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/6)

To fix the issue, the sensitive information (password file paths) should not be logged directly. Instead, you can log a more generic error message that does not expose sensitive details. For instance, replace the specific file paths with a general message indicating that the password file could not be located. This ensures that sensitive data is not exposed while still providing useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
