### PR TITLE
Refactor URLs to use host and port vars

### DIFF
--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -11,11 +11,15 @@ data:
   LOG_LEVEL: "INFO"
   APP_ENV: "production"
 
-  # Internal service URLs used for communication between pods
-  ESCALATION_ENGINE_URL: "http://escalation-engine:8003/escalate"
-  ADMIN_UI_URL: "http://admin-ui:5002"
-  TARPIT_API_URL: "http://tarpit-api:8001"
-  AI_SERVICE_URL: "http://ai-service:8000"
+  # Internal service hostnames and ports used for pod communication
+  AI_SERVICE_HOST: "ai-service"
+  AI_SERVICE_PORT: "8000"
+  ESCALATION_ENGINE_HOST: "escalation-engine"
+  ESCALATION_ENGINE_PORT: "8003"
+  TARPIT_API_HOST: "tarpit-api"
+  TARPIT_API_PORT: "8001"
+  ADMIN_UI_HOST: "admin-ui"
+  ADMIN_UI_PORT: "5002"
 
   # Redis connection details
   REDIS_HOST: "redis" # The service name of the Redis statefulset

--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -15,6 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from jinja2 import pass_context
 from src.shared.redis_client import get_redis_connection
 from src.shared.metrics import get_metrics
+from src.shared.config import CONFIG
 
 # Flag to indicate if metrics collection is actually available. Tests patch this
 # to simulate metrics being disabled.
@@ -150,7 +151,7 @@ async def settings_page(request: Request):
     current_settings = {
         "Model URI": os.getenv("MODEL_URI", "Not Set"),
         "Log Level": os.getenv("LOG_LEVEL", "INFO"),
-        "Escalation Engine URL": os.getenv("ESCALATION_ENGINE_URL", "http://escalation_engine:8003/escalate"),
+        "Escalation Engine URL": CONFIG.ESCALATION_ENDPOINT,
     }
     return templates.TemplateResponse("settings.html", {"request": request, "settings": current_settings})
 

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -20,6 +20,12 @@ def get_secret(file_variable_name: str) -> Optional[str]:
 class Config:
     """Configuration loaded from environment variables once on import."""
 
+    # Internal service hosts
+    AI_SERVICE_HOST: str = field(default_factory=lambda: os.getenv("AI_SERVICE_HOST", "ai_service"))
+    ESCALATION_ENGINE_HOST: str = field(default_factory=lambda: os.getenv("ESCALATION_ENGINE_HOST", "escalation_engine"))
+    TARPIT_API_HOST: str = field(default_factory=lambda: os.getenv("TARPIT_API_HOST", "tarpit_api"))
+    ADMIN_UI_HOST: str = field(default_factory=lambda: os.getenv("ADMIN_UI_HOST", "admin_ui"))
+
     # Service ports
     AI_SERVICE_PORT: int = field(default_factory=lambda: int(os.getenv("AI_SERVICE_PORT", 8000)))
     ESCALATION_ENGINE_PORT: int = field(default_factory=lambda: int(os.getenv("ESCALATION_ENGINE_PORT", 8003)))
@@ -115,10 +121,10 @@ class Config:
         return cfg
 
     def __post_init__(self):
-        object.__setattr__(self, "AI_SERVICE_URL", f"http://ai_service:{self.AI_SERVICE_PORT}")
-        object.__setattr__(self, "ESCALATION_ENGINE_URL", f"http://escalation_engine:{self.ESCALATION_ENGINE_PORT}")
-        object.__setattr__(self, "TARPIT_API_URL", f"http://tarpit_api:{self.TARPIT_API_PORT}")
-        object.__setattr__(self, "ADMIN_UI_URL", f"http://admin_ui:{self.ADMIN_UI_PORT}")
+        object.__setattr__(self, "AI_SERVICE_URL", f"http://{self.AI_SERVICE_HOST}:{self.AI_SERVICE_PORT}")
+        object.__setattr__(self, "ESCALATION_ENGINE_URL", f"http://{self.ESCALATION_ENGINE_HOST}:{self.ESCALATION_ENGINE_PORT}")
+        object.__setattr__(self, "TARPIT_API_URL", f"http://{self.TARPIT_API_HOST}:{self.TARPIT_API_PORT}")
+        object.__setattr__(self, "ADMIN_UI_URL", f"http://{self.ADMIN_UI_HOST}:{self.ADMIN_UI_PORT}")
 
 
 # Instantiate configuration once


### PR DESCRIPTION
## Summary
- expose service hostnames and ports in configmap
- build internal URLs from host and port vars in `Config`
- show escalation endpoint in admin UI settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687af424af588321aff74c702088c25b