### PR TITLE
Add admin warnings to PowerShell scripts

### DIFF
--- a/Generate-Secrets.ps1
+++ b/Generate-Secrets.ps1
@@ -1,6 +1,11 @@
 # Generate-Secrets.ps1 (Updated for Kubernetes)
 #
 # Creates a complete Kubernetes secrets manifest for the entire application stack.
+# Warn if not running as Administrator
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 
 $K8sDir = Join-Path $PSScriptRoot "kubernetes"
 if (-not (Test-Path $K8sDir)) { New-Item -ItemType Directory -Path $K8sDir | Out-Null }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd ai-scraping-defense
 sudo ./quickstart_dev.sh   # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
 ```
 
-On Windows, run `quickstart_dev.ps1` instead.
+On Windows, open an **Administrator PowerShell** window and run `quickstart_dev.ps1` instead.
 
 The script copies `sample.env`, generates secrets, installs Python requirements using
 
@@ -226,6 +226,8 @@ Run the helper script to deploy everything to Kubernetes in one step. Ensure the
 ```bash
 ./quick_deploy.sh       # or .\quick_deploy.ps1 on Windows
 ```
+
+If you're on Windows, run `quick_deploy.ps1` from an **Administrator PowerShell** window.
 
 The script applies all manifests using `kubectl`; it does not generate secrets.
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,9 @@
+# Warn if not running as Administrator
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
+
 # Clean up
 docker-compose down
 docker system prune -f

--- a/create_inits.ps1
+++ b/create_inits.ps1
@@ -13,6 +13,10 @@
 .EXAMPLE
     .\create_inits.ps1
 #>
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 
 # Get the current location (your project's root directory)
 $rootPath = (Get-Location).Path

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -6,6 +6,10 @@
     This script applies the manifests in a logical order to ensure dependencies
     like namespaces and secrets are created before the applications that use them.
 #>
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 
 # --- Script Configuration ---
 $ErrorActionPreference = "Stop"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,7 +12,7 @@ cd ai-scraping-defense
 sudo ./quickstart_dev.sh  # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
 ```
 
-On Windows, run `quickstart_dev.ps1` instead of the shell script.
+On Windows, run `quickstart_dev.ps1` from an **Administrator PowerShell** window instead of the shell script.
 
 The script copies `sample.env`, generates secrets, installs dependencies, and launches Docker Compose.
 
@@ -232,7 +232,7 @@ To deploy the stack to a Kubernetes cluster in one step run:
 ./quick_deploy.sh       # run .\quick_deploy.ps1 on Windows
 ```
 
-On Windows, use `quick_deploy.ps1` instead of the shell script.
+On Windows, use `quick_deploy.ps1` from an **Administrator PowerShell** window instead of the shell script.
 
 This script generates the required secrets and applies all manifests using `kubectl`.
 

--- a/quick_deploy.ps1
+++ b/quick_deploy.ps1
@@ -2,6 +2,10 @@
 .SYNOPSIS
     Quickly deploys the stack to Kubernetes.
 #>
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 $ErrorActionPreference = 'Stop'
 Set-Location -Path $PSScriptRoot
 Write-Host '=== AI Scraping Defense: Quick Deploy ===' -ForegroundColor Cyan

--- a/quickstart_dev.ps1
+++ b/quickstart_dev.ps1
@@ -2,6 +2,10 @@
 .SYNOPSIS
     Sets up the development environment with a single command.
 #>
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 $ErrorActionPreference = 'Stop'
 Set-Location -Path $PSScriptRoot
 Write-Host '=== AI Scraping Defense: Development Quickstart ===' -ForegroundColor Cyan

--- a/rename_tests.ps1
+++ b/rename_tests.ps1
@@ -12,6 +12,10 @@
 .EXAMPLE
     .\rename_tests.ps1
 #>
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 
 # Get the path to the 'test' directory relative to the script's location
 $testDirectory = Join-Path -Path $PSScriptRoot -ChildPath "test"

--- a/reset_venv.ps1
+++ b/reset_venv.ps1
@@ -11,6 +11,10 @@
 .EXAMPLE
     .\reset_venv.ps1
 #>
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 
 # --- Self-Elevation Logic ---
 # This block ensures the script runs with Administrator privileges.

--- a/setup_fake_website.ps1
+++ b/setup_fake_website.ps1
@@ -1,5 +1,9 @@
 # Requires Docker Desktop
 param()
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 $ErrorActionPreference = 'Stop'
 Write-Host "=== Launching Fake Website ===" -ForegroundColor Cyan
 

--- a/setup_load_test_suite.ps1
+++ b/setup_load_test_suite.ps1
@@ -1,4 +1,8 @@
 param()
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 $ErrorActionPreference = 'Stop'
 Write-Host '=== Installing load testing tools ===' -ForegroundColor Cyan
 

--- a/setup_local_dirs.ps1
+++ b/setup_local_dirs.ps1
@@ -1,4 +1,8 @@
 param()
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 $ErrorActionPreference = 'Stop'
 Write-Host "Creating necessary local directories for AI Scraping Defense Stack..." -ForegroundColor Cyan
 

--- a/setup_wordpress_website.ps1
+++ b/setup_wordpress_website.ps1
@@ -1,5 +1,9 @@
 # Requires Docker Desktop
 param()
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 $ErrorActionPreference = 'Stop'
 Write-Host "=== Launching WordPress Site ===" -ForegroundColor Cyan
 

--- a/stress_test.ps1
+++ b/stress_test.ps1
@@ -16,6 +16,10 @@ param(
     [int]$VUs = 50,
     [int]$DurationSeconds = 30
 )
+$adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Warning "It's recommended to run this script from an elevated PowerShell session."
+}
 
 $ErrorActionPreference = 'Stop'
 Write-Host '=== AI Scraping Defense: Stress Test ===' -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- warn when PowerShell scripts are run without Administrator privileges
- note Administrator PowerShell usage in README and docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68852a6069748321b5815ffcd584e741