### PR TITLE
Add plugin system and blocklist sync daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project provides a multi-layered, microservice-based defense system against
 - **Community Blocklist:** Optional daemon to sync IPs from a shared blocklist service.
 - **Containerized:** Fully containerized with Docker and ready for deployment on Kubernetes.
 - **Optional Cloud Integrations:** Toggle CDN caching, DDoS mitigation, managed TLS, and a Web Application Firewall using environment variables.
+- **Plugin API:** Drop-in Python modules allow custom rules to extend detection logic.
 
 ## Getting Started (Local Development)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -216,6 +216,21 @@ services:
       timeout: 5s
       retries: 5
 
+  blocklist_sync:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: blocklist_sync
+    command: ["python", "-m", "scripts.blocklist_sync_daemon"]
+    env_file:
+      - .env
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - defense_network
+    restart: unless-stopped
+
   fail2ban:
     image: crazymax/fail2ban:latest
     container_name: fail2ban

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -98,10 +98,11 @@ docker-compose up --build -d
 
 Once the containers are running, you can access the key services in your web browser:
 
-* **Admin UI:** [http://localhost:5002](http://localhost:5002)  
-* **Your Application (via Nginx Proxy):** [http://localhost:8080](http://localhost:8080)  
+* **Admin UI:** [http://localhost:5002](http://localhost:5002)
+* **Your Application (via Nginx Proxy):** [http://localhost:8080](http://localhost:8080)
 * **MailHog (Email Catcher):** [http://localhost:8025](http://localhost:8025)
 * **Redis (for blocklist management):** [http://localhost:6379](http://localhost:6379) (not directly accessible via a web interface, but can be managed using Redis CLI or GUI tools).
+* **Blocklist Sync Daemon:** runs automatically to pull updates from the community blocklist service.
 
 ### **6.1. Accessing the Admin UI**
 
@@ -110,6 +111,10 @@ To access the Admin UI, navigate to [http://localhost:5002](http://localhost:500
 ### **6.2. Accessing the MailHog Interface**
 
 MailHog is used to capture emails sent by the application for testing purposes. You can access it at [http://localhost:8025](http://localhost:8025). This is useful for verifying email functionality without sending real emails.
+
+### **6.3. Adding Custom Rule Plugins**
+
+You can extend the detection heuristics by placing Python modules inside the `plugins/` directory. Set `ENABLE_PLUGINS=true` in your `.env` file and restart the stack. Each module should define a `check(metadata)` function returning a numeric adjustment.
 
 ### **7. Stopping the Application**
 

--- a/plugins/ua_blocker.py
+++ b/plugins/ua_blocker.py
@@ -1,0 +1,10 @@
+from typing import Optional
+from src.escalation.escalation_engine import RequestMetadata
+
+def check(metadata: RequestMetadata) -> Optional[float]:
+    """Example plugin: add to score if user agent contains 'badbot'."""
+    ua = (metadata.user_agent or "").lower()
+    if 'badbot' in ua:
+        return 0.5
+    return 0.0
+

--- a/sample.env
+++ b/sample.env
@@ -61,6 +61,10 @@ COMMUNITY_BLOCKLIST_API_KEY=
 COMMUNITY_BLOCKLIST_API_URL=
 # Endpoint path for fetching the blocklist (usually '/list')
 COMMUNITY_BLOCKLIST_LIST_ENDPOINT=/list
+# Interval in seconds between sync runs
+COMMUNITY_BLOCKLIST_SYNC_INTERVAL=3600
+# TTL for blocklist entries pulled from the community feed
+COMMUNITY_BLOCKLIST_TTL_SECONDS=86400
 SMTP_PASSWORD=
 
 # CAPTCHA configuration
@@ -101,3 +105,6 @@ FAKE_LINK_DEPTH=3
 ENABLE_TARPIT_LLM_GENERATOR=false
 TARPIT_LLM_MODEL_URI=
 TARPIT_LLM_MAX_TOKENS=400
+
+# --- Plugin System ---
+ENABLE_PLUGINS=false

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,26 @@
+import importlib
+import os
+from typing import Callable, List
+
+PLUGIN_DIR = os.getenv("PLUGIN_DIR", "/app/plugins")
+
+
+def load_plugins() -> List[Callable[[object], float]]:
+    """Load plugin check functions from the plugins directory."""
+    plugins: List[Callable[[object], float]] = []
+    if not os.path.isdir(PLUGIN_DIR):
+        return plugins
+    for filename in os.listdir(PLUGIN_DIR):
+        if not filename.endswith(".py") or filename.startswith("_"):
+            continue
+        module_name = filename[:-3]
+        try:
+            module = importlib.import_module(f"plugins.{module_name}")
+            func = getattr(module, "check", None)
+            if callable(func):
+                plugins.append(func)
+        except Exception as e:  # pragma: no cover - unexpected
+            import logging
+            logging.error("Failed to load plugin %s: %s", filename, e)
+    return plugins
+


### PR DESCRIPTION
## Summary
- create simple plugin loader with example plugin
- integrate plugin checks into the escalation engine
- add blocklist sync daemon service in docker-compose
- expose new environment variables in `sample.env`
- update docs with plugin instructions and daemon mention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b35d1da80832189856560ffe158e8