### PR TITLE
Fix quickstart/deploy scripts to run from script directory

### DIFF
--- a/quick_deploy.ps1
+++ b/quick_deploy.ps1
@@ -3,6 +3,7 @@
     Quickly deploys the stack to Kubernetes.
 #>
 $ErrorActionPreference = 'Stop'
+Set-Location -Path $PSScriptRoot
 Write-Host '=== AI Scraping Defense: Quick Deploy ===' -ForegroundColor Cyan
 
 if (-not (Test-Path '.env')) {

--- a/quick_deploy.sh
+++ b/quick_deploy.sh
@@ -2,6 +2,10 @@
 # Quick deployment for Kubernetes
 set -e
 
+# Always operate from the directory where this script resides
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 echo "=== AI Scraping Defense: Quick Deploy ==="
 
 # Ensure .env exists for docker build context or other scripts

--- a/quickstart_dev.ps1
+++ b/quickstart_dev.ps1
@@ -3,6 +3,7 @@
     Sets up the development environment with a single command.
 #>
 $ErrorActionPreference = 'Stop'
+Set-Location -Path $PSScriptRoot
 Write-Host '=== AI Scraping Defense: Development Quickstart ===' -ForegroundColor Cyan
 
 if (-not (Test-Path '.env')) {

--- a/quickstart_dev.sh
+++ b/quickstart_dev.sh
@@ -2,6 +2,10 @@
 # Quick setup script for local development
 set -e
 
+# Always operate from the directory where this script resides
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 echo "=== AI Scraping Defense: Development Quickstart ==="
 
 # Copy sample.env if .env doesn't exist


### PR DESCRIPTION
## Summary
- ensure quickstart/deploy scripts work when run from other paths
- add `Set-Location` in PowerShell and `cd` logic in shell scripts

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687deaa43760832196fdf2d3b82c998a