### PR TITLE
Add Traefik load balancer

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -299,12 +299,33 @@ services:
     depends_on:
       - nginx_proxy
 
+  traefik:
+    image: traefik:v2.11
+    container_name: traefik
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - --api.insecure=true
+    ports:
+      - "8005:80"
+      - "8081:8080"
+    networks:
+      - defense_network
+    restart: unless-stopped
+
   llama3:
     image: ollama/ollama:latest
     container_name: llama3
     command: ["sh", "-c", "ollama pull llama3 && ollama serve"]
     ports:
       - "11434:11434"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.llm.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.llm.entrypoints=web"
+      - "traefik.http.services.llm.loadbalancer.server.port=11434"
+      - "traefik.http.services.llm.loadbalancer.weight=2"
     volumes:
       - ./models/shared-data:/root/.ollama
     healthcheck:
@@ -322,6 +343,12 @@ services:
     command: ["sh", "-c", "ollama pull mixtral && ollama serve"]
     ports:
       - "11435:11434"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.llm.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.llm.entrypoints=web"
+      - "traefik.http.services.llm.loadbalancer.server.port=11434"
+      - "traefik.http.services.llm.loadbalancer.weight=1"
     volumes:
       - ./models/shared-data:/root/.ollama
     healthcheck:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,7 @@ The AI Scraping Defense system is designed as a distributed, microservice-based 
 ## Core Components
 
 - **Nginx Proxy:** The public-facing entry point for all traffic. It uses Lua scripting for high-performance initial request filtering, such as checking against a blocklist in Redis. Suspicious requests are asynchronously forwarded to the AI Service for deeper analysis.
+- **Traefik Router:** Provides internal load balancing for the optional local LLM containers. The Docker provider automatically discovers containers with Traefik labels, and the `llama3` and `mixtral` services assign routing rules and weights to distribute traffic.
 
 - **Python Services:** A collection of specialized microservices that form the "brain" of the system. All Python services are built from a single, unified `Dockerfile` to ensure consistency and reduce build times.
 


### PR DESCRIPTION
## Summary
- include Traefik service in `docker-compose.yml`
- configure LLM containers with Traefik routing labels
- document Traefik under Core Components

## Testing
- `pre-commit run --files docker-compose.yaml docs/architecture.md`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68858ecab1e48321849560a2b6f6d6fc