### PR TITLE
Add export option to secrets scripts

### DIFF
--- a/Generate-Secrets.ps1
+++ b/Generate-Secrets.ps1
@@ -1,6 +1,11 @@
 # Generate-Secrets.ps1 (Updated for Kubernetes)
 #
 # Creates a complete Kubernetes secrets manifest for the entire application stack.
+# Optional arguments
+param(
+    [string]$ExportPath
+)
+
 # Warn if not running as Administrator
 $adminCheck = [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
 if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
@@ -140,6 +145,28 @@ data:
 "@
 
 Set-Content -Path $OutputFile -Value $yamlContent -Encoding UTF8
+
+if ($ExportPath) {
+    $creds = [ordered]@{
+        ADMIN_UI_USERNAME = $adminUiUsername
+        ADMIN_UI_PASSWORD = $adminUiPassword
+        NGINX_PASSWORD = $nginxPassword
+        POSTGRES_PASSWORD = $postgresPassword
+        REDIS_PASSWORD = $redisPassword
+        SYSTEM_SEED = $systemSeed
+        OPENAI_API_KEY = $openaiApiKey
+        ANTHROPIC_API_KEY = $anthropicApiKey
+        GOOGLE_API_KEY = $googleApiKey
+        COHERE_API_KEY = $cohereApiKey
+        MISTRAL_API_KEY = $mistralApiKey
+        EXTERNAL_API_KEY = $externalApiKey
+        IP_REPUTATION_API_KEY = $ipReputationApiKey
+        COMMUNITY_BLOCKLIST_API_KEY = $communityBlocklistApiKey
+    }
+    $creds | ConvertTo-Json -Depth 1 | Set-Content -Path $ExportPath -Encoding UTF8
+    try { chmod 600 $ExportPath 2>$null } catch {}
+    Write-Host "Credentials exported to: $ExportPath" -ForegroundColor Green
+}
 
 # Output credentials
 Write-Host "Successfully created Kubernetes secrets file at: $OutputFile" -ForegroundColor Green

--- a/README.md
+++ b/README.md
@@ -104,12 +104,16 @@ Follow these steps if you prefer to configure everything yourself.
 
     ```bash
     bash ./generate_secrets.sh
+    # export credentials to a JSON file
+    bash ./generate_secrets.sh --export-path my_secrets.json
     ```
 
     *On Windows:*
 
     ```powershell
     .\Generate-Secrets.ps1
+    # save credentials to a JSON file
+    .\Generate-Secrets.ps1 -ExportPath my_secrets.json
     ```
 
 5. **Enable HTTPS (Optional):**

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,12 +102,16 @@ The application requires several secrets to run (e.g., database passwords). A sc
   ./generate_secrets.sh
   # optionally update your .env automatically
   ./generate_secrets.sh --update-env
+  # save credentials to a JSON file
+  ./generate_secrets.sh --export-path my_secrets.json
 ```
 
 * **On Windows (in a PowerShell terminal):**
 
 ``` PowerShell
   .\Generate-Secrets.ps1
+  # export credentials to JSON
+  .\Generate-Secrets.ps1 -ExportPath my_secrets.json
 ```
 
 When run from the interactive helper, the correct script is chosen

--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -14,10 +14,19 @@ generate_password() {
 }
 
 update_env=false
-for arg in "$@"; do
-  case "$arg" in
+export_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --update-env)
       update_env=true
+      shift
+      ;;
+    --export-path)
+      export_path="$2"
+      shift 2
+      ;;
+    *)
       shift
       ;;
   esac
@@ -116,6 +125,29 @@ data:
   IP_REPUTATION_API_KEY: $(echo -n "$IP_REPUTATION_API_KEY" | base64 | tr -d '\n')
   COMMUNITY_BLOCKLIST_API_KEY: $(echo -n "$COMMUNITY_BLOCKLIST_API_KEY" | base64 | tr -d '\n')
 EOL
+
+if [ -n "$export_path" ]; then
+  cat > "$export_path" << EOF
+{
+  "ADMIN_UI_USERNAME": "$ADMIN_UI_USERNAME",
+  "ADMIN_UI_PASSWORD": "$ADMIN_UI_PASSWORD",
+  "NGINX_PASSWORD": "$NGINX_PASSWORD",
+  "POSTGRES_PASSWORD": "$POSTGRES_PASSWORD",
+  "REDIS_PASSWORD": "$REDIS_PASSWORD",
+  "SYSTEM_SEED": "$SYSTEM_SEED",
+  "OPENAI_API_KEY": "$OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY": "$ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY": "$GOOGLE_API_KEY",
+  "COHERE_API_KEY": "$COHERE_API_KEY",
+  "MISTRAL_API_KEY": "$MISTRAL_API_KEY",
+  "EXTERNAL_API_KEY": "$EXTERNAL_API_KEY",
+  "IP_REPUTATION_API_KEY": "$IP_REPUTATION_API_KEY",
+  "COMMUNITY_BLOCKLIST_API_KEY": "$COMMUNITY_BLOCKLIST_API_KEY"
+}
+EOF
+  chmod 600 "$export_path"
+  echo -e "${GREEN}Credentials exported to: ${export_path}${NC}"
+fi
 
 # Output credentials
 echo -e "\nSuccessfully created Kubernetes secrets file at: ${GREEN}${OUTPUT_FILE}${NC}"


### PR DESCRIPTION
## Summary
- support `--export-path` in `generate_secrets.sh`
- support `-ExportPath` in `Generate-Secrets.ps1`
- update README and getting started docs with new flag

## Testing
- `python test/run_all_tests.py -h`

------
https://chatgpt.com/codex/tasks/task_e_68854ffe83048321a1b7e6d45e301d33