### PR TITLE
Add env validator script and integrate in setup

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -73,6 +73,14 @@ To bring the stack up, only a handful of settings must be reviewed in `.env`:
 
 The `[scripts/interactive_setup.py](../scripts/interactive_setup.py)` helper referenced above will prompt for these values and update `.env` automatically.
 
+You can verify the file at any time using the validator:
+
+```bash
+python scripts/validate_env.py
+```
+
+The quickstart setup scripts call this command for you.
+
 ### **3. Set Up the Python Virtual Environment**
 
 To keep your project's Python dependencies isolated, we use a virtual environment. A setup script is provided to automate this process.

--- a/quickstart_dev.ps1
+++ b/quickstart_dev.ps1
@@ -27,6 +27,9 @@ if (Test-Path "setup_local_dirs.ps1") { & "$PSScriptRoot/setup_local_dirs.ps1" }
 # Install Python requirements with constraints
 & "$PSScriptRoot/.venv/Scripts/pip.exe" install -r requirements.txt -c constraints.txt
 
+# Validate .env configuration
+& "$PSScriptRoot/.venv/Scripts/python.exe" scripts/validate_env.py
+
 # Run tests
 & "$PSScriptRoot/.venv/Scripts/python.exe" test/run_all_tests.py
 

--- a/quickstart_dev.sh
+++ b/quickstart_dev.sh
@@ -31,6 +31,9 @@ sudo bash ./reset_venv.sh
 # Install Python requirements with constraints
 ./.venv/bin/pip install -r requirements.txt -c constraints.txt
 
+# Validate .env configuration
+./.venv/bin/python scripts/validate_env.py
+
 # Run tests to ensure environment integrity
 ./.venv/bin/python test/run_all_tests.py
 

--- a/scripts/validate_env.py
+++ b/scripts/validate_env.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate required settings in the .env file."""
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+
+def parse_env(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env[key] = value
+    return env
+
+
+REQUIRED_KEYS = [
+    "MODEL_URI",
+    "NGINX_HTTP_PORT",
+    "NGINX_HTTPS_PORT",
+    "ADMIN_UI_PORT",
+    "REAL_BACKEND_HOST",
+]
+
+PROVIDER_KEYS = {
+    "openai://": "OPENAI_API_KEY",
+    "mistral://": "MISTRAL_API_KEY",
+    "anthropic://": "ANTHROPIC_API_KEY",
+    "google://": "GOOGLE_API_KEY",
+    "cohere://": "COHERE_API_KEY",
+}
+
+
+def validate_env(env: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+
+    for key in REQUIRED_KEYS:
+        if not env.get(key):
+            errors.append(f"{key} is missing or empty")
+
+    model_uri = env.get("MODEL_URI", "")
+    for prefix, key in PROVIDER_KEYS.items():
+        if model_uri.startswith(prefix) and not env.get(key):
+            errors.append(f"{key} required for MODEL_URI {model_uri}")
+
+    for key in ("NGINX_HTTP_PORT", "NGINX_HTTPS_PORT", "ADMIN_UI_PORT"):
+        value = env.get(key)
+        try:
+            port = int(value)
+            if not 1 <= port <= 65535:
+                raise ValueError
+        except Exception:
+            errors.append(f"{key} has invalid port value: {value}")
+
+    if not env.get("REAL_BACKEND_HOST"):
+        errors.append("REAL_BACKEND_HOST is missing or empty")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate .env configuration")
+    parser.add_argument(
+        "env_path",
+        nargs="?",
+        default=".env",
+        help="Path to the env file (default: .env)",
+    )
+    args = parser.parse_args()
+    env_file = Path(args.env_path)
+
+    env = parse_env(env_file)
+    errors = validate_env(env)
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}")
+        return 1
+
+    print("Environment looks valid.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    raise SystemExit(main())

--- a/test/scripts/test_validate_env.py
+++ b/test/scripts/test_validate_env.py
@@ -1,0 +1,48 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import validate_env
+
+
+class TestValidateEnv(unittest.TestCase):
+    def test_valid_env(self):
+        content = """MODEL_URI=sklearn:///model
+NGINX_HTTP_PORT=8080
+NGINX_HTTPS_PORT=8443
+ADMIN_UI_PORT=5002
+REAL_BACKEND_HOST=http://localhost
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".env"
+            path.write_text(content)
+            env = validate_env.parse_env(path)
+            errors = validate_env.validate_env(env)
+            self.assertEqual(errors, [])
+
+    def test_missing_required(self):
+        content = "MODEL_URI=sklearn:///model"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".env"
+            path.write_text(content)
+            env = validate_env.parse_env(path)
+            errors = validate_env.validate_env(env)
+            self.assertTrue(any("NGINX_HTTP_PORT" in e for e in errors))
+
+    def test_model_specific_key(self):
+        content = """MODEL_URI=openai://gpt-4
+NGINX_HTTP_PORT=8080
+NGINX_HTTPS_PORT=8443
+ADMIN_UI_PORT=5002
+REAL_BACKEND_HOST=http://localhost
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".env"
+            path.write_text(content)
+            env = validate_env.parse_env(path)
+            errors = validate_env.validate_env(env)
+            self.assertTrue(any("OPENAI_API_KEY" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `scripts/validate_env.py` to verify `.env` values
- run validator in `quickstart_dev.sh` and PowerShell equivalent
- document validator usage in getting started guide
- add unit tests for validator

## Testing
- `python3 -m pip install -q -r requirements.txt -c constraints.txt`
- `python3 test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68856c164218832196aec4caa94cd238