### PR TITLE
Enable TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,16 +76,28 @@ This setup uses Docker Compose to orchestrate all the necessary services on your
 
     **Important:** The script will print the generated credentials to the console. Copy these and save them in a secure password manager.
 
-5. **Launch the Stack:**
+5. **Enable HTTPS (Optional):**
+    Edit the `.env` file to set `ENABLE_HTTPS=true` and provide paths to your TLS certificate and key.
+
+    ```bash
+    ENABLE_HTTPS=true
+    TLS_CERT_PATH=./nginx/certs/tls.crt
+    TLS_KEY_PATH=./nginx/certs/tls.key
+    ```
+
+    Make sure the certificate files exist at those paths or update them accordingly.
+
+6. **Launch the Stack:**
     Build and start all the services using Docker Compose.
 
     ```bash
     docker-compose up --build -d
     ```
 
-6. **Access the Services:**
+7. **Access the Services:**
     - **Admin UI:** `http://localhost:5002`
     - **Your Application (via proxy):** `http://localhost:8080`
+    - **HTTPS (if enabled):** `https://localhost:8443`
 
 ## Project Structure
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro
       - ./nginx/lua:/etc/nginx/lua:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
       # Restored Nginx cache volumes for stability and performance
       - nginx_client_body_temp:/var/run/openresty/nginx-client-body
       - nginx_proxy_temp:/var/cache/nginx/proxy_temp
@@ -56,6 +57,9 @@ services:
       - ADMIN_UI_HOST=admin_ui
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - ENABLE_HTTPS=${ENABLE_HTTPS}
+      - TLS_CERT_PATH=${TLS_CERT_PATH}
+      - TLS_KEY_PATH=${TLS_KEY_PATH}
     depends_on:
       escalation_engine:
         condition: service_healthy

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -119,3 +119,90 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
+
+# HTTPS Server Block (optional)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name localhost _;
+
+    ssl_certificate ${TLS_CERT_PATH};
+    ssl_certificate_key ${TLS_KEY_PATH};
+
+    # Standard security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Robots.txt
+    location = /robots.txt {
+        alias /etc/nginx/robots.txt;
+        access_log off;
+        log_not_found off;
+    }
+
+    # Serve generated ZIP archives (honeypots)
+    location /docs/archives/ {
+        alias /usr/share/nginx/html/archives/;
+        autoindex off;
+    }
+
+    # Health check endpoint for Docker
+    location /healthz {
+        access_log off;
+        return 200 "OK";
+    }
+
+    # Lua script for initial IP blocklist check
+    access_by_lua_file /etc/nginx/lua/check_blocklist.lua;
+
+    # Admin UI location
+    location /admin/ {
+        auth_basic              "Admin Area - Restricted";
+        auth_basic_user_file    /etc/nginx/secrets/.htpasswd;
+        proxy_pass              http://admin_ui/;
+
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Script-Name /admin;
+
+        proxy_http_version      1.1;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        Connection "upgrade";
+
+        proxy_connect_timeout   60s;
+        proxy_send_timeout      60s;
+        proxy_read_timeout      60s;
+
+        proxy_redirect          off;
+        proxy_buffering         off;
+    }
+
+    # Tarpit API (internal redirect target)
+    location /api/tarpit {
+        internal;
+        proxy_pass http://tarpit_api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Main content / Proxy to real backend
+    location / {
+        set $lua_proxy_pass_upstream '';
+        access_by_lua_file /etc/nginx/lua/detect_bot.lua;
+        limit_req zone=req_rate_limit burst=100 nodelay;
+
+        if ($lua_proxy_pass_upstream ~* "^http") {
+            proxy_pass $lua_proxy_pass_upstream;
+        }
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/sample.env
+++ b/sample.env
@@ -75,6 +75,11 @@ ENABLE_MANAGED_TLS=false
 TLS_PROVIDER=certbot
 TLS_EMAIL=
 
+# --- Local TLS Configuration ---
+ENABLE_HTTPS=false
+TLS_CERT_PATH=./nginx/certs/tls.crt
+TLS_KEY_PATH=./nginx/certs/tls.key
+
 ENABLE_WAF=false
 WAF_RULES_PATH=/etc/nginx/waf_rules.conf
 


### PR DESCRIPTION
## Summary
- add optional HTTPS server block to nginx
- expose certificate directory in docker-compose and pass TLS env vars
- add ENABLE_HTTPS, TLS_CERT_PATH and TLS_KEY_PATH to sample.env
- document enabling TLS in README

## Testing
- `pytest -q` *(fails: Redis password file tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a867d76b08321a0c5af49751c30fd