### PR TITLE
Add WordPress test site script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ For a one-command setup, run `./quickstart_dev.sh` on Linux/macOS or `quickstart
     docker-compose up --build -d
     ```
 
+    If you'd like to try the proxy in front of a WordPress site, run `./setup_wordpress_website.sh` instead. It launches WordPress and MariaDB containers on the same Docker network and sets `REAL_BACKEND_HOST` automatically.
+
 7. **Access the Services:**
     - **Admin UI:** `http://localhost:5002`
     - **Cloud Dashboard:** `http://localhost:5006`

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -120,6 +120,16 @@ MailHog is used to capture emails sent by the application for testing purposes. 
 
 You can extend the detection heuristics by placing Python modules inside the `plugins/` directory. Set `ENABLE_PLUGINS=true` in your `.env` file and restart the stack. Each module should define a `check(metadata)` function returning a numeric adjustment.
 
+### **6.4. Running a WordPress Test Site**
+
+If you want to see how the defense stack performs in front of a real CMS, a helper script is provided to launch a WordPress instance and wire it into the proxy.
+
+```bash
+./setup_wordpress_website.sh
+```
+
+The script starts the Docker Compose stack (if it is not already running) and then launches WordPress and its MariaDB database on the same `defense_network`. Traffic allowed by the proxy will reach WordPress via `REAL_BACKEND_HOST`. Once started you can visit the site directly at [http://localhost:8082](http://localhost:8082) or through the defense stack at [http://localhost:8080](http://localhost:8080).
+
 ### **7. Stopping the Application**
 
 To stop the application stack, you can run:

--- a/setup_wordpress_website.sh
+++ b/setup_wordpress_website.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# =============================================================================
+#  setup_wordpress_website.sh - launch a WordPress site for testing
+#
+#  This helper spins up WordPress and MariaDB containers and connects them
+#  to the AI Scraping Defense stack. The proxy will forward allowed traffic
+#  to the WordPress container using the REAL_BACKEND_HOST variable.
+#
+#  DISCLAIMER: This script is intended for local testing only. Do not expose
+#  the stack to production traffic without a security review.
+# =============================================================================
+set -e
+
+# Ensure .env exists
+if [ ! -f .env ]; then
+  cp sample.env .env
+  echo "Created .env from sample.env"
+fi
+
+# Update REAL_BACKEND_HOST to point at the WordPress container
+if grep -q '^REAL_BACKEND_HOST=' .env; then
+  sed -i.bak 's|^REAL_BACKEND_HOST=.*|REAL_BACKEND_HOST=http://wordpress:80|' .env && rm -f .env.bak
+else
+  echo 'REAL_BACKEND_HOST=http://wordpress:80' >> .env
+fi
+
+# Start the AI Scraping Defense stack
+docker-compose up --build -d
+
+# Determine the Docker network created by docker-compose
+NETWORK_NAME=$(docker network ls --filter name=defense_network -q | head -n 1)
+if [ -z "$NETWORK_NAME" ]; then
+  echo "Could not locate the defense_network. Is the stack running?"
+  exit 1
+fi
+
+# Launch MariaDB for WordPress
+if [ ! "$(docker ps -q -f name=wordpress_db)" ]; then
+  docker run -d --name wordpress_db \
+    --network $NETWORK_NAME \
+    -e MYSQL_ROOT_PASSWORD=example \
+    -e MYSQL_DATABASE=wordpress \
+    -e MYSQL_USER=wordpress \
+    -e MYSQL_PASSWORD=wordpress \
+    mariadb:10
+else
+  echo "wordpress_db container already running"
+fi
+
+# Launch the WordPress container
+if [ ! "$(docker ps -q -f name=wordpress)" ]; then
+  docker run -d --name wordpress \
+    --network $NETWORK_NAME \
+    -p 8082:80 \
+    -e WORDPRESS_DB_HOST=wordpress_db:3306 \
+    -e WORDPRESS_DB_USER=wordpress \
+    -e WORDPRESS_DB_PASSWORD=wordpress \
+    -e WORDPRESS_DB_NAME=wordpress \
+    wordpress:php8.1-apache
+else
+  echo "wordpress container already running"
+fi
+
+echo "WordPress available at http://localhost:8082"
+echo "Proxy via AI Scraping Defense at http://localhost:8080"


### PR DESCRIPTION
## Summary
- create `setup_wordpress_website.sh` to spin up WordPress with MariaDB
- document using the script in README and getting started docs

## Testing
- `python3 test/run_all_tests.py`
- `flake8` *(fails: E302 expected 2 blank lines, found 1)*

------
https://chatgpt.com/codex/tasks/task_e_687be5f4560c8321b2c95fb7c58f4a0b