### PR TITLE
Implement peer-to-peer blocklist sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project provides a multi-layered, microservice-based defense system against
 - **Rate Limiting:** Adaptive per-IP limits updated by a small daemon writing to Nginx.
 - **Community Blocklist:** Optional daemon to sync IPs from a shared blocklist service.
 - **Public Community Blocklist Service:** Lightweight FastAPI app for contributors to share and fetch malicious IPs.
+- **Federated Threat Sharing:** Peer-to-peer sync exchanges blocklisted IPs between deployments.
 - **Containerized:** Fully containerized with Docker and ready for deployment on Kubernetes.
 - **Multi-Tenant Ready:** Namespace configuration and Redis keys with `TENANT_ID` for easy isolation.
 - **Optional Cloud Integrations:** Toggle CDN caching, DDoS mitigation, managed TLS, and a Web Application Firewall using environment variables.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,7 @@ Expanding feature sets and refining system efficiency:
 
 Larger-scale improvements and broader adoption:
 
-* **Federated Model for Threat Intelligence Sharing** – Establish **peer-to-peer collaboration between deployments** to exchange bot intelligence.  
+* ✅ **Federated Model for Threat Intelligence Sharing** – Establish **peer-to-peer collaboration between deployments** to exchange bot intelligence.
 * **Cloud-Based Management Dashboard** – Provide **hosted real-time monitoring** for multiple installations.  
 * **Industry Partnerships** – Integrate with cybersecurity initiatives and FOSS security groups for wider adoption.  
 * **Automated Configuration Recommendations** – AI-driven suggestions for optimal firewall/tarpit settings based on incoming traffic patterns.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,6 +105,7 @@ Once the containers are running, you can access the key services in your web bro
 * **MailHog (Email Catcher):** [http://localhost:8025](http://localhost:8025)
 * **Redis (for blocklist management):** [http://localhost:6379](http://localhost:6379) (not directly accessible via a web interface, but can be managed using Redis CLI or GUI tools).
 * **Blocklist Sync Daemon:** runs automatically to pull updates from the community blocklist service.
+* **Peer Sync Daemon:** exchanges blocklisted IPs with configured peer deployments.
 
 ### **6.1. Accessing the Admin UI**
 

--- a/sample.env
+++ b/sample.env
@@ -71,6 +71,12 @@ COMMUNITY_BLOCKLIST_LIST_ENDPOINT=/list
 COMMUNITY_BLOCKLIST_SYNC_INTERVAL=3600
 # TTL for blocklist entries pulled from the community feed
 COMMUNITY_BLOCKLIST_TTL_SECONDS=86400
+# Comma-separated list of peer blocklist URLs for federated sharing
+PEER_BLOCKLIST_URLS=
+# Interval in seconds between peer sync runs
+PEER_BLOCKLIST_SYNC_INTERVAL=3600
+# TTL for entries pulled from peers
+PEER_BLOCKLIST_TTL_SECONDS=86400
 SMTP_PASSWORD=
 
 # CAPTCHA configuration

--- a/scripts/peer_blocklist_sync_daemon.py
+++ b/scripts/peer_blocklist_sync_daemon.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+import logging
+
+from src.util import peer_blocklist_sync
+
+SYNC_INTERVAL_SECONDS = int(os.getenv("PEER_BLOCKLIST_SYNC_INTERVAL", "3600"))
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+async def run_sync_loop(stop_event: asyncio.Event | None = None) -> None:
+    """Run the peer blocklist sync task periodically."""
+    if stop_event is None:
+        stop_event = asyncio.Event()
+    while not stop_event.is_set():
+        try:
+            await peer_blocklist_sync.sync_peer_blocklists()
+        except Exception as exc:  # pragma: no cover - unexpected
+            logger.error("Peer blocklist sync failed: %s", exc)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=SYNC_INTERVAL_SECONDS)
+        except asyncio.TimeoutError:
+            continue
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(run_sync_loop())
+    except KeyboardInterrupt:
+        logger.info("Peer blocklist sync daemon stopped")

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -5,4 +5,5 @@ from .ddos_protection import report_attack  # noqa: F401
 from .tls_manager import ensure_certificate  # noqa: F401
 from .waf_manager import load_waf_rules, reload_waf_rules  # noqa: F401
 from .adaptive_rate_limit_manager import compute_and_update  # noqa: F401
+from .peer_blocklist_sync import sync_peer_blocklists  # noqa: F401
 

--- a/src/util/peer_blocklist_sync.py
+++ b/src/util/peer_blocklist_sync.py
@@ -1,0 +1,73 @@
+import os
+import asyncio
+import logging
+from typing import List, Optional
+
+import httpx
+
+from src.shared.redis_client import get_redis_connection
+from src.shared.config import tenant_key
+
+PEER_BLOCKLIST_URLS = os.getenv("PEER_BLOCKLIST_URLS", "")
+REDIS_DB_BLOCKLIST = int(os.getenv("REDIS_DB_BLOCKLIST", 2))
+PEER_BLOCKLIST_TTL_SECONDS = int(os.getenv("PEER_BLOCKLIST_TTL_SECONDS", 86400))
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+async def fetch_peer_ips(url: str) -> List[str]:
+    """Fetch a list of malicious IPs from a peer deployment."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, timeout=10.0)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, list):
+            return [ip for ip in data if isinstance(ip, str)]
+        if isinstance(data, dict):
+            ips = data.get("ips")
+            if isinstance(ips, list):
+                return [ip for ip in ips if isinstance(ip, str)]
+        return []
+
+def update_redis_blocklist(ips: List[str], redis_conn) -> int:
+    """Insert IPs into the Redis blocklist with a TTL."""
+    if not ips or not redis_conn:
+        return 0
+    added = 0
+    for ip in ips:
+        key = tenant_key(f"blocklist:ip:{ip}")
+        try:
+            redis_conn.setex(key, PEER_BLOCKLIST_TTL_SECONDS, "peer")
+            added += 1
+        except Exception as exc:  # pragma: no cover - unexpected redis errors
+            logger.error("Failed to set Redis key for IP %s: %s", ip, exc)
+    return added
+
+async def sync_peer_blocklists() -> Optional[int]:
+    """Fetch blocklists from configured peers and update Redis."""
+    if not PEER_BLOCKLIST_URLS:
+        logger.info("No peer blocklist URLs configured.")
+        return 0
+    urls = [u.strip() for u in PEER_BLOCKLIST_URLS.split(',') if u.strip()]
+    if not urls:
+        logger.info("Peer blocklist URL list empty.")
+        return 0
+    redis_conn = get_redis_connection(db_number=REDIS_DB_BLOCKLIST)
+    if not redis_conn:
+        logger.error("Could not connect to Redis for peer blocklist updates.")
+        return None
+    total_added = 0
+    for url in urls:
+        try:
+            logger.info("Fetching peer blocklist from %s", url)
+            ips = await fetch_peer_ips(url)
+        except Exception as e:  # pragma: no cover - network errors
+            logger.error("Failed to fetch peer blocklist from %s: %s", url, e)
+            continue
+        added = update_redis_blocklist(ips, redis_conn)
+        total_added += added
+    logger.info("Added/updated %s IPs from peer blocklists.", total_added)
+    return total_added
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    asyncio.run(sync_peer_blocklists())

--- a/test/util/test_peer_blocklist_sync.py
+++ b/test/util/test_peer_blocklist_sync.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from src.util import peer_blocklist_sync as sync
+
+class TestPeerBlocklistSync(unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_peer_ips_list_format(self):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = ["1.1.1.1", "2.2.2.2"]
+        mock_resp.raise_for_status.return_value = None
+        mock_client.__aenter__.return_value.get.return_value = mock_resp
+        with patch("src.util.peer_blocklist_sync.httpx.AsyncClient", return_value=mock_client):
+            ips = await sync.fetch_peer_ips("http://example.com/list")
+        self.assertEqual(ips, ["1.1.1.1", "2.2.2.2"])
+
+    async def test_fetch_peer_ips_dict_format(self):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"ips": ["3.3.3.3"]}
+        mock_resp.raise_for_status.return_value = None
+        mock_client.__aenter__.return_value.get.return_value = mock_resp
+        with patch("src.util.peer_blocklist_sync.httpx.AsyncClient", return_value=mock_client):
+            ips = await sync.fetch_peer_ips("http://example.com/list")
+        self.assertEqual(ips, ["3.3.3.3"])
+
+    async def test_sync_peer_blocklists_updates_redis(self):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = ["4.4.4.4"]
+        mock_resp.raise_for_status.return_value = None
+        mock_client.__aenter__.return_value.get.return_value = mock_resp
+        mock_redis = MagicMock()
+        with patch("src.util.peer_blocklist_sync.httpx.AsyncClient", return_value=mock_client), \
+             patch("src.util.peer_blocklist_sync.get_redis_connection", return_value=mock_redis), \
+             patch.object(sync, "PEER_BLOCKLIST_URLS", "http://peer/list"):
+            result = await sync.sync_peer_blocklists()
+        mock_redis.setex.assert_called_once()
+        self.assertEqual(result, 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add federated peer blocklist sync utility and daemon
- document the new feature and environment variables
- update roadmap to mark the item complete
- add unit tests for peer sync

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687b6f7891ec8321956f05757fe29dbb