### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/src/rag/train_markov_postgres.py
+++ b/src/rag/train_markov_postgres.py
@@ -47,7 +47,7 @@ def get_pg_password():
         with open(secret_path, 'r') as f:
             return f.read().strip()
     except Exception as e:
-        logger.error(f"Failed to read PostgreSQL password from {secret_path}: {e}")
+        logger.error(f"Failed to read PostgreSQL password file: {e}")
         return None
 
 def connect_db():


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/7](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/7)

To fix this issue, we should avoid logging the path to the secrets file (`secret_path`). Instead, we can log a generic error message indicating failure to read the password file, without revealing its location. If we wish to provide context for debugging, we can still log the exception (`e`) but omit the file path.

The change is limited to line 50 in `src/rag/train_markov_postgres.py`, inside the exception handler of `get_pg_password()`. Replace the log message with a generic statement like `"Failed to read PostgreSQL password file: {e}"`.

No additional imports or method changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
