### PR TITLE
Fix tarpit api port default

### DIFF
--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -29,7 +29,7 @@ class Config:
     # Service ports
     AI_SERVICE_PORT: int = field(default_factory=lambda: int(os.getenv("AI_SERVICE_PORT", 8000)))
     ESCALATION_ENGINE_PORT: int = field(default_factory=lambda: int(os.getenv("ESCALATION_ENGINE_PORT", 8003)))
-    TARPIT_API_PORT: int = field(default_factory=lambda: int(os.getenv("TARPIT_API_PORT", 8005)))
+    TARPIT_API_PORT: int = field(default_factory=lambda: int(os.getenv("TARPIT_API_PORT", 8001)))
     ADMIN_UI_PORT: int = field(default_factory=lambda: int(os.getenv("ADMIN_UI_PORT", 5002)))
 
     # Redis


### PR DESCRIPTION
## Summary
- align default `TARPIT_API_PORT` with compose and kubernetes settings

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687b019c4cac832199a203a33f683a44