### PR TITLE
Add tenant-aware configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,19 @@ Several integrations are disabled by default to keep the stack lightweight. You 
 - `Dockerfile`: A single Dockerfile used to build the base image for all Python services.
 - `jszip-rs/`: Rust implementation of the fake JavaScript archive generator.
 - `markov-train-rs/`: Rust implementation of the Markov training utility.
+
+### Running Multiple Tenants
+
+Create an `.env` file per tenant with a unique `TENANT_ID` and port mappings.
+Launch each stack with a distinct project name so Docker Compose keeps the
+services isolated:
+
+```bash
+docker compose --env-file .env.siteA -p siteA up -d
+docker compose --env-file .env.siteB -p siteB up -d
+```
+
+Redis keys and SQLite records are automatically prefixed with the tenant ID.
 ## Configuring AI Models
 
 The detection services load a model specified by the `MODEL_URI` value in `.env`. Examples include a local scikit-learn file or an external API:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -265,3 +265,18 @@ This script generates the required secrets and applies all manifests using `kube
 ## **Manual Kubernetes Deployment**
 
 For a detailed walkthrough see [kubernetes_deployment.md](kubernetes_deployment.md). The `deploy.sh` and `deploy.ps1` scripts allow you to apply the manifests manually when you need more control over the process.
+
+## **Running Multiple Tenants**
+
+You can launch several isolated environments on the same host by creating a
+separate `.env` file for each tenant and specifying a unique `TENANT_ID` along
+with non-conflicting service ports. Bring up each stack using the `-p` flag to
+set a project name:
+
+```bash
+docker compose --env-file .env.tenant1 -p tenant1 up -d
+docker compose --env-file .env.tenant2 -p tenant2 up -d
+```
+
+Redis keys and SQLite records are namespaced automatically. Review the exposed
+ports in each `.env` so the Admin UI and other services do not collide.


### PR DESCRIPTION
## Summary
- support tenant-aware `get_config` and `tenant_key`
- store tenant ID in decisions database
- update unit tests for new schema
- document running multiple tenants side-by-side

## Testing
- `python -m test.run_all_tests`

------
https://chatgpt.com/codex/tasks/task_e_68859f3b6a308321b591e9f2177288b1