### PR TITLE
Add fail2ban support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,6 +51,7 @@ services:
       - nginx_fastcgi_temp:/var/cache/nginx/fastcgi_temp
       - nginx_uwsgi_temp:/var/cache/nginx/uwsgi_temp
       - nginx_scgi_temp:/var/cache/nginx/scgi_temp
+      - nginx_logs:/var/log/nginx
     environment:
       - LUA_PATH=/usr/local/openresty/lualib/?.lua;;
       - AI_SERVICE_HOST=ai_service
@@ -215,6 +216,22 @@ services:
       timeout: 5s
       retries: 5
 
+  fail2ban:
+    image: crazymax/fail2ban:latest
+    container_name: fail2ban
+    network_mode: "host"
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      - ./fail2ban:/data
+      - nginx_logs:/var/log/nginx:ro
+    env_file:
+      - .env
+    restart: unless-stopped
+    depends_on:
+      - nginx_proxy
+
 networks:
   defense_network:
     driver: bridge
@@ -227,3 +244,4 @@ volumes:
   nginx_fastcgi_temp:
   nginx_uwsgi_temp:
   nginx_scgi_temp:
+  nginx_logs:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,3 +166,24 @@ The stack can integrate with external services for enhanced protection. Each int
 - **Web Application Firewall (`ENABLE_WAF`)** – Applies additional request filtering using customizable rules.
 
 These features are optional so deployments remain lightweight when cloud services are unavailable.
+
+## Local IP Banning with Fail2ban
+
+Fail2ban monitors the shared Nginx logs and inserts firewall rules using
+`iptables` or `nftables` when an IP is blocked by the Lua script. The log line
+`check_blocklist: Blocking IP <ip>` triggers a temporary ban matching the Redis
+blocklist TTL.
+
+### Activation Steps
+
+1. **Docker Compose** – Ensure the `fail2ban` service is enabled and start it
+   alongside the other containers:
+   ```bash
+   docker compose up -d fail2ban
+   ```
+2. **Kubernetes** – Apply `nginx-logs-pvc.yaml`, update the `nginx-deployment`
+   to mount this volume, then deploy `fail2ban-deployment.yaml`.
+
+Fail2ban runs with `NET_ADMIN` and `NET_RAW` capabilities so it can modify host
+firewall rules. Review these permissions and adjust `bantime` and `findtime`
+within the jail to fit your security policy.

--- a/fail2ban/filter.d/nginx-blocklist.conf
+++ b/fail2ban/filter.d/nginx-blocklist.conf
@@ -1,0 +1,3 @@
+[Definition]
+failregex = check_blocklist: Blocking IP <HOST>
+ignoreregex =

--- a/fail2ban/jail.d/nginx-blocklist.conf
+++ b/fail2ban/jail.d/nginx-blocklist.conf
@@ -1,0 +1,9 @@
+[nginx-blocklist]
+enabled = true
+filter = nginx-blocklist
+logpath = /var/log/nginx/error.log
+# Use the same bantime as Redis TTL
+bantime = 86400
+findtime = 300
+maxretry = 1
+action = iptables-allports[name=nginx-blocklist]

--- a/kubernetes/fail2ban-deployment.yaml
+++ b/kubernetes/fail2ban-deployment.yaml
@@ -1,0 +1,59 @@
+# kubernetes/fail2ban-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fail2ban
+  namespace: ai-defense
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fail2ban
+  template:
+    metadata:
+      labels:
+        app: fail2ban
+    spec:
+      containers:
+      - name: fail2ban
+        image: crazymax/fail2ban:latest
+        imagePullPolicy: Always
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
+        volumeMounts:
+        - name: nginx-logs
+          mountPath: /var/log/nginx
+          readOnly: true
+        - name: fail2ban-config
+          mountPath: /data
+        env:
+        - name: IPTABLES_MODE
+          value: "nft"
+      volumes:
+      - name: nginx-logs
+        persistentVolumeClaim:
+          claimName: nginx-logs-pvc
+      - name: fail2ban-config
+        configMap:
+          name: fail2ban-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fail2ban-config
+  namespace: ai-defense
+data:
+  jail.local: |
+    [nginx-blocklist]
+    enabled = true
+    filter = nginx-blocklist
+    logpath = /var/log/nginx/error.log
+    bantime = 86400
+    findtime = 300
+    maxretry = 1
+    action = iptables-allports[name=nginx-blocklist]
+  filter.d/nginx-blocklist.conf: |
+    [Definition]
+    failregex = check_blocklist: Blocking IP <HOST>
+    ignoreregex =

--- a/kubernetes/nginx-deployment.yaml
+++ b/kubernetes/nginx-deployment.yaml
@@ -74,6 +74,8 @@ spec:
         - name: nginx-auth-secret
           mountPath: /etc/nginx/secrets
           readOnly: true
+        - name: nginx-logs
+          mountPath: /var/log/nginx
       volumes:
       - name: nginx-config
         configMap:
@@ -91,3 +93,6 @@ spec:
       - name: nginx-auth-secret
         secret:
           secretName: nginx-auth
+      - name: nginx-logs
+        persistentVolumeClaim:
+          claimName: nginx-logs-pvc

--- a/kubernetes/nginx-logs-pvc.yaml
+++ b/kubernetes/nginx-logs-pvc.yaml
@@ -1,0 +1,13 @@
+# kubernetes/nginx-logs-pvc.yaml
+# Persistent storage for shared Nginx logs.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nginx-logs-pvc
+  namespace: ai-defense
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
## Summary
- add fail2ban service to docker-compose
- deploy fail2ban via Kubernetes with a shared log PVC
- mount nginx logs for fail2ban in both compose and k8s
- document how to enable fail2ban and related security notes

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b322d2b388321b658ac05a3a793fc