### PR TITLE
Add pre-commit hooks and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,15 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Install dependencies from the main requirements file
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          # Optionally install dependencies for individual services if they exist
-          # Example: if [ -f tarpit/requirements.txt ]; then pip install -r tarpit/requirements.txt; fi
-          # Example: if [ -f admin_ui/requirements.txt ]; then pip install -r admin_ui/requirements.txt; fi
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # Install dependencies from the main requirements file
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install pre-commit
+        # Optionally install dependencies for individual services if they exist
+        # Example: if [ -f tarpit/requirements.txt ]; then pip install -r tarpit/requirements.txt; fi
+        # Example: if [ -f admin_ui/requirements.txt ]; then pip install -r admin_ui/requirements.txt; fi
 
-      - name: Lint with flake8
-        run: |
-          pip install flake8
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run pre-commit
+      run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        language_version: python3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,12 +27,13 @@ We welcome meaningful contributions, including but not limited to:
 
 1. **Find an Issue or Propose an Idea:** Look through existing issues or propose a new feature/improvement in the Issues tab or Discussions.
 2. **Fork the Repository:** Create your own copy of the project.
-3. **Create a Feature Branch:** `git checkout -b feature/your-new-feature`
-4. **Make Your Changes:** Implement your feature or bug fix. Ensure code is linted and follows project style (if defined).
-5. **Test Your Changes:** Run existing tests or add new ones as appropriate. Test the functionality locally using Docker Compose.
-6. **Commit Your Changes:** Use clear and descriptive commit messages: `git commit -am 'feat: Add advanced header analysis heuristic'`
-7. **Push to Your Fork:** `git push origin feature/your-new-feature`
-8. **Submit a Pull Request:** Open a PR against the `main` branch of the original repository. Fill out the PR template clearly.
+3. **Install pre-commit Hooks:** After cloning, run `pre-commit install` so style checks run automatically.
+4. **Create a Feature Branch:** `git checkout -b feature/your-new-feature`
+5. **Make Your Changes:** Implement your feature or bug fix. Ensure code is linted and follows project style (if defined).
+6. **Test Your Changes:** Run existing tests or add new ones as appropriate. Test the functionality locally using Docker Compose.
+7. **Commit Your Changes:** Use clear and descriptive commit messages: `git commit -am 'feat: Add advanced header analysis heuristic'`
+8. **Push to Your Fork:** `git push origin feature/your-new-feature`
+9. **Submit a Pull Request:** Open a PR against the `main` branch of the original repository. Fill out the PR template clearly.
 
 ## Code Style (Example)
 


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with black, isort and flake8
- mention running `pre-commit install` in contributing guide
- run `pre-commit` in CI instead of raw flake8

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md .github/workflows/ci.yml`
- `python -m pip install -r requirements.txt`
- `python test/run_all_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68857d5f0898832197976332762deeb4