### PR TITLE
Fix Redis port configuration

### DIFF
--- a/src/shared/redis_client.py
+++ b/src/shared/redis_client.py
@@ -19,13 +19,15 @@ def get_redis_connection(db_number=0):
             logging.error(f"Redis password file not found at {password_file}")
             return None
     
+    redis_port = int(os.environ.get("REDIS_PORT", 6379))
+
     try:
         r = redis.Redis(
             host=redis_host,
-            port=6379,
+            port=redis_port,
             password=password,
             db=db_number,
-            decode_responses=True # Decode responses to UTF-8 by default
+            decode_responses=True  # Decode responses to UTF-8 by default
         )
         r.ping()
         logging.info(f"Successfully connected to Redis at {redis_host} on DB {db_number}")


### PR DESCRIPTION
## Summary
- update `get_redis_connection` so the Redis port can be configured via `REDIS_PORT`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab33241f88321a4a5f063a96f9f05