### PR TITLE
Add cross-platform stress test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,13 @@ To experiment with the stack's performance under load, run the helper script:
 ```
 
 It installs common open-source tools such as **wrk**, **siege**, **ab**, **k6**, and **locust**. Use them responsibly and only against environments you control.
+
+After installing the tools, you can run a basic stress test using the provided scripts:
+
+```powershell
+./stress_test.ps1 -Target http://your-linux-host:8080 -VUs 50 -DurationSeconds 30
+```
+
+```bash
+./stress_test.sh http://your-linux-host:8080
+```

--- a/stress_test.ps1
+++ b/stress_test.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+    Runs a simple k6 stress test against the stack.
+.DESCRIPTION
+    Generates a temporary k6 script that repeatedly hits the target URL.
+    Use only against systems you own or are authorized to test.
+.PARAMETER Target
+    Base URL of the stack. Default http://localhost:8080
+.PARAMETER VUs
+    Number of virtual users. Default 50.
+.PARAMETER DurationSeconds
+    Duration of the test in seconds. Default 30.
+#>
+param(
+    [string]$Target = "http://localhost:8080",
+    [int]$VUs = 50,
+    [int]$DurationSeconds = 30
+)
+
+$ErrorActionPreference = 'Stop'
+Write-Host '=== AI Scraping Defense: Stress Test ===' -ForegroundColor Cyan
+
+if (-not (Get-Command k6 -ErrorAction SilentlyContinue)) {
+    Write-Error 'k6 is not installed. Install it from https://k6.io/ or via Chocolatey: choco install k6'
+    exit 1
+}
+
+$tempFile = New-TemporaryFile
+@"
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export let options = {
+    vus: $VUs,
+    duration: '${DurationSeconds}s',
+};
+
+export default function () {
+    http.get('$Target');
+    sleep(1);
+}
+"@ | Set-Content $tempFile -Encoding ascii
+
+& k6 run $tempFile
+Remove-Item $tempFile
+Write-Host 'Stress test complete.' -ForegroundColor Green

--- a/stress_test.sh
+++ b/stress_test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# =============================================================================
+#  stress_test.sh - run a simple k6 load test against the stack
+#
+#  Use only against infrastructure you own or have permission to test.
+# =============================================================================
+set -e
+
+TARGET="${1:-http://localhost:8080}"
+VUS="${VUS:-50}"
+DURATION="${DURATION:-30s}"
+
+echo "=== Running k6 stress test on $TARGET for $DURATION with $VUS VUs ==="
+
+if ! command -v k6 >/dev/null; then
+    echo "ERROR: k6 is not installed. Install from https://k6.io/ before running." >&2
+    exit 1
+fi
+
+cat <<EOT > /tmp/k6_stress.js
+import http from 'k6/http';
+import { sleep } from 'k6';
+export let options = {
+  vus: $VUS,
+  duration: '$DURATION',
+};
+export default function () {
+  http.get('$TARGET');
+  sleep(1);
+}
+EOT
+
+k6 run /tmp/k6_stress.js
+rm /tmp/k6_stress.js
+
+echo "k6 stress test complete."


### PR DESCRIPTION
## Summary
- add `stress_test.ps1` to run a k6 load test from Windows
- add `stress_test.sh` for Linux/macOS users
- document usage of the new scripts in README

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687bf72e40448321a9cfdd2c5910471f