### PR TITLE
Ensure quickstart uses sudo on *nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ Run the automated script after cloning the repository:
 ```bash
 git clone https://github.com/your-username/ai-scraping-defense.git
 cd ai-scraping-defense
-./quickstart_dev.sh        # automatically uses .ps1 on Windows
+sudo ./quickstart_dev.sh   # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
 ```
 
-The helper scripts detect your operating system and invoke the PowerShell
-versions when running on Windows.
+On Windows, run `quickstart_dev.ps1` instead.
 
 The script copies `sample.env`, generates secrets, installs Python requirements using
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,11 +9,10 @@ Run the helper script after cloning the repository:
 ```bash
 git clone https://github.com/your-username/ai-scraping-defense.git
 cd ai-scraping-defense
-./quickstart_dev.sh       # automatically uses .ps1 on Windows
+sudo ./quickstart_dev.sh  # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
 ```
 
-The helper scripts detect your platform and call the PowerShell variants
-whenever the setup runs on Windows.
+On Windows, run `quickstart_dev.ps1` instead of the shell script.
 
 The script copies `sample.env`, generates secrets, installs dependencies, and launches Docker Compose.
 
@@ -230,11 +229,10 @@ The `.env` file also contains toggles for several optional integrations:
 To deploy the stack to a Kubernetes cluster in one step run:
 
 ```bash
-./quick_deploy.sh       # automatically uses .ps1 on Windows
+./quick_deploy.sh       # run .\quick_deploy.ps1 on Windows
 ```
 
-Like the local setup script, this command detects Windows and calls the
-PowerShell version when needed.
+On Windows, use `quick_deploy.ps1` instead of the shell script.
 
 This script generates the required secrets and applies all manifests using `kubectl`.
 

--- a/quickstart_dev.sh
+++ b/quickstart_dev.sh
@@ -2,6 +2,11 @@
 # Quick setup script for local development
 set -e
 
+# Warn if not running as root on Linux/macOS
+if [ "$(id -u)" -ne 0 ]; then
+  echo "WARNING: It's recommended to run this script with sudo on Linux/macOS" >&2
+fi
+
 # Always operate from the directory where this script resides
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"


### PR DESCRIPTION
## Summary
- document that `quickstart_dev.sh` should be run with `sudo`
- warn in the script if it's not run as root
- clarify that Windows users must run the PS1 scripts manually

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688520fa8c008321a0100b47877814e7