### PR TITLE
Implement tenant namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project provides a multi-layered, microservice-based defense system against
 - **Rate Limiting:** Adaptive per-IP limits updated by a small daemon writing to Nginx.
 - **Community Blocklist:** Optional daemon to sync IPs from a shared blocklist service.
 - **Containerized:** Fully containerized with Docker and ready for deployment on Kubernetes.
+- **Multi-Tenant Ready:** Namespace configuration and Redis keys with `TENANT_ID` for easy isolation.
 - **Optional Cloud Integrations:** Toggle CDN caching, DDoS mitigation, managed TLS, and a Web Application Firewall using environment variables.
 - **Plugin API:** Drop-in Python modules allow custom rules to extend detection logic.
 
@@ -45,6 +46,7 @@ For a one-command setup, run `./quickstart_dev.sh` on Linux/macOS or `quickstart
     ```
 
     Open the `.env` file and review the default settings. You do not need to change anything to get started, but this is where you would add your API keys later.
+    Set `TENANT_ID` to a unique value for each isolated deployment.
     To enable the CAPTCHA verification service, populate `CAPTCHA_SECRET` with your reCAPTCHA secret key.
     Tarpit behavior can be tuned with `TARPIT_MAX_HOPS` and `TARPIT_HOP_WINDOW_SECONDS` to automatically block clients that spend too much time in the tarpit.
 

--- a/nginx/lua/check_blocklist.lua
+++ b/nginx/lua/check_blocklist.lua
@@ -6,7 +6,8 @@
 local redis_host = os.getenv("REDIS_HOST") or "redis"
 local redis_port = tonumber(os.getenv("REDIS_PORT")) or 6379
 local redis_db_blocklist = tonumber(os.getenv("REDIS_DB_BLOCKLIST")) or 2
-local redis_blocklist_key_prefix = "blocklist:ip:" -- Prefix for individual IP keys
+local tenant_id = os.getenv("TENANT_ID") or "default"
+local redis_blocklist_key_prefix = tenant_id .. ":blocklist:ip:" -- Prefix for individual IP keys
 local redis_timeout_ms = 200 -- Connection/read timeout in milliseconds
 
 -- Get the remote IP address

--- a/sample.env
+++ b/sample.env
@@ -8,6 +8,7 @@
 LOG_LEVEL=INFO
 FLASK_ENV=development
 DEBUG=true
+TENANT_ID=default
 
 # --- Model Configuration ---
 # The primary URI to select the model and adapter.

--- a/src/escalation/escalation_engine.py
+++ b/src/escalation/escalation_engine.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Optional, Union
 import httpx
 import os
 import datetime
+from src.shared.config import tenant_key
 import time
 import json
 import numpy as np
@@ -132,7 +133,7 @@ ROBOTS_TXT_PATH = CONFIG.TRAINING_ROBOTS_TXT_PATH
 
 REDIS_DB_FREQUENCY = CONFIG.REDIS_DB_FREQUENCY
 FREQUENCY_WINDOW_SECONDS = CONFIG.FREQUENCY_WINDOW_SECONDS
-FREQUENCY_KEY_PREFIX = "freq:"
+FREQUENCY_KEY_PREFIX = os.getenv("FREQUENCY_KEY_PREFIX") or tenant_key("freq:")
 FREQUENCY_TRACKING_TTL = FREQUENCY_WINDOW_SECONDS + 60
 
 # Browser fingerprint tracking configuration
@@ -385,7 +386,7 @@ def track_fingerprint(fingerprint: str, ip: str) -> int:
     if not FINGERPRINT_TRACKING_ENABLED or not fingerprint or not redis_client_fingerprints:
         return 1
     try:
-        key = f"fp:{fingerprint}"
+        key = tenant_key(f"fp:{fingerprint}")
         redis_client_fingerprints.sadd(key, ip)
         redis_client_fingerprints.expire(key, FINGERPRINT_WINDOW_SECONDS)
         return int(redis_client_fingerprints.scard(key))

--- a/src/shared/decision_db.py
+++ b/src/shared/decision_db.py
@@ -6,8 +6,13 @@ decisions and related metadata for analysis and debugging.
 import os
 import sqlite3
 from contextlib import contextmanager
+from src.shared.config import CONFIG
 
-DB_PATH = os.getenv("DECISIONS_DB_PATH", "/app/data/decisions.db")
+DEFAULT_DB_DIR = "/app/data"
+DB_PATH = os.getenv(
+    "DECISIONS_DB_PATH",
+    os.path.join(DEFAULT_DB_DIR, CONFIG.TENANT_ID, "decisions.db"),
+)
 
 # Ensure the directory for the database exists so connecting does not fail
 os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)

--- a/src/util/adaptive_rate_limit_manager.py
+++ b/src/util/adaptive_rate_limit_manager.py
@@ -5,9 +5,10 @@ from typing import List, Optional
 
 from src.shared.redis_client import get_redis_connection
 from src.util import compute_rate_limit
+from src.shared.config import tenant_key
 
 REDIS_DB_FREQUENCY = int(os.getenv("REDIS_DB_FREQUENCY", 3))
-FREQUENCY_KEY_PREFIX = os.getenv("FREQUENCY_KEY_PREFIX", "freq:")
+FREQUENCY_KEY_PREFIX = os.getenv("FREQUENCY_KEY_PREFIX") or tenant_key("freq:")
 FREQUENCY_WINDOW_SECONDS = int(os.getenv("ADAPTIVE_RATE_WINDOW_SECONDS", 60))
 BASE_RATE_LIMIT = int(os.getenv("BASE_RATE_LIMIT", 60))
 NGINX_RATE_LIMIT_CONF = os.getenv(

--- a/src/util/community_blocklist_sync.py
+++ b/src/util/community_blocklist_sync.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 import httpx
 
 from src.shared.redis_client import get_redis_connection
+from src.shared.config import tenant_key
 
 COMMUNITY_BLOCKLIST_API_URL = os.getenv(
     "COMMUNITY_BLOCKLIST_API_URL", "https://mock_community_blocklist_api:8000"
@@ -37,7 +38,7 @@ def update_redis_blocklist(ips: List[str], redis_conn) -> int:
         return 0
     added = 0
     for ip in ips:
-        key = f"blocklist:ip:{ip}"
+        key = tenant_key(f"blocklist:ip:{ip}")
         try:
             redis_conn.setex(key, BLOCKLIST_TTL_SECONDS, "community")
             added += 1

--- a/test/admin_ui/test_admin_ui.py
+++ b/test/admin_ui/test_admin_ui.py
@@ -90,7 +90,7 @@ class TestAdminUIComprehensive(unittest.TestCase):
         response = self.client.post('/block', json={'ip': '3.3.3.3'})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'status': 'success', 'ip': '3.3.3.3'})
-        mock_redis_instance.sadd.assert_called_once_with('blocklist', '3.3.3.3')
+        mock_redis_instance.sadd.assert_called_once_with('default:blocklist', '3.3.3.3')
 
     @patch('src.admin_ui.admin_ui.get_redis_connection')
     def test_unblock_ip_success(self, mock_get_redis):
@@ -102,7 +102,7 @@ class TestAdminUIComprehensive(unittest.TestCase):
         response = self.client.post('/unblock', json={'ip': '1.1.1.1'})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'status': 'success', 'ip': '1.1.1.1'})
-        mock_redis_instance.srem.assert_called_once_with('blocklist', '1.1.1.1')
+        mock_redis_instance.srem.assert_called_once_with('default:blocklist', '1.1.1.1')
         
     def test_block_ip_invalid_payload(self):
         """Test the /block endpoint with an invalid payload."""

--- a/test/ai_webhook/test_ai_webhook.py
+++ b/test/ai_webhook/test_ai_webhook.py
@@ -34,7 +34,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 10.0.0.1 added to blocklist.'})
-        self.mock_redis_client.sadd.assert_called_once_with('blocklist', '10.0.0.1')
+        self.mock_redis_client.sadd.assert_called_once_with('default:blocklist', '10.0.0.1')
 
     def test_webhook_receiver_allow_ip_success(self):
         """Test a successful 'allow_ip' action."""
@@ -44,7 +44,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 20.0.0.2 removed from blocklist.'})
-        self.mock_redis_client.srem.assert_called_once_with('blocklist', '20.0.0.2')
+        self.mock_redis_client.srem.assert_called_once_with('default:blocklist', '20.0.0.2')
         
     def test_webhook_receiver_flag_ip_success(self):
         """Test a successful 'flag_ip' action."""
@@ -55,7 +55,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 30.0.0.3 flagged.'})
         # The key name is defined inside the ai_webhook script
-        self.mock_redis_client.set.assert_called_once_with('ip_flag:30.0.0.3', 'Suspicious activity')
+        self.mock_redis_client.set.assert_called_once_with('default:ip_flag:30.0.0.3', 'Suspicious activity')
 
     def test_webhook_receiver_unflag_ip_success(self):
         """Test a successful 'unflag_ip' action."""
@@ -65,7 +65,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'status': 'success', 'message': 'IP 40.0.0.4 unflagged.'})
-        self.mock_redis_client.delete.assert_called_once_with('ip_flag:40.0.0.4')
+        self.mock_redis_client.delete.assert_called_once_with('default:ip_flag:40.0.0.4')
 
     def test_webhook_receiver_invalid_action(self):
         """Test that an unsupported action returns a 400 error."""

--- a/test/escalation/test_fingerprint.py
+++ b/test/escalation/test_fingerprint.py
@@ -27,9 +27,9 @@ class TestFingerprinting(unittest.TestCase):
         ):
             mock_redis.scard.return_value = 2
             count = ee.track_fingerprint("abc", "1.1.1.1")
-        mock_redis.sadd.assert_called_once_with("fp:abc", "1.1.1.1")
-        mock_redis.expire.assert_called_once_with("fp:abc", ee.FINGERPRINT_WINDOW_SECONDS)
-        mock_redis.scard.assert_called_once_with("fp:abc")
+        mock_redis.sadd.assert_called_once_with("default:fp:abc", "1.1.1.1")
+        mock_redis.expire.assert_called_once_with("default:fp:abc", ee.FINGERPRINT_WINDOW_SECONDS)
+        mock_redis.scard.assert_called_once_with("default:fp:abc")
         self.assertEqual(count, 2)
 
 if __name__ == "__main__":

--- a/test/tarpit/test_ip_flagger.py
+++ b/test/tarpit/test_ip_flagger.py
@@ -29,7 +29,7 @@ class TestIPFlaggerComprehensive(unittest.TestCase):
 
         self.assertTrue(result)
         self.mock_get_redis.assert_called_once_with(db_number=ip_flagger.REDIS_DB_FLAGGED_IPS)
-        self.mock_redis_client.setex.assert_called_once_with("ip_flag:8.8.8.8", ip_flagger.FLAGGED_IP_TTL_SECONDS, "Test Reason: High frequency")
+        self.mock_redis_client.setex.assert_called_once_with("default:ip_flag:8.8.8.8", ip_flagger.FLAGGED_IP_TTL_SECONDS, "Test Reason: High frequency")
         self.mock_redis_client.expire.assert_called_once()
 
     def test_flag_suspicious_ip_redis_connection_fails(self):
@@ -55,7 +55,7 @@ class TestIPFlaggerComprehensive(unittest.TestCase):
         self.mock_redis_client.exists.return_value = 1
         result = ip_flagger.is_ip_flagged("9.9.9.9")
         self.assertTrue(result)
-        self.mock_redis_client.exists.assert_called_once_with("ip_flag:9.9.9.9")
+        self.mock_redis_client.exists.assert_called_once_with("default:ip_flag:9.9.9.9")
 
     def test_is_ip_flagged_false(self):
         """Test checking an unflagged IP returns False."""
@@ -76,7 +76,7 @@ class TestIPFlaggerComprehensive(unittest.TestCase):
         self.mock_redis_client.delete.return_value = 1
         result = ip_flagger.remove_ip_flag("8.8.8.8")
         self.assertTrue(result)
-        self.mock_redis_client.delete.assert_any_call("ip_flag:8.8.8.8")
+        self.mock_redis_client.delete.assert_any_call("default:ip_flag:8.8.8.8")
         self.mock_redis_client.delete.assert_any_call(f"{ip_flagger.FLAG_COUNT_PREFIX}8.8.8.8")
         
     def test_remove_ip_flag_redis_command_error(self):


### PR DESCRIPTION
## Summary
- add `TENANT_ID` config setting and tenant prefix helper
- namespace Redis and DB keys using tenant prefix
- update Lua blocklist check for tenant ID
- document multi-tenant usage in README and sample.env
- update tests for new key names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b615566d88321b0e014e6d31013c4