### PR TITLE
Add ModSecurity configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,6 +44,7 @@ services:
       - ./nginx/lua:/etc/nginx/lua:ro
       - ./nginx/certs:/etc/nginx/certs:ro
       - ./nginx/.htpasswd:/etc/nginx/secrets/.htpasswd:ro
+      - ./waf:/etc/nginx/modsecurity:ro
       # Restored Nginx cache volumes for stability and performance
       - nginx_client_body_temp:/var/run/openresty/nginx-client-body
       - nginx_proxy_temp:/var/cache/nginx/proxy_temp

--- a/docs/kubernetes_deployment.md
+++ b/docs/kubernetes_deployment.md
@@ -37,6 +37,15 @@ You must update all the Kubernetes Deployment and CronJob manifests in the kuber
 
 Search for the image: key in all *.yaml files inside kubernetes/ and replace the placeholder value (e.g., your-registry/ai-scraping-defense:latest) with the $IMAGE_NAME you defined above.
 
+### **Enable ModSecurity**
+
+1. Download the OWASP CRS into the `waf/` directory so that `crs-setup.conf` and a `rules` folder are available.
+2. Create the `waf-rules` ConfigMap:
+   ```bash
+   kubectl create configmap waf-rules --from-file=waf/ -n ai-defense
+   ```
+3. Apply the manifests which mount `/etc/nginx/modsecurity` in the Nginx deployment.
+
 ### **3. Generate and Apply Secrets**
 
 The application's secrets (passwords, API keys) are managed via a single secrets.yaml file, which should **never** be committed to version control.

--- a/kubernetes/nginx-deployment.yaml
+++ b/kubernetes/nginx-deployment.yaml
@@ -65,6 +65,8 @@ spec:
           mountPath: /etc/nginx/conf.d
         - name: lua-scripts
           mountPath: /etc/nginx/lua
+        - name: waf-rules
+          mountPath: /etc/nginx/modsecurity
         - name: robots-txt
           mountPath: /etc/nginx/robots.txt
           subPath: robots.txt
@@ -79,6 +81,9 @@ spec:
       - name: lua-scripts
         configMap:
           name: lua-scripts-config # Assumes a configmap for lua scripts exists
+      - name: waf-rules
+        configMap:
+          name: waf-rules
       - name: robots-txt
         configMap:
           name: live-robots-txt-config

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,6 @@
+# Load the ModSecurity module
+load_module modules/ngx_http_modsecurity_module.so;
+
 # Logging Format
 log_format detailed '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
@@ -6,6 +9,10 @@ log_format detailed '$remote_addr - $remote_user [$time_local] '
 
 access_log /var/log/nginx/access.log detailed;
 error_log /var/log/nginx/error.log warn;
+
+# Enable ModSecurity and load rules
+modsecurity on;
+modsecurity_rules_file /etc/nginx/modsecurity/modsecurity.conf;
 
 # Gzip Settings
 gzip on;

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -3,6 +3,6 @@ from .adaptive_rate_limit import compute_rate_limit  # noqa: F401
 from .cdn_manager import purge_cache  # noqa: F401
 from .ddos_protection import report_attack  # noqa: F401
 from .tls_manager import ensure_certificate  # noqa: F401
-from .waf_manager import load_waf_rules  # noqa: F401
+from .waf_manager import load_waf_rules, reload_waf_rules  # noqa: F401
 from .adaptive_rate_limit_manager import compute_and_update  # noqa: F401
 

--- a/waf/README.md
+++ b/waf/README.md
@@ -1,0 +1,3 @@
+This directory should contain ModSecurity configuration files.
+Download and extract the OWASP Core Rule Set into this folder so that
+`crs-setup.conf` and the `rules` directory are present.

--- a/waf/modsecurity.conf
+++ b/waf/modsecurity.conf
@@ -1,0 +1,3 @@
+# Base ModSecurity configuration
+Include /etc/nginx/modsecurity/crs-setup.conf
+Include /etc/nginx/modsecurity/rules/*.conf

--- a/waf/rules/custom.rules
+++ b/waf/rules/custom.rules
@@ -1,0 +1,2 @@
+# Example custom rule
+SecRule REQUEST_HEADERS:User-Agent "BadBot" "id:1000,phase:1,deny,log,msg:'Block BadBot'"


### PR DESCRIPTION
## Summary
- load ModSecurity module in nginx
- mount OWASP CRS rules in Docker and Kubernetes
- allow reloading rules via waf_manager
- document ModSecurity setup steps

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687b2d5ac23c83218f4ff17a56a430e0