### PR TITLE
Add interactive setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ Follow these steps if you prefer to configure everything yourself.
     ```
 
 2. **Create Environment File:**
-    Copy the example environment file to create your local configuration.
+    Copy the example environment file or use the interactive helper to customise settings.
 
     ```bash
     cp sample.env .env
+    # optional guided setup
+    python scripts/interactive_setup.py
     ```
 
     Open `.env` and review the defaults. Set `TENANT_ID` for isolated deployments and add any API keys you plan to use. For **production** deployments update `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443`.
@@ -68,7 +70,7 @@ Follow these steps if you prefer to configure everything yourself.
     ```
 
 4. **Generate Secrets:**
-    Run the secret generation script to create passwords for the database, Admin UI, and other services. It writes a `kubernetes/secrets.yaml` file and prints the credentials to your console.
+    Run the secret generation script to create passwords for the database, Admin UI, and other services. It writes a `kubernetes/secrets.yaml` file and prints the credentials to your console. If you used `interactive_setup.py` above, this step has already been performed.
 
     *On Linux or macOS:*
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -42,11 +42,14 @@ Copy the template to create your own local .env file:
 ``` bash
 # On Linux or macOS
 cp sample.env .env
+# optional guided setup
+python scripts/interactive_setup.py
 ```
 
 ``` PowerShell
 # On Windows (in a PowerShell terminal)
 Copy-Item sample.env .env
+python scripts/interactive_setup.py
 ```
 
 Now, open the .env file in your code editor. For now, you can leave the default values as they are. This is where you would add your real API keys for services like OpenAI or Mistral when you're ready to use them. For **production** deployments, update `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443` so the proxy listens on the standard web ports.
@@ -72,7 +75,7 @@ This script will create a virtual environment in the .venv directory, install al
 
 ### **4. Generate Local Secrets**
 
-The application requires several secrets to run (e.g., database passwords). A script is provided to generate these securely. It creates `kubernetes/secrets.yaml` and prints the credentials to your console. By default it **does not** modify your `.env` file.
+The application requires several secrets to run (e.g., database passwords). A script is provided to generate these securely. It creates `kubernetes/secrets.yaml` and prints the credentials to your console. By default it **does not** modify your `.env` file. If you used the interactive setup script, this step is performed automatically.
 
 * **On Linux or macOS:**
 

--- a/scripts/interactive_setup.py
+++ b/scripts/interactive_setup.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Interactive setup script for AI Scraping Defense.
+
+This helper prompts for key configuration values, writes them to
+`.env`, optionally stores secrets in an SQLite database, and then runs
+`generate_secrets.sh --update-env` to populate generated values.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+
+KEY_SETTINGS = [
+    "MODEL_URI",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "COHERE_API_KEY",
+    "MISTRAL_API_KEY",
+    "EXTERNAL_API_KEY",
+    "NGINX_HTTP_PORT",
+    "NGINX_HTTPS_PORT",
+    "ADMIN_UI_PORT",
+]
+
+
+def parse_env(path: Path) -> dict[str, str]:
+    """Parse simple KEY=VALUE lines from a .env style file."""
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env[key] = value
+    return env
+
+
+def update_env_file(path: Path, values: dict[str, str]) -> None:
+    """Update or append KEY=VALUE lines in an env file."""
+    lines = []
+    seen = set()
+    if path.exists():
+        for line in path.read_text().splitlines():
+            if line.strip() and not line.strip().startswith("#") and "=" in line:
+                key = line.split("=", 1)[0]
+                if key in values:
+                    lines.append(f"{key}={values[key]}\n")
+                    seen.add(key)
+                    continue
+            lines.append(line + "\n")
+    for key, value in values.items():
+        if key not in seen:
+            lines.append(f"{key}={value}\n")
+    path.write_text("".join(lines))
+
+
+def store_secrets(root: Path, env: dict[str, str]) -> None:
+    """Store secrets in an SQLite database under secrets/ if user agrees."""
+    resp = input("Store secrets in local SQLite database? [y/N]: ").strip().lower()
+    if resp != "y":
+        return
+    secrets_dir = root / "secrets"
+    secrets_dir.mkdir(exist_ok=True)
+    db_path = secrets_dir / "local_secrets.db"
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS secrets (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        for key, value in env.items():
+            if any(s in key for s in ("PASSWORD", "API_KEY", "SECRET")):
+                conn.execute(
+                    "REPLACE INTO secrets (key, value) VALUES (?, ?)", (key, value)
+                )
+    print(f"Secrets stored in {db_path}")
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent.parent
+    env_file = root / ".env"
+    sample_file = root / "sample.env"
+
+    if not env_file.exists() and sample_file.exists():
+        env_file.write_text(sample_file.read_text())
+        print("Created .env from sample.env")
+
+    env = parse_env(env_file if env_file.exists() else sample_file)
+
+    print("Configure key settings (leave blank to keep defaults):")
+    updates: dict[str, str] = {}
+    for key in KEY_SETTINGS:
+        default = env.get(key, "")
+        prompt = f"{key} [{default}]: " if default else f"{key}: "
+        val = input(prompt).strip()
+        updates[key] = val if val else default
+
+    env.update(updates)
+    update_env_file(env_file, updates)
+    store_secrets(root, env)
+
+    print("Running generate_secrets.sh --update-env ...")
+    subprocess.run(["bash", "generate_secrets.sh", "--update-env"], cwd=root, check=True)
+    print("Setup complete. Updated .env and generated secrets.")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/interactive_setup.py` for guided creation of `.env`
- document the helper in `README.md` and `docs/getting_started.md`
- note that the helper also runs `generate_secrets.sh --update-env`

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68846bbf1134832183d257b940dab36d