### PR TITLE
Document security_scan usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,3 +349,7 @@ After installing the tools, you can run a basic stress test using the provided s
 ```bash
 ./stress_test.sh http://your-linux-host:8080
 ```
+
+## Security Scan Helper
+
+The optional script `security_scan.sh` automates tools such as **Nmap**, **Nikto**, and **Trivy** to perform vulnerability checks. Install these dependencies and run the script with `sudo` so network scans can complete. See [docs/security_scan.md](docs/security_scan.md) for more details. **Use this script only on systems you own or have permission to test.**

--- a/docs/security_scan.md
+++ b/docs/security_scan.md
@@ -1,0 +1,11 @@
+# Security Scan Helper
+
+`security_scan.sh` runs a collection of open-source tools to audit a target for common weaknesses. It invokes scanners such as **Nmap**, **Nikto**, **OWASP ZAP**, and **Trivy** alongside optional checks like **SQLMap** and **Bandit**.
+
+## Prerequisites
+- Linux environment with the required utilities installed (e.g. `nmap`, `nikto`, `zaproxy`, `trivy`, `sqlmap`, `masscan`, `bandit`, etc.)
+- Many scans need elevated privileges; run the script with `sudo`.
+- Optionally install Docker if container images will be scanned.
+
+## Legal Considerations
+Only run the script against systems you own or have explicit permission to test. Unauthorized scanning can be illegal and may violate service agreements. Always consult local laws and organizational policies before performing any security tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Architecture: docs/architecture.md
     - Key Data Flows: docs/key_data_flows.md
     - API Reference: docs/model_adapter_guide.md
+    - Security Scan Helper: docs/security_scan.md
   - Microservices:
     - Tarpit Service: tarpit/README.md
     # Add READMEs for other services (escalation, admin_ui) here if they exist


### PR DESCRIPTION
## Summary
- add docs/security_scan.md with prerequisites and legal notes
- link the new page from README and mkdocs navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688580d968d08321a9dc159d9dac3b9f