### PR TITLE
Add htpasswd file mount and generation

### DIFF
--- a/Generate-Secrets.ps1
+++ b/Generate-Secrets.ps1
@@ -5,6 +5,7 @@
 $K8sDir = Join-Path $PSScriptRoot "kubernetes"
 if (-not (Test-Path $K8sDir)) { New-Item -ItemType Directory -Path $K8sDir | Out-Null }
 $OutputFile = Join-Path $K8sDir "secrets.yaml"
+$NginxHtpasswdFile = Join-Path $PSScriptRoot "nginx/.htpasswd"
 
 function New-RandomPassword {
     param([int]$Length = 24)
@@ -47,6 +48,7 @@ $mistralApiKey = "mistral-" + (New-RandomPassword -Length 40)
 
 # Create Nginx htpasswd content using bcrypt
 $htpasswdFileContent = (htpasswd -nbBC 12 $adminUiUsername $nginxPassword).Trim()
+Set-Content -Path $NginxHtpasswdFile -Value $htpasswdFileContent -Encoding ASCII
 
 # Base64 encode all values
 $postgresUser_b64 = ConvertTo-Base64 "postgres"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro
       - ./nginx/lua:/etc/nginx/lua:ro
       - ./nginx/certs:/etc/nginx/certs:ro
+      - ./nginx/.htpasswd:/etc/nginx/secrets/.htpasswd:ro
       # Restored Nginx cache volumes for stability and performance
       - nginx_client_body_temp:/var/run/openresty/nginx-client-body
       - nginx_proxy_temp:/var/cache/nginx/proxy_temp

--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -4,7 +4,9 @@
 
 # --- Configuration ---
 GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
-K8S_DIR="$(dirname "$0")/kubernetes"; mkdir -p "$K8S_DIR"; OUTPUT_FILE="$K8S_DIR/secrets.yaml"
+SCRIPT_DIR="$(dirname "$0")"
+K8S_DIR="$SCRIPT_DIR/kubernetes"; mkdir -p "$K8S_DIR"; OUTPUT_FILE="$K8S_DIR/secrets.yaml"
+HTPASSWD_OUTPUT_FILE="$SCRIPT_DIR/nginx/.htpasswd"
 
 # --- Functions ---
 generate_password() { LC_ALL=C tr -dc 'A-Za-z0-9_!@#$%^&*' < /dev/urandom | head -c "${1:-24}"; }
@@ -24,6 +26,8 @@ OPENAI_API_KEY="sk-$(generate_password 40)"; ANTHROPIC_API_KEY="sk-ant-$(generat
 
 # Create Nginx htpasswd content using bcrypt
 HTPASSWD_FILE_CONTENT=$(htpasswd -nbBC 12 "$ADMIN_UI_USERNAME" "$NGINX_PASSWORD" | tr -d '\n')
+# Write htpasswd file for local Docker Compose usage
+echo "$HTPASSWD_FILE_CONTENT" > "$HTPASSWD_OUTPUT_FILE"
 
 # Write YAML to file
 cat > "$OUTPUT_FILE" << EOL


### PR DESCRIPTION
## Summary
- mount nginx/.htpasswd into nginx container for docker-compose
- generate secrets scripts now output `.htpasswd` into nginx folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687af0b775f083218884da1f2bc7749a