### PR TITLE
Add load testing script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,13 @@ This flexibility makes it easy to experiment with different classifiers.
 ## Automated Deployment
 
 Use `./quick_deploy.sh` (Linux/macOS) or `quick_deploy.ps1` (Windows) for a streamlined Kubernetes deployment. These scripts generate required secrets and apply all manifests using kubectl.
+
+## Load Testing Helpers
+
+To experiment with the stack's performance under load, run the helper script:
+
+```bash
+./setup_load_test_suite.sh
+```
+
+It installs common open-source tools such as **wrk**, **siege**, **ab**, **k6**, and **locust**. Use them responsibly and only against environments you control.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -145,3 +145,21 @@ docker-compose down
 ```
 
 This will stop and remove all the containers defined in your docker-compose.yml file.
+
+### **8. Stress Testing the Stack**
+
+For load and performance experiments, a helper script installs several open-source testing tools. Run it from the project root:
+
+```bash
+./setup_load_test_suite.sh
+```
+
+The script installs utilities like **wrk**, **siege**, **ab**, **k6**, and **locust**. After installation, you can try commands such as:
+
+```bash
+wrk -t4 -c100 -d30s http://localhost:8080
+siege -c50 -t1m http://localhost:8080
+ab -n 1000 -c100 http://localhost:8080/
+```
+
+Use these programs only against systems you own or have explicit permission to test.

--- a/setup_load_test_suite.sh
+++ b/setup_load_test_suite.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# =============================================================================
+#  setup_load_test_suite.sh - install basic load testing tools
+#
+#  This helper installs a few common utilities for stress testing the
+#  AI Scraping Defense stack. Use only against infrastructure you own
+#  or are authorized to test.
+# =============================================================================
+set -e
+
+echo "=== Installing load testing tools ==="
+
+# Determine package manager
+if command -v apt-get >/dev/null; then
+    PKG_MANAGER="apt-get"
+elif command -v yum >/dev/null; then
+    PKG_MANAGER="yum"
+else
+    echo "Unsupported package manager. Install wrk, siege, and apache2-utils manually."
+    exit 1
+fi
+
+sudo $PKG_MANAGER update -y
+sudo $PKG_MANAGER install -y wrk siege apache2-utils
+
+# Install k6 if missing
+if ! command -v k6 >/dev/null; then
+    echo "Installing k6..."
+    if [ "$PKG_MANAGER" = "apt-get" ]; then
+        sudo apt-get install -y gnupg2 curl
+        curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+        sudo apt-get update
+        sudo apt-get install -y k6
+    else
+        sudo yum install -y k6
+    fi
+fi
+
+# Install Locust via pip
+if ! command -v locust >/dev/null; then
+    pip install --user locust
+fi
+
+cat <<'MSG'
+
+Load testing tools installed.
+Example commands:
+  wrk -t4 -c100 -d30s http://localhost:8080
+  siege -c50 -t1m http://localhost:8080
+  ab -n 1000 -c100 http://localhost:8080/
+  k6 run examples/script.js
+  locust -f examples/locustfile.py
+
+Ensure you have permission before running tests.
+MSG


### PR DESCRIPTION
## Summary
- add `setup_load_test_suite.sh` for installing load testing utilities
- document load testing script in README and Getting Started guide
- mention common tools and commands for stress testing

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687bf1b1a97c8321a442a158010ff95c