### PR TITLE
Fix postgres service indentation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -230,13 +230,13 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./db/init_markov.sql:/docker-entrypoint-initdb.d/init_markov.sql
-      environment:
-        # The official Postgres image expects the POSTGRES_* variables, but
-        # our .env uses the newer PG_* naming. Map them here so both the
-        # container and the rest of the stack get the correct values.
-        - POSTGRES_USER=${PG_USER}
-        - POSTGRES_PASSWORD_FILE=${PG_PASSWORD_FILE}
-        - POSTGRES_DB=${PG_DBNAME}
+    environment:
+      # The official Postgres image expects the POSTGRES_* variables, but
+      # our .env uses the newer PG_* naming. Map them here so both the
+      # container and the rest of the stack get the correct values.
+      - POSTGRES_USER=${PG_USER}
+      - POSTGRES_PASSWORD_FILE=${PG_PASSWORD_FILE}
+      - POSTGRES_DB=${PG_DBNAME}
     ports:
       - "${PG_PORT:-5432}:5432"
     networks:


### PR DESCRIPTION
## Summary
- fix indentation of `environment` block in `postgres` service

## Testing
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687df40d16e88321a286449a81d1b305