### PR TITLE
Sync Postgres init schema

### DIFF
--- a/kubernetes/postgres-init-script-cm.yaml
+++ b/kubernetes/postgres-init-script-cm.yaml
@@ -8,10 +8,38 @@ metadata:
   namespace: ai-defense
 data:
   init.sql: |
-    -- This script creates the table for the Markov model if it doesn't already exist.
-    CREATE TABLE IF NOT EXISTS markov_model (
+    -- anti_scrape/db/init_markov.sql (Placeholder Schema)
+    -- Basic schema for PostgreSQL Markov chain storage
+
+    -- Table to store unique words/tokens
+    CREATE TABLE IF NOT EXISTS markov_words (
         id SERIAL PRIMARY KEY,
-        state_key TEXT UNIQUE NOT NULL,
-        next_words TEXT NOT NULL,
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+        word TEXT UNIQUE NOT NULL
     );
+
+    -- Create index for faster word lookup
+    CREATE INDEX IF NOT EXISTS idx_markov_words_word ON markov_words (word);
+
+    -- Insert the empty string as a special token (ID 1 if table is empty)
+    INSERT INTO markov_words (word) VALUES ('') ON CONFLICT (word) DO NOTHING;
+
+    -- Table to store sequences (word1_id -> word2_id -> next_word_id) and frequency
+    CREATE TABLE IF NOT EXISTS markov_sequences (
+        p1 INT NOT NULL REFERENCES markov_words(id),
+        p2 INT NOT NULL REFERENCES markov_words(id),
+        next_id INT NOT NULL REFERENCES markov_words(id),
+        freq INT DEFAULT 1 NOT NULL,
+        -- Constraint to ensure combination of p1, p2, next_id is unique
+        CONSTRAINT uq_sequence UNIQUE (p1, p2, next_id)
+    );
+
+    -- Index for fast lookup of next possible words based on previous two
+    CREATE INDEX IF NOT EXISTS idx_markov_sequences_prev ON markov_sequences (p1, p2);
+
+    -- Optional: Index for frequency-based lookups if needed
+    CREATE INDEX IF NOT EXISTS idx_markov_sequences_freq ON markov_sequences (p1, p2, freq DESC);
+
+    -- Example of how the training script would insert/update:
+    -- INSERT INTO markov_sequences (p1, p2, next_id, freq)
+    -- VALUES (%s, %s, %s, 1)
+    -- ON CONFLICT (p1, p2, next_id) DO UPDATE SET freq = markov_sequences.freq + 1;

--- a/src/tarpit/markov_generator.py
+++ b/src/tarpit/markov_generator.py
@@ -155,8 +155,8 @@ def get_next_word_from_db(word1_id, word2_id):
         cursor.execute(
             """
             SELECT w.word, s.freq
-            FROM sequences s
-            JOIN words w ON s.next_id = w.id
+            FROM markov_sequences s
+            JOIN markov_words w ON s.next_id = w.id
             WHERE s.p1 = %s AND s.p2 = %s
             ORDER BY s.freq DESC, random() -- Add random() for variety among equal frequencies
             LIMIT 20; -- Limit results for performance
@@ -202,7 +202,7 @@ def get_word_id(word):
         return 1 # ID for empty string (start/end token)
 
     try:
-        cursor.execute("SELECT id FROM words WHERE word = %s", (word,))
+        cursor.execute("SELECT id FROM markov_words WHERE word = %s", (word,))
         result = cursor.fetchone()
         return result[0] if result else 1  # Default to empty string ID if word not found
     except Exception as e:

--- a/tarpit-rs/src/lib.rs
+++ b/tarpit-rs/src/lib.rs
@@ -22,13 +22,13 @@ fn get_connection() -> Result<Client, postgres::Error> {
 
 fn get_word_id(client: &mut Client, word: &str) -> i32 {
     if word.is_empty() { return 1; }
-    if let Ok(row) = client.query_opt("SELECT id FROM words WHERE word = $1", &[&word]) {
+    if let Ok(row) = client.query_opt("SELECT id FROM markov_words WHERE word = $1", &[&word]) {
         row.map(|r| r.get::<usize, i32>(0)).unwrap_or(1)
     } else { 1 }
 }
 
 fn get_next_word_from_db(client: &mut Client, w1: i32, w2: i32) -> Option<String> {
-    let stmt = "SELECT w.word, s.freq FROM sequences s JOIN words w ON s.next_id = w.id WHERE s.p1 = $1 AND s.p2 = $2 ORDER BY s.freq DESC, random() LIMIT 20";
+    let stmt = "SELECT w.word, s.freq FROM markov_sequences s JOIN markov_words w ON s.next_id = w.id WHERE s.p1 = $1 AND s.p2 = $2 ORDER BY s.freq DESC, random() LIMIT 20";
     match client.query(stmt, &[&w1, &w2]) {
         Ok(rows) if !rows.is_empty() => {
             let words: Vec<String> = rows.iter().map(|r| r.get(0)).collect();

--- a/test/tarpit/test_markov_generator.py
+++ b/test/tarpit/test_markov_generator.py
@@ -152,7 +152,7 @@ class TestMarkovGenerator(unittest.TestCase):
 
         word_id = markov_generator.get_word_id("testword")
         self.assertEqual(word_id, 123)
-        mock_cursor.execute.assert_called_once_with("SELECT id FROM words WHERE word = %s", ("testword",))
+        mock_cursor.execute.assert_called_once_with("SELECT id FROM markov_words WHERE word = %s", ("testword",))
 
     @patch("src.tarpit.markov_generator._get_db_connection")
     def test_get_word_id_not_found_returns_empty_id(self, mock_get_conn):


### PR DESCRIPTION
## Summary
- align postgres-init-script ConfigMap with `db/init_markov.sql`
- update tarpit Markov generator to use `markov_words` and `markov_sequences`
- adjust Rust tarpit bindings for new table names
- update unit tests for new SQL queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aee85c9488321ba89bc7bb9e4f7b0