### PR TITLE
Add imagePullPolicy to k8s manifests

### DIFF
--- a/kubernetes/admin-ui-deployment.yaml
+++ b/kubernetes/admin-ui-deployment.yaml
@@ -31,6 +31,7 @@ spec:
       - name: admin-ui
         # IMPORTANT: Replace with your actual container image registry and tag.
         image: your-registry/ai-scraping-defense:latest
+        imagePullPolicy: Always
         # Command to run the FastAPI admin UI.
         command: ["python", "src/admin_ui/admin_ui.py"]
         ports:

--- a/kubernetes/ai-service-deployment.yaml
+++ b/kubernetes/ai-service-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
       - name: ai-service
         image: your-registry/ai-scraping-defense:latest
+        imagePullPolicy: Always
         # Updated command to run the Uvicorn server for the AI webhook.
         command: ["uvicorn", "src.ai_service.ai_webhook:app", "--host", "0.0.0.0", "--port", "8000"]
         ports:

--- a/kubernetes/archive-rotator-deployment.yaml
+++ b/kubernetes/archive-rotator-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: archive-rotator
         image: your-registry/ai-scraping-defense:latest
+        imagePullPolicy: Always
         # Updated command to run the rotating archive script.
         command: ["python", "src/tarpit/rotating_archive.py"]
         env:

--- a/kubernetes/corpus-updater-cronjob.yaml
+++ b/kubernetes/corpus-updater-cronjob.yaml
@@ -14,6 +14,7 @@ spec:
           containers:
           - name: corpus-updater
             image: your-registry/ai-scraping-defense:latest
+            imagePullPolicy: Always
             # Updated command to run the corpus updater script.
             command: ["python", "src/util/corpus_wikipedia_updater.py"]
             env:

--- a/kubernetes/escalation-engine-deployment.yaml
+++ b/kubernetes/escalation-engine-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
       - name: escalation-engine
         image: your-registry/ai-scraping-defense:latest
+        imagePullPolicy: Always
         # Updated command to run the Uvicorn server for the escalation engine.
         command: ["uvicorn", "src.escalation.escalation_engine:app", "--host", "0.0.0.0", "--port", "8003"]
         ports:

--- a/kubernetes/markov-model-trainer.yaml
+++ b/kubernetes/markov-model-trainer.yaml
@@ -14,6 +14,7 @@ spec:
           containers:
           - name: markov-trainer
             image: your-registry/ai-scraping-defense:latest
+            imagePullPolicy: Always
             # Updated command to run the Markov training script.
             command: ["python", "src/rag/train_markov_postgres.py"]
             envFrom:

--- a/kubernetes/nginx-deployment.yaml
+++ b/kubernetes/nginx-deployment.yaml
@@ -37,6 +37,7 @@ spec:
       containers:
       - name: nginx
         image: openresty/openresty:1.21.4.1-alpine
+        imagePullPolicy: Always
         ports:
         - containerPort: 80
         - containerPort: 443

--- a/kubernetes/postgres-statefulset.yaml
+++ b/kubernetes/postgres-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
       - name: postgres
         image: postgres:15-alpine
+        imagePullPolicy: Always
         ports:
         - containerPort: 5432
           name: postgres

--- a/kubernetes/redis-statefulset.yaml
+++ b/kubernetes/redis-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
       containers:
       - name: redis
         image: redis:7-alpine
+        imagePullPolicy: Always
         # Command to start Redis server and require a password.
         # Using sh -c so the REDIS_PASSWORD environment variable expands correctly.
         command: ["sh", "-c", "redis-server --requirepass \"$REDIS_PASSWORD\""]

--- a/kubernetes/robots-fetcher-cronjob.yaml
+++ b/kubernetes/robots-fetcher-cronjob.yaml
@@ -17,6 +17,7 @@ spec:
           containers:
           - name: robots-fetcher
             image: your-registry/ai-scraping-defense:latest
+            imagePullPolicy: Always
             # Updated command to run the robots fetcher script.
             command: ["python", "src/util/robots_fetcher.py"]
             env:

--- a/kubernetes/tarpit-api-deployment.yaml
+++ b/kubernetes/tarpit-api-deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
       - name: tarpit-api
         image: your-registry/ai-scraping-defense:latest
+        imagePullPolicy: Always
         command: ["uvicorn", "src.tarpit.tarpit_api:app", "--host", "0.0.0.0", "--port", "8001"]
         ports:
         - containerPort: 8001


### PR DESCRIPTION
## Summary
- ensure Kubernetes always pulls the latest container image by default
- add `imagePullPolicy: Always` to all deployment/statefulset/cronjob manifests

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687af5fd1af48321afb41c19d287d0ab