### PR TITLE
Specify Rust toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ For remote providers, set the corresponding API key in `.env` (`OPENAI_API_KEY`,
 
 `markov-train-rs` contains a high-performance implementation of the corpus loader.
 It exposes a `train_from_corpus_rs` function callable from Python via PyO3.
+The repository is pinned to **Rust 1.78.0** via `rust-toolchain.toml`. Ensure
+that toolchain is installed before building the Rust crates.
 
 Build the extension with Cargo:
 

--- a/frequency-rs/Cargo.toml
+++ b/frequency-rs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "frequency-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.78"
 
 [lib]
 name = "frequency_rs"

--- a/jszip-rs/Cargo.toml
+++ b/jszip-rs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jszip-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.78"
 build = "build.rs"
 
 [lib]

--- a/markov-train-rs/Cargo.toml
+++ b/markov-train-rs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "markov-train-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.78"
 
 [lib]
 name = "markov_train_rs"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.78.0"

--- a/tarpit-rs/Cargo.toml
+++ b/tarpit-rs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tarpit-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.78"
 
 [lib]
 name = "tarpit_rs"


### PR DESCRIPTION
## Summary
- pin the repo to Rust 1.78.0 via `rust-toolchain.toml`
- require Rust 1.78 in each Cargo crate
- mention the Rust toolchain in the README

## Testing
- `cargo check` in `markov-train-rs`

------
https://chatgpt.com/codex/tasks/task_e_6881c3a21314832188ce301212aee3b5