### PR TITLE
Add Helm chart with autoscaling

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ These features and enhancements are prioritized for near-term development:
 Expanding feature sets and refining system efficiency:
 
 * **Multi-Tenant Support** – Enable easier deployment for multiple websites and organizations.  
-* **Kubernetes Scaling Enhancements** – Improve Helm charts and autoscaling options for large-scale deployments.  
+* ✅ **Kubernetes Scaling Enhancements** – Initial Helm chart with optional autoscaling for large clusters.
 * ✅ **Plugin API for Custom Rules** – Allow user-defined filtering rules for specialized site protection needs.  
 * **Expanded Honeypots** – Introduce more deceptive mechanisms like **auto-generated bad API endpoints**.  
 * **Anomaly Detection via AI** – Move beyond heuristics and integrate **anomaly detection models** for more adaptive security.  

--- a/docs/kubernetes_deployment.md
+++ b/docs/kubernetes_deployment.md
@@ -4,9 +4,21 @@ This guide outlines the steps to deploy the AI Scraping Defense stack to a Kuber
 
 ## Prerequisites
 
-- A running Kubernetes cluster.  
-- `kubectl` configured to communicate with your cluster.  
+- A running Kubernetes cluster.
+- `kubectl` configured to communicate with your cluster.
 - A container registry (e.g., Docker Hub, Google Container Registry, GitHub Container Registry) to store your built Docker image.
+
+### Deploy with Helm
+
+The repository now ships with a basic Helm chart located in the `helm/ai-scraping-defense` directory. Using Helm simplifies deployment and enables optional Horizontal Pod Autoscaler (HPA) resources.
+
+```bash
+helm install ai-defense ./helm/ai-scraping-defense \
+  --set image.repository=your-registry/ai-scraping-defense \
+  --set image.tag=latest
+```
+
+Customize the values in `values.yaml` or via `--set` flags to tune replica counts and autoscaling limits for large clusters.
 
 ## Deployment Steps
 

--- a/helm/ai-scraping-defense/Chart.yaml
+++ b/helm/ai-scraping-defense/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ai-scraping-defense
+description: Helm chart for deploying the AI Scraping Defense stack
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/helm/ai-scraping-defense/README.md
+++ b/helm/ai-scraping-defense/README.md
@@ -1,0 +1,15 @@
+# AI Scraping Defense Helm Chart
+
+This chart deploys a minimal version of the AI Scraping Defense stack. It includes the Nginx proxy and AI service along with optional Horizontal Pod Autoscalers.
+
+## Usage
+
+Update `values.yaml` with your desired image repository and tuning options. Then install the chart:
+
+```bash
+helm install ai-defense ./ai-scraping-defense \
+  --set image.repository=your-registry/ai-scraping-defense \
+  --set image.tag=latest
+```
+
+Autoscaling can be toggled via the `nginx.hpa.enabled` and `aiService.hpa.enabled` values.

--- a/helm/ai-scraping-defense/templates/_helpers.tpl
+++ b/helm/ai-scraping-defense/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "ai-scraping-defense.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/ai-scraping-defense/templates/ai-service-deployment.yaml
+++ b/helm/ai-scraping-defense/templates/ai-service-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-scraping-defense.fullname" . }}-ai
+spec:
+  selector:
+    app: ai-service
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-scraping-defense.fullname" . }}-ai
+spec:
+  replicas: {{ .Values.aiService.replicaCount }}
+  selector:
+    matchLabels:
+      app: ai-service
+  template:
+    metadata:
+      labels:
+        app: ai-service
+    spec:
+      containers:
+        - name: ai-service
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["uvicorn", "src.ai_service.ai_webhook:app", "--host", "0.0.0.0", "--port", "8000"]
+          ports:
+            - containerPort: 8000
+          resources: {{ toYaml .Values.aiService.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/helm/ai-scraping-defense/templates/ai-service-hpa.yaml
+++ b/helm/ai-scraping-defense/templates/ai-service-hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.aiService.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ai-scraping-defense.fullname" . }}-ai
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ai-scraping-defense.fullname" . }}-ai
+  minReplicas: {{ .Values.aiService.hpa.minReplicas }}
+  maxReplicas: {{ .Values.aiService.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.aiService.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ai-scraping-defense/templates/nginx-deployment.yaml
+++ b/helm/ai-scraping-defense/templates/nginx-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-scraping-defense.fullname" . }}-nginx
+spec:
+  selector:
+    app: nginx-proxy
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-scraping-defense.fullname" . }}-nginx
+spec:
+  replicas: {{ .Values.nginx.replicaCount }}
+  selector:
+    matchLabels:
+      app: nginx-proxy
+  template:
+    metadata:
+      labels:
+        app: nginx-proxy
+    spec:
+      containers:
+        - name: nginx
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          resources: {{ toYaml .Values.nginx.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/helm/ai-scraping-defense/templates/nginx-hpa.yaml
+++ b/helm/ai-scraping-defense/templates/nginx-hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.nginx.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ai-scraping-defense.fullname" . }}-nginx
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ai-scraping-defense.fullname" . }}-nginx
+  minReplicas: {{ .Values.nginx.hpa.minReplicas }}
+  maxReplicas: {{ .Values.nginx.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.nginx.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/ai-scraping-defense/values.yaml
+++ b/helm/ai-scraping-defense/values.yaml
@@ -1,0 +1,34 @@
+image:
+  repository: your-registry/ai-scraping-defense
+  tag: latest
+  pullPolicy: Always
+
+nginx:
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+
+aiService:
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70


### PR DESCRIPTION
## Summary
- add new `ai-scraping-defense` Helm chart with optional HPA
- document Helm deployment in Kubernetes guide
- mark roadmap item complete

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687b65bbeb9c83218a356432dabecab3