### PR TITLE
Clarify secrets generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,16 @@ For a one-command setup, run `./quickstart_dev.sh` on Linux/macOS or `quickstart
     ```
 
 4. **Generate Secrets:**
-    Run the secret generation script. This will create passwords for the database, admin UI, etc., and store them in the `.env` file for Docker Compose to use.
+    Run the secret generation script to create passwords for the database, Admin UI, and other services. It writes a `kubernetes/secrets.yaml` file and prints the credentials to your console. The script **does not** modify `.env` unless you use the optional `--update-env` flag.
 
     *On Linux or macOS:*
 
     ```bash
+    # prints credentials only
     bash ./generate_secrets.sh
+
+    # optionally update .env with the generated values
+    bash ./generate_secrets.sh --update-env
     ```
 
     *On Windows (in a PowerShell terminal):*

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,12 +61,14 @@ This script will create a virtual environment in the .venv directory, install al
 
 ### **4. Generate Local Secrets**
 
-The application requires several secrets to run (e.g., database passwords). A script is provided to generate these securely and automatically populate your .env file.
+The application requires several secrets to run (e.g., database passwords). A script is provided to generate these securely. It creates `kubernetes/secrets.yaml` and prints the credentials to your console. By default it **does not** modify your `.env` file.
 
 * **On Linux or macOS:**
 
 ```  bash
   ./generate_secrets.sh
+  # optionally update your .env automatically
+  ./generate_secrets.sh --update-env
 ```
 
 * **On Windows (in a PowerShell terminal):**

--- a/docs/kubernetes_deployment.md
+++ b/docs/kubernetes_deployment.md
@@ -55,7 +55,7 @@ First, run the secret generation script:
 - **On Linux/macOS:** bash ./generate_secrets.sh
 - **On Windows:** .Generate-Secrets.ps1
 
-This creates a kubernetes/secrets.yaml file with securely generated, base64-encoded values.
+This creates a `kubernetes/secrets.yaml` file with securely generated, base64-encoded values and prints the plaintext credentials to your console.
 
 **IMPORTANT:** Before applying, open kubernetes/secrets.yaml and replace the placeholder API keys (e.g., YOUR_BASE64_ENCODED_OPENAI_API_KEY) with your actual, base64-encoded keys if you plan to use those services.
 


### PR DESCRIPTION
## Summary
- document how `generate_secrets.sh` works
- allow updating `.env` via `--update-env`

## Testing
- `python3 test/run_all_tests.py`
- `bash -n generate_secrets.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b4ae36df0832191c5db3b3f7d16f8