### PR TITLE
Update quick deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ cd ai-scraping-defense
 ./quickstart_dev.sh        # or .\quickstart_dev.ps1 on Windows
 ```
 
-The script copies `sample.env`, generates secrets, installs dependencies, and launches Docker Compose for you.
+The script copies `sample.env`, generates secrets, installs Python requirements using
+`pip install -r requirements.txt -c constraints.txt`, and launches Docker Compose for you.
 
 ## Manual Local Setup
 
@@ -52,10 +53,19 @@ Follow these steps if you prefer to configure everything yourself.
     python scripts/interactive_setup.py
     ```
 
+    The interactive helper can also launch Docker Compose or deploy to
+    Kubernetes when it finishes, if you choose to proceed automatically.
+
     Open `.env` and review the defaults. Set `TENANT_ID` for isolated deployments and add any API keys you plan to use. For **production** deployments update `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443`.
 
 3. **Set Up Python Virtual Environment:**
     Run the setup script to create a virtual environment and install all Python dependencies.
+    After the environment is created, install the project requirements with pinned
+    constraints:
+
+    ```bash
+    pip install -r requirements.txt -c constraints.txt
+    ```
 
     *On Linux or macOS:*
 
@@ -191,13 +201,15 @@ This flexibility makes it easy to experiment with different classifiers.
 
 ## Quick Kubernetes Deployment
 
-Run the helper script to deploy everything to Kubernetes in one step:
+Run the helper script to deploy everything to Kubernetes in one step. Ensure the
+`kubernetes/secrets.yaml` file already exists (generate it with
+`generate_secrets.sh` or the interactive setup):
 
 ```bash
 ./quick_deploy.sh       # or .\quick_deploy.ps1 on Windows
 ```
 
-The script generates secrets and applies all manifests using `kubectl`.
+The script applies all manifests using `kubectl`; it does not generate secrets.
 
 ## Manual Kubernetes Deployment
 

--- a/quick_deploy.ps1
+++ b/quick_deploy.ps1
@@ -11,9 +11,6 @@ if (-not (Test-Path '.env')) {
     Write-Host 'Created .env from sample.env'
 }
 
-# Generate Kubernetes secrets
-& "$PSScriptRoot/Generate-Secrets.ps1"
-
 # Deploy manifests
 & "$PSScriptRoot/deploy.ps1"
 

--- a/quick_deploy.sh
+++ b/quick_deploy.sh
@@ -14,9 +14,6 @@ if [ ! -f .env ]; then
   echo "Created .env from sample.env"
 fi
 
-# Generate Kubernetes secrets
-bash ./generate_secrets.sh
-
 # Deploy to Kubernetes
 bash ./deploy.sh
 

--- a/quickstart_dev.ps1
+++ b/quickstart_dev.ps1
@@ -20,6 +20,9 @@ if (Test-Path "setup_local_dirs.ps1") { & "$PSScriptRoot/setup_local_dirs.ps1" }
 # Reset virtual environment
 & "$PSScriptRoot/reset_venv.ps1"
 
+# Install Python requirements with constraints
+& "$PSScriptRoot/.venv/Scripts/pip.exe" install -r requirements.txt -c constraints.txt
+
 # Run tests
 & "$PSScriptRoot/.venv/Scripts/python.exe" test/run_all_tests.py
 

--- a/quickstart_dev.sh
+++ b/quickstart_dev.sh
@@ -23,6 +23,9 @@ bash ./generate_secrets.sh
 # Reset Python virtual environment (requires sudo for system packages)
 sudo bash ./reset_venv.sh
 
+# Install Python requirements with constraints
+./.venv/bin/pip install -r requirements.txt -c constraints.txt
+
 # Run tests to ensure environment integrity
 ./.venv/bin/python test/run_all_tests.py
 

--- a/scripts/interactive_setup.py
+++ b/scripts/interactive_setup.py
@@ -109,6 +109,14 @@ def main() -> None:
     subprocess.run(["bash", "generate_secrets.sh", "--update-env"], cwd=root, check=True)
     print("Setup complete. Updated .env and generated secrets.")
 
+    resp = input("Launch the local Docker Compose stack now? [y/N]: ").strip().lower()
+    if resp == "y":
+        subprocess.run(["bash", "quickstart_dev.sh"], cwd=root, check=True)
+
+    resp = input("Deploy to Kubernetes using quick_deploy.sh now? [y/N]: ").strip().lower()
+    if resp == "y":
+        subprocess.run(["bash", "quick_deploy.sh"], cwd=root, check=True)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual usage
     main()


### PR DESCRIPTION
## Summary
- remove secret generation step from quick deployment scripts
- allow interactive setup to launch Docker or deploy to Kubernetes
- document the new flow and preexisting secrets requirement

## Testing
- `python3 -m venv .venv`
- `.venv/bin/python -m pip install --upgrade pip setuptools wheel`
- `.venv/bin/pip install -r requirements.txt -c constraints.txt`
- `.venv/bin/python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688482059de48321982c986787c3a4c7