### PR TITLE
Ensure quickstart uses sudo on *nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run the automated script after cloning the repository:
 ```bash
 git clone https://github.com/your-username/ai-scraping-defense.git
 cd ai-scraping-defense
-./quickstart_dev.sh        # automatically uses .ps1 on Windows
+sudo ./quickstart_dev.sh   # use sudo on Linux/macOS, automatically uses .ps1 on Windows
 ```
 
 The helper scripts detect your operating system and invoke the PowerShell

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,7 +9,7 @@ Run the helper script after cloning the repository:
 ```bash
 git clone https://github.com/your-username/ai-scraping-defense.git
 cd ai-scraping-defense
-./quickstart_dev.sh       # automatically uses .ps1 on Windows
+sudo ./quickstart_dev.sh  # use sudo on Linux/macOS, automatically uses .ps1 on Windows
 ```
 
 The helper scripts detect your platform and call the PowerShell variants

--- a/quickstart_dev.sh
+++ b/quickstart_dev.sh
@@ -2,6 +2,11 @@
 # Quick setup script for local development
 set -e
 
+# Warn if not running as root on Linux/macOS
+if [ "$(id -u)" -ne 0 ]; then
+  echo "WARNING: It's recommended to run this script with sudo on Linux/macOS" >&2
+fi
+
 # Always operate from the directory where this script resides
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"


### PR DESCRIPTION
## Summary
- document that `quickstart_dev.sh` should be run with `sudo`
- warn in the script if it's not run as root

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688520fa8c008321a0100b47877814e7