### PR TITLE
Fix localhost links in getting started docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -98,10 +98,10 @@ docker-compose up --build -d
 
 Once the containers are running, you can access the key services in your web browser:
 
-* **Admin UI:** [http://localhost:5002](https://www.google.com/search?q=http://localhost:5002)  
-* **Your Application (via Nginx Proxy):** [http://localhost:8080](https://www.google.com/search?q=http://localhost:8080)  
-* **MailHog (Email Catcher):** [http://localhost:8025](https://www.google.com/search?q=http://localhost:8025)
-* **Redis (for blocklist management):** [http://localhost:6379](https://www.google.com/search?q=http://localhost:6379) (not directly accessible via a web interface, but can be managed using Redis CLI or GUI tools).
+* **Admin UI:** [http://localhost:5002](http://localhost:5002)  
+* **Your Application (via Nginx Proxy):** [http://localhost:8080](http://localhost:8080)  
+* **MailHog (Email Catcher):** [http://localhost:8025](http://localhost:8025)
+* **Redis (for blocklist management):** [http://localhost:6379](http://localhost:6379) (not directly accessible via a web interface, but can be managed using Redis CLI or GUI tools).
 
 ### **6.1. Accessing the Admin UI**
 


### PR DESCRIPTION
## Summary
- replace Google redirect links with direct localhost links in docs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3e31f5ec8321b82c89b6abce6a7d