### PR TITLE
Add placeholders for backend host and API key

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -56,6 +56,9 @@ REDIS_HOST=redis
 # Default SMTP host for alerts
 ALERT_SMTP_HOST=mailhog
 
+# Destination for allowed traffic from the proxy
+REAL_BACKEND_HOST=http://localhost:8082
+
 # --- Alert SMTP Configuration ---
 ALERT_SMTP_USE_TLS=false
 ALERT_SMTP_USER=
@@ -160,3 +163,5 @@ ENABLE_PLUGINS=false
 
 # --- Escalation Engine Configuration ---
 ESCALATION_THRESHOLD=0.8
+# API key required to access escalation engine endpoints
+ESCALATION_API_KEY=


### PR DESCRIPTION
## Summary
- add `REAL_BACKEND_HOST` placeholder to `sample.env`
- add `ESCALATION_API_KEY` placeholder to `sample.env`
- ensure `.gitignore` still excludes `.env`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688495c1e6ec832183c17de1e6bd9ee7