### PR TITLE
Clarify production proxy ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For a one-command setup, run `./quickstart_dev.sh` on Linux/macOS or `quickstart
     Set `TENANT_ID` to a unique value for each isolated deployment.
     To enable the CAPTCHA verification service, populate `CAPTCHA_SECRET` with your reCAPTCHA secret key.
     Tarpit behavior can be tuned with `TARPIT_MAX_HOPS` and `TARPIT_HOP_WINDOW_SECONDS` to automatically block clients that spend too much time in the tarpit.
+    For **production** deployments, change `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443` so the proxy listens on standard web ports.
 
 3. **Set Up Python Virtual Environment:**
     Run the setup script to create a virtual environment and install all Python dependencies.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -38,7 +38,7 @@ cp sample.env .env
 Copy-Item sample.env .env
 ```
 
-Now, open the .env file in your code editor. For now, you can leave the default values as they are. This is where you would add your real API keys for services like OpenAI or Mistral when you're ready to use them.
+Now, open the .env file in your code editor. For now, you can leave the default values as they are. This is where you would add your real API keys for services like OpenAI or Mistral when you're ready to use them. For **production** deployments, update `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443` so the proxy listens on the standard web ports.
 
 ### **3. Set Up the Python Virtual Environment**
 

--- a/sample.env
+++ b/sample.env
@@ -20,9 +20,12 @@ TENANT_ID=default
 # MODEL_URI=ollama://llama3
 MODEL_URI=sklearn:///app/models/bot_detection_rf_model.joblib
 
-# --- Service Ports (Defaults are usually fine) ---
-NGINX_HTTP_PORT=8080
-NGINX_HTTPS_PORT=8443
+# --- Service Ports (Defaults are usually fine for local testing) ---
+# For production deployments you will typically expose the proxy
+# on the standard HTTP/HTTPS ports. Set these to 80 and 443
+# when deploying to a public-facing environment.
+NGINX_HTTP_PORT=8080  # change to 80 in production
+NGINX_HTTPS_PORT=8443 # change to 443 in production
 AI_SERVICE_PORT=8000
 TARPIT_API_PORT=8001
 TARPIT_MAX_HOPS=250


### PR DESCRIPTION
## Summary
- document that Nginx should listen on 80/443 in production
- add note about changing ports in environment file
- explain production port settings in the getting started guide

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e04f6bfc883219f9ec3910faac68e