### PR TITLE
Update Admin UI docs and split CSS

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ The AI Scraping Defense system is designed as a distributed, microservice-based 
   - **AI Service:** A simple webhook that receives suspicious request data from Nginx and queues it for analysis by the Escalation Engine.
   - **Escalation Engine:** The central analysis component. It runs a multi-stage pipeline to score requests, using heuristics, a machine learning model, and optionally a powerful LLM for a final verdict.
   - **Tarpit API:** Provides a set of "tarpits" (e.g., zip bombs, slow responses, nonsensical data) designed to waste the resources of confirmed malicious bots.
-  - **Admin UI:** A FastAPI-based web interface for monitoring system metrics, viewing the blocklist, and managing basic settings.
+  - **Admin UI:** A FastAPI-based web interface for monitoring system metrics and viewing the blocklist. Configuration is loaded from environment variables, though a couple of runtime-only options (log level and escalation endpoint) can be tweaked via the interface.
 
 - **Data Stores:**
   - **Redis:** An in-memory data store used for high-speed operations like caching, managing the IP blocklist, and tracking request frequencies.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,7 +105,7 @@ Once the containers are running, you can access the key services in your web bro
 
 ### **6.1. Accessing the Admin UI**
 
-To access the Admin UI, navigate to [http://localhost:5002](http://localhost:5002) in your web browser. This interface allows you to manage blocklists, view metrics, and configure settings.
+To access the Admin UI, navigate to [http://localhost:5002](http://localhost:5002) in your web browser. The dashboard primarily displays the current environment-based configuration and lets you manage the IP blocklist. A couple of runtime-only options (such as log level and escalation endpoint) can be adjusted on this page, but any changes will be lost when the service restarts.
 
 ### **6.2. Accessing the MailHog Interface**
 

--- a/src/admin_ui/static/index.css
+++ b/src/admin_ui/static/index.css
@@ -1,0 +1,53 @@
+body {
+    font-family: sans-serif;
+    line-height: 1.6;
+    margin: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+}
+.container {
+    max-width: 900px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+h1, h2 {
+    color: #555;
+}
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+    margin-top: 20px;
+}
+.metric-card {
+    background: #e9ecef;
+    padding: 15px;
+    border-radius: 5px;
+    text-align: center;
+}
+.metric-card h3 {
+    margin-top: 0;
+    font-size: 1em;
+    color: #495057;
+    text-transform: capitalize; /* Display keys nicely */
+}
+.metric-value {
+    font-size: 1.8em;
+    font-weight: bold;
+    color: #007bff;
+}
+#last-updated {
+    margin-top: 20px;
+    font-size: 0.9em;
+    color: #6c757d;
+    text-align: right;
+}
+#error-message {
+    color: red;
+    font-weight: bold;
+    margin-top: 10px;
+    display: none; /* Hidden by default */
+}

--- a/src/admin_ui/static/settings.css
+++ b/src/admin_ui/static/settings.css
@@ -1,0 +1,3 @@
+body {
+    font-family: 'Inter', sans-serif;
+}

--- a/src/admin_ui/templates/index.html
+++ b/src/admin_ui/templates/index.html
@@ -4,61 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Scraping Defense - Admin Dashboard</title>
-    <style>
-        body {
-            font-family: sans-serif;
-            line-height: 1.6;
-            margin: 20px;
-            background-color: #f4f4f4;
-            color: #333;
-        }
-        .container {
-            max-width: 900px;
-            margin: auto;
-            background: #fff;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-        }
-        h1, h2 {
-            color: #555;
-        }
-        .metrics-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 15px;
-            margin-top: 20px;
-        }
-        .metric-card {
-            background: #e9ecef;
-            padding: 15px;
-            border-radius: 5px;
-            text-align: center;
-        }
-        .metric-card h3 {
-            margin-top: 0;
-            font-size: 1em;
-            color: #495057;
-            text-transform: capitalize; /* Display keys nicely */
-        }
-        .metric-value {
-            font-size: 1.8em;
-            font-weight: bold;
-            color: #007bff;
-        }
-        #last-updated {
-            margin-top: 20px;
-            font-size: 0.9em;
-            color: #6c757d;
-            text-align: right;
-        }
-        #error-message {
-            color: red;
-            font-weight: bold;
-            margin-top: 10px;
-            display: none; /* Hidden by default */
-        }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='index.css') }}">
 </head>
 <body>
     <div class="container">

--- a/src/admin_ui/templates/settings.html
+++ b/src/admin_ui/templates/settings.html
@@ -5,9 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>System Settings - AI Scraping Defense</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='settings.css') }}">
 </head>
 <body class="bg-gray-100 text-gray-800">
     <div class="container mx-auto p-4 md:p-8">
@@ -47,13 +45,29 @@
                     </table>
                 </div>
 
+                <form method="post" class="mt-6 space-y-4">
+                    {% if updated %}
+                    <div class="text-green-700">Settings updated.</div>
+                    {% endif %}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700" for="LOG_LEVEL">Log Level</label>
+                        <input class="mt-1 p-2 border rounded w-full" type="text" name="LOG_LEVEL" id="LOG_LEVEL" value="{{ settings['LOG_LEVEL'] }}">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700" for="ESCALATION_ENDPOINT">Escalation Engine URL</label>
+                        <input class="mt-1 p-2 border rounded w-full" type="text" name="ESCALATION_ENDPOINT" id="ESCALATION_ENDPOINT" value="{{ settings['ESCALATION_ENDPOINT'] }}">
+                    </div>
+                    <button class="px-4 py-2 bg-blue-600 text-white rounded" type="submit">Save</button>
+                </form>
+
                 <div class="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
                     <h3 class="font-semibold text-lg text-blue-800">How to Change Settings</h3>
                     <p class="mt-2 text-sm text-blue-700">
-                        <strong>For Local Development:</strong> Modify the values in your <strong>.env</strong> file and restart the services with <code>docker-compose up -d --build</code>.
+                        Some basic options can be updated using the form above.
+                        For other values, modify your <strong>.env</strong> file and restart the services with <code>docker-compose up -d --build</code>.
                     </p>
                     <p class="mt-2 text-sm text-blue-700">
-                        <strong>For Kubernetes Production:</strong> Update the values in your <strong>ConfigMap</strong> and <strong>Secret</strong> manifests and re-apply them to your cluster using <code>kubectl apply -f ...</code>.
+                        In production environments, update your <strong>ConfigMap</strong> and <strong>Secret</strong> manifests and re-apply them using <code>kubectl apply -f ...</code>.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- clarify that runtime-only settings edits are temporary
- emphasize env var config and mention log level/escalation endpoint edits
- move inline CSS from admin templates to standalone files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3a4bb08c83218dac29b88386ef62