### PR TITLE
Add Rust tests and update CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Install Rust toolchain
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+          source "$HOME/.cargo/env"
+          rustup default nightly
+      - name: Run Rust tests
+        run: |
+          source "$HOME/.cargo/env"
+          rustup run nightly cargo test --manifest-path jszip-rs/Cargo.toml --quiet
+          rustup run nightly cargo test --manifest-path markov-train-rs/Cargo.toml --quiet
       - name: Run test suite
         run: python test/run_all_tests.py
       - name: Upload coverage

--- a/jszip-rs/src/lib.rs
+++ b/jszip-rs/src/lib.rs
@@ -15,7 +15,7 @@ const FILENAME_PREFIXES: [&str; 12] = [
 const FILENAME_SUFFIXES: [&str; 6] = ["_min", "_pack", "_bundle", "_lib", "_core", ""];
 const FILENAME_EXT: &str = ".js";
 
-fn rand_string(len: usize) -> String {
+pub fn rand_string(len: usize) -> String {
     rand::thread_rng()
         .sample_iter(&Alphanumeric)
         .take(len)
@@ -24,7 +24,7 @@ fn rand_string(len: usize) -> String {
 }
 
 #[pyfunction]
-fn generate_realistic_filename() -> PyResult<String> {
+pub fn generate_realistic_filename() -> PyResult<String> {
     let mut rng = rand::thread_rng();
     let prefix = FILENAME_PREFIXES[rng.gen_range(0..FILENAME_PREFIXES.len())];
     let suffix = FILENAME_SUFFIXES[rng.gen_range(0..FILENAME_SUFFIXES.len())];
@@ -32,7 +32,7 @@ fn generate_realistic_filename() -> PyResult<String> {
     Ok(format!("{}{}{}.{}", prefix, suffix, random_hash, "js"))
 }
 
-fn generate_file_content(name: &str, target_size: usize) -> Vec<u8> {
+pub fn generate_file_content(name: &str, target_size: usize) -> Vec<u8> {
     let mut rng = rand::thread_rng();
     let mut content = format!("// Fake module: {}\n(function() {{\n", name);
     let vars = rng.gen_range(5..20);
@@ -52,7 +52,7 @@ fn generate_file_content(name: &str, target_size: usize) -> Vec<u8> {
 }
 
 #[pyfunction(signature = (num_files, output_dir = None))]
-fn create_fake_js_zip(num_files: usize, output_dir: Option<String>) -> PyResult<Option<String>> {
+pub fn create_fake_js_zip(num_files: usize, output_dir: Option<String>) -> PyResult<Option<String>> {
     let out_dir = output_dir.unwrap_or_else(|| DEFAULT_ARCHIVE_DIR.to_string());
     fs::create_dir_all(&out_dir).map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(format!("Failed to create dir: {}", e)))?;
     let timestamp = Utc::now().format("%Y%m%d_%H%M%S");

--- a/jszip-rs/tests/integration.rs
+++ b/jszip-rs/tests/integration.rs
@@ -1,0 +1,27 @@
+use jszip_rs::{generate_realistic_filename, create_fake_js_zip, rand_string, generate_file_content};
+use std::path::PathBuf;
+
+#[test]
+fn random_string_length() {
+    let s = rand_string(10);
+    assert_eq!(s.len(), 10);
+}
+
+#[test]
+fn content_at_least_size() {
+    let data = generate_file_content("test", 64);
+    assert!(data.len() >= 64);
+}
+
+#[test]
+fn filename_has_js_extension() {
+    let name = generate_realistic_filename().unwrap();
+    assert!(name.ends_with(".js"));
+}
+
+#[test]
+fn zip_file_created() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = create_fake_js_zip(1, Some(dir.path().to_string_lossy().to_string())).unwrap().unwrap();
+    assert!(PathBuf::from(&path).exists());
+}

--- a/markov-train-rs/Cargo.toml
+++ b/markov-train-rs/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.78"
 
 [lib]
 name = "markov_train_rs"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.24.2", features = ["extension-module"] }

--- a/markov-train-rs/src/lib.rs
+++ b/markov-train-rs/src/lib.rs
@@ -25,7 +25,7 @@ fn connect_db() -> Result<Client, postgres::Error> {
     Client::connect(&conn_str, NoTls)
 }
 
-fn tokenize_text(text: &str, re1: &Regex, re2: &Regex, re3: &Regex) -> Vec<String> {
+pub fn tokenize_text(text: &str, re1: &Regex, re2: &Regex, re3: &Regex) -> Vec<String> {
     let mut s = re1.replace_all(text, "").to_lowercase();
     s = re2.replace_all(&s, "").to_string();
     s.split_whitespace()

--- a/markov-train-rs/tests/tokenize.rs
+++ b/markov-train-rs/tests/tokenize.rs
@@ -1,0 +1,20 @@
+use markov_train_rs::tokenize_text;
+use regex::Regex;
+
+#[test]
+fn tokenize_basic_sentence() {
+    let re1 = Regex::new(r"[-']").unwrap();
+    let re2 = Regex::new(r"[^\w\s'-]").unwrap();
+    let re3 = Regex::new(r"^[-']+|[-']+$").unwrap();
+    let tokens = tokenize_text("Hello, world! It's 2024.", &re1, &re2, &re3);
+    assert_eq!(tokens, vec!["hello", "world", "its", "2024"]);
+}
+
+#[test]
+fn tokenize_handles_empty() {
+    let re1 = Regex::new(r"[-']").unwrap();
+    let re2 = Regex::new(r"[^\w\s'-]").unwrap();
+    let re3 = Regex::new(r"^[-']+|[-']+$").unwrap();
+    let tokens = tokenize_text("?!", &re1, &re2, &re3);
+    assert!(tokens.is_empty());
+}


### PR DESCRIPTION
## Summary
- add integration test suites for `markov-train-rs` and `jszip-rs`
- expose functions in Rust crates for testing
- update CI workflow to run Rust tests alongside Python suite

## Testing
- `rustup run nightly cargo test --manifest-path jszip-rs/Cargo.toml --quiet`
- `rustup run nightly cargo test --manifest-path markov-train-rs/Cargo.toml --quiet`
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68855dc8aa0c83219f1c3485c73473c1