### PR TITLE
Remove duplicate function from updater

### DIFF
--- a/src/util/corpus_wikipedia_updater.py
+++ b/src/util/corpus_wikipedia_updater.py
@@ -163,13 +163,5 @@ def main():
     logger.info("--- Wikipedia Corpus Updater Finished ---")
 
 
-def main():
-    """Main execution function."""
-    logger.info("--- Wikipedia Corpus Updater Started ---")
-    articles = fetch_random_wikipedia_articles(NUM_ARTICLES_TO_FETCH)
-    update_corpus_file(articles)
-    logger.info("--- Wikipedia Corpus Updater Finished ---")
-
-
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- clean up `corpus_wikipedia_updater.py` by removing a duplicate `main()`

## Testing
- `python3 -m py_compile src/util/corpus_wikipedia_updater.py`

------
https://chatgpt.com/codex/tasks/task_e_6885340c577883219ed7b0d9a3a3152d