### PR TITLE
Add decoy API endpoints for honeypot

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,7 +24,7 @@ Expanding feature sets and refining system efficiency:
 * **Multi-Tenant Support** – Enable easier deployment for multiple websites and organizations.  
 * ✅ **Kubernetes Scaling Enhancements** – Initial Helm chart with optional autoscaling for large clusters.
 * ✅ **Plugin API for Custom Rules** – Allow user-defined filtering rules for specialized site protection needs.  
-* **Expanded Honeypots** – Introduce more deceptive mechanisms like **auto-generated bad API endpoints**.  
+* ✅ **Expanded Honeypots** – Introduce more deceptive mechanisms like **auto-generated bad API endpoints**.
 * **Anomaly Detection via AI** – Move beyond heuristics and integrate **anomaly detection models** for more adaptive security.  
 * **Public Community Blocklist** – Optional contributor-driven IP reputation database.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ This project includes:
 
 - FastAPI-based tarpit to delay or confuse bots
 - ZIP archive honeypots containing fake JavaScript traps
+- Auto-generated decoy API endpoints to mislead scrapers
 - Escalation engine for behavioral analysis (local + LLM)
 - Admin UI with real-time metrics
 - Markov-based fake text generators

--- a/src/tarpit/__init__.py
+++ b/src/tarpit/__init__.py
@@ -1,4 +1,11 @@
-from . import ip_flagger, js_zip_generator, markov_generator, rotating_archive, tarpit_api
+from . import (
+    ip_flagger,
+    js_zip_generator,
+    markov_generator,
+    rotating_archive,
+    tarpit_api,
+    bad_api_generator,
+)
 try:
     import tarpit_rs
 except Exception:  # pragma: no cover - optional dependency
@@ -16,4 +23,5 @@ __all__ = [
     'tarpit_rs',
     'rotating_archive',
     'tarpit_api',
+    'bad_api_generator',
 ]

--- a/src/tarpit/bad_api_generator.py
+++ b/src/tarpit/bad_api_generator.py
@@ -1,0 +1,84 @@
+# src/tarpit/bad_api_generator.py
+"""Generate deceptive API endpoints for the tarpit honeypot."""
+
+from __future__ import annotations
+
+import logging
+import random
+import string
+from typing import List
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+try:
+    from src.shared.honeypot_logger import log_honeypot_hit
+    HONEYPOT_LOGGING_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    HONEYPOT_LOGGING_AVAILABLE = False
+
+    def log_honeypot_hit(details: dict) -> None:  # type: ignore[empty-body]
+        return
+
+logger = logging.getLogger(__name__)
+
+COMMON_PREFIXES = ["v1", "v2", "internal", "private"]
+RESOURCE_NAMES = [
+    "config",
+    "data",
+    "auth",
+    "report",
+    "metrics",
+    "status",
+    "secrets",
+]
+
+GENERATED_BAD_API_ENDPOINTS: List[str] = []
+
+
+def _rand_str(length: int = 6) -> str:
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
+
+
+def generate_bad_endpoints(count: int = 5) -> List[str]:
+    """Return a list of fake API endpoint paths."""
+    endpoints: List[str] = []
+    for _ in range(count):
+        prefix = random.choice(COMMON_PREFIXES)
+        resource = random.choice(RESOURCE_NAMES)
+        unique = _rand_str()
+        endpoints.append(f"/{prefix}/{resource}/{unique}")
+    return endpoints
+
+
+def register_bad_endpoints(app: FastAPI, count: int = 5) -> List[str]:
+    """Register fake API endpoints on the provided FastAPI app."""
+    endpoints = generate_bad_endpoints(count)
+    global GENERATED_BAD_API_ENDPOINTS
+    GENERATED_BAD_API_ENDPOINTS = endpoints
+
+    for path in endpoints:
+        async def handler(request: Request, path: str = path):
+            client_ip = request.client.host if request.client else "unknown"
+            ua = request.headers.get("user-agent", "unknown")
+            details = {
+                "ip": client_ip,
+                "user_agent": ua,
+                "path": f"/api{path}",
+                "method": request.method,
+            }
+            if HONEYPOT_LOGGING_AVAILABLE:
+                try:
+                    log_honeypot_hit(details)
+                except Exception as exc:  # pragma: no cover - log unexpected error
+                    logger.error(f"Error logging honeypot hit: {exc}", exc_info=True)
+            logger.info(f"BAD API HIT: /api{path} from {client_ip}")
+            return JSONResponse({"detail": "Invalid API endpoint"}, status_code=404)
+
+        app.add_api_route(
+            f"/api{path}",
+            handler,
+            methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
+        )
+    return endpoints
+

--- a/src/tarpit/tarpit_api.py
+++ b/src/tarpit/tarpit_api.py
@@ -94,6 +94,7 @@ ENABLE_TARPIT_CATCH_ALL = CONFIG.ENABLE_TARPIT_CATCH_ALL
 # --- THIS IS THE SOLE REFACTORING CHANGE ---
 # Replaced the manual Redis Connection Pools with calls to the centralized client.
 from src.shared.redis_client import get_redis_connection
+from .bad_api_generator import register_bad_endpoints, GENERATED_BAD_API_ENDPOINTS
 redis_hops = get_redis_connection(db_number=REDIS_DB_TAR_PIT_HOPS)
 redis_blocklist = get_redis_connection(db_number=REDIS_DB_BLOCKLIST)
 
@@ -105,6 +106,7 @@ if not redis_hops or not redis_blocklist:
 
 # --- FastAPI App ---
 app = FastAPI()
+BAD_API_ENDPOINTS = register_bad_endpoints(app)
 
 # --- Helper Functions (Preserved from your original file) ---
 async def slow_stream_content(content: str):

--- a/test/tarpit/__init__.py
+++ b/test/tarpit/__init__.py
@@ -6,6 +6,7 @@ from src.tarpit import (
     markov_generator,
     rotating_archive,
     tarpit_api,
+    bad_api_generator,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     'markov_generator',
     'rotating_archive',
     'tarpit_api',
+    'bad_api_generator',
 ]

--- a/test/tarpit/test_bad_api_generator.py
+++ b/test/tarpit/test_bad_api_generator.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.tarpit import bad_api_generator
+
+
+class TestBadApiGenerator(unittest.TestCase):
+    def test_generate_bad_endpoints_count(self):
+        endpoints = bad_api_generator.generate_bad_endpoints(count=3)
+        self.assertEqual(len(endpoints), 3)
+        self.assertEqual(len(set(endpoints)), 3)
+        for ep in endpoints:
+            self.assertTrue(ep.startswith("/"))
+
+    def test_register_bad_endpoints(self):
+        app = FastAPI()
+        with patch('src.tarpit.bad_api_generator.log_honeypot_hit') as log_mock:
+            eps = bad_api_generator.register_bad_endpoints(app, count=2)
+            self.assertEqual(len(eps), 2)
+            client = TestClient(app)
+            resp = client.get(f"/api{eps[0]}")
+            self.assertEqual(resp.status_code, 404)
+            log_mock.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- generate fake API endpoints at startup via `bad_api_generator`
- register the decoy endpoints in `tarpit_api`
- document this honeypot upgrade
- test coverage for generator

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687b680275648321a8b76ec545c6d36d