### PR TITLE
Update blocklist URL to HTTPS

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -56,6 +56,11 @@ MISTRAL_API_KEY=
 EXTERNAL_API_KEY=
 IP_REPUTATION_API_KEY=
 COMMUNITY_BLOCKLIST_API_KEY=
+# Base URL for the community blocklist sync service
+# Default: https://mock_community_blocklist_api:8000
+COMMUNITY_BLOCKLIST_API_URL=
+# Endpoint path for fetching the blocklist (usually '/list')
+COMMUNITY_BLOCKLIST_LIST_ENDPOINT=/list
 SMTP_PASSWORD=
 
 # CAPTCHA configuration

--- a/src/rag/train_markov_postgres.py
+++ b/src/rag/train_markov_postgres.py
@@ -41,8 +41,11 @@ def get_pg_password():
             if os.path.exists(alt_path_proj):
                 secret_path = alt_path_proj
             else:
-                 logger.error("Password file could not be found in the expected locations.")
-                 return None
+                logger.error(
+                    "Password file could not be found in the expected locations. "
+                    f"Tried: {PG_PASSWORD_FILE}, {alt_path_run}, {alt_path_proj}"
+                )
+                return None
     try:
         with open(secret_path, 'r') as f:
             return f.read().strip()

--- a/src/shared/redis_client.py
+++ b/src/shared/redis_client.py
@@ -16,7 +16,7 @@ def get_redis_connection(db_number=0):
             with open(password_file, 'r') as f:
                 password = f.read().strip()
         except FileNotFoundError:
-            logging.error("Redis password file not found.")
+            logging.error(f"Redis password file not found at {password_file}")
             return None
     
     try:

--- a/src/util/community_blocklist_sync.py
+++ b/src/util/community_blocklist_sync.py
@@ -7,7 +7,9 @@ import httpx
 
 from src.shared.redis_client import get_redis_connection
 
-COMMUNITY_BLOCKLIST_API_URL = os.getenv("COMMUNITY_BLOCKLIST_API_URL", "http://mock_community_blocklist_api:8000")
+COMMUNITY_BLOCKLIST_API_URL = os.getenv(
+    "COMMUNITY_BLOCKLIST_API_URL", "https://mock_community_blocklist_api:8000"
+)
 COMMUNITY_BLOCKLIST_LIST_ENDPOINT = os.getenv("COMMUNITY_BLOCKLIST_LIST_ENDPOINT", "/list")
 REDIS_DB_BLOCKLIST = int(os.getenv("REDIS_DB_BLOCKLIST", 2))
 BLOCKLIST_TTL_SECONDS = int(os.getenv("COMMUNITY_BLOCKLIST_TTL_SECONDS", 86400))


### PR DESCRIPTION
## Summary
- default community blocklist URL uses HTTPS
- document environment variables for blocklist sync service
- include path in Redis password file error message
- improve Markov training script log when password file missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a867bab44832185a6401566052105