### PR TITLE
Add health probes to deployments

### DIFF
--- a/kubernetes/admin-ui-deployment.yaml
+++ b/kubernetes/admin-ui-deployment.yaml
@@ -50,3 +50,15 @@ spec:
             name: admin-ui-credentials
         - secretRef:
             name: redis-credentials
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 5002
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 5002
+          initialDelaySeconds: 10
+          periodSeconds: 10

--- a/kubernetes/ai-service-deployment.yaml
+++ b/kubernetes/ai-service-deployment.yaml
@@ -45,3 +45,15 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10

--- a/kubernetes/escalation-engine-deployment.yaml
+++ b/kubernetes/escalation-engine-deployment.yaml
@@ -49,6 +49,18 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8003
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8003
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - name: models-storage
           mountPath: /app/models

--- a/kubernetes/nginx-deployment.yaml
+++ b/kubernetes/nginx-deployment.yaml
@@ -48,6 +48,18 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - name: nginx-config
           mountPath: /etc/nginx/conf.d

--- a/kubernetes/tarpit-api-deployment.yaml
+++ b/kubernetes/tarpit-api-deployment.yaml
@@ -41,6 +41,18 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 10
+          periodSeconds: 10
         envFrom:
         - configMapRef:
             name: app-config


### PR DESCRIPTION
## Summary
- configure `readinessProbe` and `livenessProbe` for nginx
- add health probes for ai-service deployment
- add health probes for escalation-engine deployment
- add health probes for tarpit-api deployment
- add health probes for admin-ui deployment

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687afb2e5c788321b6e4f052a7117b77