### PR TITLE
Add cloud provider deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ The script applies all manifests using `kubectl`; it does not generate secrets.
 
 For a detailed, step-by-step guide see [docs/kubernetes_deployment.md](docs/kubernetes_deployment.md). The `deploy.sh` and `deploy.ps1` scripts provide a manual approach if you need more control.
 
+## Cloud Deployment (GKE Example)
+
+To deploy the stack to a managed Kubernetes service such as Google Kubernetes Engine, follow the instructions in [docs/cloud_provider_deployment.md](docs/cloud_provider_deployment.md). Convenience scripts are provided for automation:
+
+```bash
+./gke_deploy.sh       # or .\gke_deploy.ps1 on Windows
+```
+
+
 ## Load Testing Helpers
 
 To experiment with the stack's performance under load, run the helper script:

--- a/docs/cloud_provider_deployment.md
+++ b/docs/cloud_provider_deployment.md
@@ -1,0 +1,85 @@
+# Cloud Provider Deployment (GKE Example)
+
+This guide explains how to deploy the AI Scraping Defense stack to **Google Kubernetes Engine (GKE)**. The process is similar for other managed Kubernetes services such as Amazon EKS or Azure AKS.
+
+## Prerequisites
+
+- A Google Cloud project with billing enabled.
+- The [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) with `gcloud` and `kubectl` available in your path.
+- Docker configured to push images to Google Container Registry (GCR).
+- A copy of this repository cloned locally.
+
+## Manual Deployment Steps
+
+1. **Build and Push the Docker Image**
+
+   ```bash
+   export PROJECT_ID="your-gcp-project"
+   export IMAGE="gcr.io/$PROJECT_ID/ai-scraping-defense:latest"
+
+   # Authenticate with Google Cloud and build the image
+   gcloud auth configure-docker
+   docker build -t "$IMAGE" .
+   docker push "$IMAGE"
+   ```
+
+2. **Create or Reuse a GKE Cluster**
+
+   ```bash
+   export CLUSTER_NAME="ai-defense-cluster"
+   export GKE_ZONE="us-central1-a"
+
+   gcloud container clusters create "$CLUSTER_NAME" \
+       --zone "$GKE_ZONE" --num-nodes 3
+   gcloud container clusters get-credentials "$CLUSTER_NAME" --zone "$GKE_ZONE"
+   ```
+
+3. **Generate Kubernetes Secrets**
+
+   Run the provided script to create `kubernetes/secrets.yaml`:
+
+   ```bash
+   ./generate_secrets.sh
+   ```
+
+   Replace the placeholder API keys in `kubernetes/secrets.yaml` with your actual base64‑encoded credentials before applying.
+
+4. **Update Image References**
+
+   Search the manifests under `kubernetes/` for the `image:` field and replace the default placeholder with your `$IMAGE` path.
+
+5. **Deploy the Manifests**
+
+   Apply the Kubernetes resources using the helper script:
+
+   ```bash
+   ./deploy.sh
+   ```
+
+6. **Verify the Deployment**
+
+   ```bash
+   kubectl get pods -n ai-defense
+   kubectl get svc -n ai-defense
+   ```
+
+   Once the pods are running, access the service using the external IP of the `nginx-proxy` service.
+
+## Automated Deployment
+
+For convenience, scripts are provided to automate these steps:
+
+- `gke_deploy.sh` &ndash; Bash script for Linux/macOS
+- `gke_deploy.ps1` &ndash; PowerShell script for Windows
+
+The scripts build and push the image, create the cluster if it does not already exist, and then invoke `deploy.sh` / `deploy.ps1` to apply the manifests.
+
+```bash
+./gke_deploy.sh
+```
+
+```powershell
+./gke_deploy.ps1
+```
+
+Customize environment variables such as `PROJECT_ID`, `CLUSTER_NAME`, and `GKE_ZONE` before running the scripts to suit your Google Cloud environment.

--- a/gke_deploy.ps1
+++ b/gke_deploy.ps1
@@ -1,0 +1,44 @@
+param(
+    [string]$ProjectId = $env:GOOGLE_PROJECT_ID,
+    [string]$ClusterName = $env:CLUSTER_NAME,
+    [string]$Zone = $env:GKE_ZONE,
+    [string]$ImageTag = 'latest'
+)
+
+if (-not $ProjectId) { $ProjectId = Read-Host 'GCP Project ID' }
+if (-not $ClusterName) { $ClusterName = 'ai-defense-cluster' }
+if (-not $Zone) { $Zone = 'us-central1-a' }
+
+$Image = "gcr.io/$ProjectId/ai-scraping-defense:$ImageTag"
+
+Write-Host "Building Docker image $Image"
+& gcloud auth configure-docker --quiet
+
+docker build -t $Image .
+docker push $Image
+
+# Create cluster if it does not exist
+& gcloud container clusters describe $ClusterName --zone $Zone 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Creating GKE cluster $ClusterName"
+    gcloud container clusters create $ClusterName --zone $Zone --num-nodes 3
+}
+
+# Configure kubectl
+ gcloud container clusters get-credentials $ClusterName --zone $Zone
+
+# Update image references in manifests
+Get-ChildItem -Path kubernetes -Filter '*.yaml' -Recurse | ForEach-Object {
+    (Get-Content $_.FullName) -replace 'your-registry/ai-scraping-defense:latest', $Image | Set-Content $_.FullName
+}
+
+# Generate secrets if needed
+if (-not (Test-Path 'kubernetes/secrets.yaml')) {
+    Write-Host 'Generating secrets file'
+    ./Generate-Secrets.ps1
+}
+
+# Deploy manifests
+./deploy.ps1
+
+Write-Host 'Deployment complete. View pods with: kubectl get pods -n ai-defense'

--- a/gke_deploy.sh
+++ b/gke_deploy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Deploy the AI Scraping Defense stack to Google Kubernetes Engine
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-${GOOGLE_PROJECT_ID:-your-gcp-project}}"
+CLUSTER_NAME="${CLUSTER_NAME:-ai-defense-cluster}"
+GKE_ZONE="${GKE_ZONE:-us-central1-a}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+IMAGE="gcr.io/$PROJECT_ID/ai-scraping-defense:$IMAGE_TAG"
+
+# Build and push the Docker image
+echo "Building Docker image $IMAGE"
+gcloud auth configure-docker --quiet
+
+docker build -t "$IMAGE" .
+docker push "$IMAGE"
+
+# Create the cluster if it does not exist
+if ! gcloud container clusters describe "$CLUSTER_NAME" --zone "$GKE_ZONE" >/dev/null 2>&1; then
+  echo "Creating GKE cluster $CLUSTER_NAME"
+  gcloud container clusters create "$CLUSTER_NAME" \
+    --zone "$GKE_ZONE" --num-nodes 3
+fi
+
+# Configure kubectl
+ gcloud container clusters get-credentials "$CLUSTER_NAME" --zone "$GKE_ZONE"
+
+# Update image references in manifests
+find kubernetes -name '*.yaml' -print0 | xargs -0 sed -i "s|your-registry/ai-scraping-defense:latest|$IMAGE|g"
+
+# Generate secrets if missing
+if [ ! -f kubernetes/secrets.yaml ]; then
+  echo "Generating secrets file"
+  bash ./generate_secrets.sh
+fi
+
+# Deploy the manifests
+bash ./deploy.sh
+
+echo "Deployment complete. View pods with: kubectl get pods -n ai-defense"


### PR DESCRIPTION
## Summary
- provide instructions for deploying to Google Kubernetes Engine
- add helper scripts for automatic GKE deployment
- reference new documentation from README

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688536d8ae488321bb30b8c0a93d0c93