### PR TITLE
Fix TLS cert directory

### DIFF
--- a/setup_local_dirs.sh
+++ b/setup_local_dirs.sh
@@ -11,7 +11,8 @@ mkdir -p models
 mkdir -p archives
 mkdir -p secrets
 mkdir -p nginx/errors
-mkdir -p certs
+# TLS certificate directory matching TLS_CERT_PATH and TLS_KEY_PATH in .env
+mkdir -p nginx/certs
 # The kubernetes directory should already exist if you cloned the repo.
 
 echo "Creating placeholder secret files in ./secrets/ (REMEMBER TO FILL THESE WITH ACTUAL VALUES):"


### PR DESCRIPTION
## Summary
- ensure `setup_local_dirs.sh` creates `nginx/certs` to match TLS paths

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687b4d16b434832189ba41667e3259be