### PR TITLE
Use rust builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,19 @@
 # Dockerfile
 # Use an official Python runtime as a parent image.
 # Using a slim image reduces the final image size.
+### Builder stage used to compile the Rust extensions
+FROM rust:latest AS builder
+WORKDIR /build
+
+# Copy only the Rust crates needed for compilation
+COPY tarpit-rs/ ./tarpit-rs/
+COPY frequency-rs/ ./frequency-rs/
+
+# Build the crates in release mode to produce shared libraries
+RUN cd tarpit-rs && cargo build --release && \
+    cd ../frequency-rs && cargo build --release
+
+### Final runtime image without the Rust toolchain
 FROM python:3.11-slim
 
 # Set the working directory in the container to /app
@@ -19,20 +32,12 @@ COPY requirements.txt constraints.txt ./
 # -c constraints.txt is used to enforce specific versions for dependencies if needed.
 RUN pip install --no-cache-dir -r requirements.txt -c constraints.txt
 
-# Install Rust toolchain for building the tarpit-rs crate
-RUN apt-get update && apt-get install -y --no-install-recommends cargo && rm -rf /var/lib/apt/lists/*
-
-# Copy the entire 'src' directory from the host into the container at /app/src.
-# This brings all your application source code into the image.
+# Copy the application source code
 COPY src/ /app/src/
-COPY tarpit-rs/ /app/tarpit-rs/
-COPY frequency-rs/ /app/frequency-rs/
 
-# Build the Rust crates and place the resulting shared libraries where Python can import them
-RUN cd /app/tarpit-rs && cargo build --release && \
-    cp target/release/libtarpit_rs.so /app/tarpit_rs.so && \
-    cd /app/frequency-rs && cargo build --release && \
-    cp target/release/libfrequency_rs.so /app/frequency_rs.so
+# Copy the pre-built shared libraries from the builder stage
+COPY --from=builder /build/tarpit-rs/target/release/libtarpit_rs.so /app/tarpit_rs.so
+COPY --from=builder /build/frequency-rs/target/release/libfrequency_rs.so /app/frequency_rs.so
 
 # Copy the entrypoint script into the container and make it executable.
 # This script often contains logic to wait for dependencies (like databases)


### PR DESCRIPTION
## Summary
- refactor the Dockerfile to build `tarpit-rs` and `frequency-rs` using a `rust:latest` stage
- copy only the resulting `.so` files into the final `python:3.11-slim` image

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687af2605ee88321b1a3c5f53fcef5d0