### PR TITLE
docs: describe monitoring and router ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,18 @@ MODEL_URI=mistral://mistral-large-latest
 
 For remote providers, set the corresponding API key in `.env` (`OPENAI_API_KEY`, `MISTRAL_API_KEY`, etc.).
 
-All LLM requests from the Escalation Engine are sent to the **Prompt Router**. The router constructs the final target URL from `PROMPT_ROUTER_HOST` and `PROMPT_ROUTER_PORT` and decides whether to use a local model or forward the prompt to the cloud proxy.
+All LLM requests from the Escalation Engine are sent to the **Prompt Router**. The
+router constructs the final target URL from `PROMPT_ROUTER_HOST` and
+`PROMPT_ROUTER_PORT` and decides whether to use a local model or forward the
+prompt to the cloud proxy. The default port values are shown in
+`sample.env`:
+
+```env
+# excerpt from sample.env
+PROMPT_ROUTER_PORT=8009
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+```
 
 ## Model Adapter Guide
 
@@ -373,9 +384,19 @@ The optional script `security_scan.sh` automates tools such as **Nmap**, **Nikto
 
 ## Monitoring Stack
 
-Docker Compose includes a small Prometheus and Grafana setup. Prometheus scrapes the Python services every 15 seconds using `monitoring/prometheus.yml`, and Grafana exposes dashboards on `${GRAFANA_PORT:-3000}`.
+Docker Compose includes a small Prometheus and Grafana setup. Prometheus scrapes
+the Python services every 15 seconds using `monitoring/prometheus.yml`, and
+Grafana exposes dashboards on `${GRAFANA_PORT:-3000}`.
+
+```env
+# excerpt from sample.env
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+```
 
 - **Prometheus UI:** [http://localhost:${PROMETHEUS_PORT:-9090}](http://localhost:9090) shows raw metrics and scrape targets.
 - **Grafana UI:** [http://localhost:${GRAFANA_PORT:-3000}](http://localhost:3000) (default login `admin` / `admin`). You can import a dashboard from Grafana's library or create your own to monitor request rates and response times.
 
-The stack also runs a `watchtower` container that checks for image updates every minute and restarts services automatically. Remove or comment out the `watchtower` section in `docker-compose.yaml` if you prefer manual updates.
+The stack also runs a `watchtower` container that checks for image updates every
+minute and restarts services automatically. Remove or comment out the
+`watchtower` section in `docker-compose.yaml` if you prefer manual updates.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -69,6 +69,7 @@ To bring the stack up, only a handful of settings must be reviewed in `.env`:
 - `EXTERNAL_API_KEY` for optional integrations.
 - Port values such as `NGINX_HTTP_PORT`, `NGINX_HTTPS_PORT`, and `ADMIN_UI_PORT` typically work as-is.
 - `PROMPT_ROUTER_HOST` and `PROMPT_ROUTER_PORT` define where the Escalation Engine sends its LLM requests.
+- `PROMETHEUS_PORT` and `GRAFANA_PORT` control the monitoring dashboard ports.
 - `REAL_BACKEND_HOST` tells Nginx where to forward requests that pass the bot checks when the defense stack sits in front of another web server.
 - `ALERT_SMTP_PASSWORD_FILE` or `ALERT_SMTP_PASSWORD` if you plan to send alert emails via SMTP.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ To get a full understanding of the project, please review the following document
 - [**Key Data Flows**](key_data_flows.md)**:** This document explains the lifecycle of a request as it moves through our defense layers, from initial filtering to deep analysis.  
 - [**Model Adapter Guide**](model_adapter_guide.md)**:** A technical deep-dive into the flexible Model Adapter pattern, which allows the system to easily switch between different machine learning models and LLM providers.
 - [**Prompt Router**](prompt_router.md)**:** Explains how LLM requests are routed between local containers and the cloud.
+- [**Monitoring Stack**](monitoring_stack.md)**:** Using Prometheus, Grafana, and Watchtower for observability and automatic updates.
 - [**Kubernetes Deployment**](kubernetes_deployment.md)**:** A step-by-step guide for deploying the entire application stack to a production-ready Kubernetes cluster.
 - [**Fail2ban**](fail2ban.md)**:** Configuration and deployment instructions for the optional firewall banning service.
 

--- a/docs/monitoring_stack.md
+++ b/docs/monitoring_stack.md
@@ -1,0 +1,16 @@
+# Monitoring Stack
+
+Docker Compose includes a small Prometheus server for metrics collection and a Grafana instance for visualization. Both services are disabled when deploying to Kubernetes unless you enable them explicitly.
+
+Prometheus scrapes the Python microservices every 15 seconds using `monitoring/prometheus.yml`. Grafana exposes dashboards and can be used to build custom views of request rates, response times, and other service metrics.
+
+Watchtower runs alongside these containers and automatically checks for new Docker images every minute, restarting services when updates are available. Remove the `watchtower` section from `docker-compose.yaml` if you prefer manual updates.
+
+```env
+# excerpt from sample.env
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+```
+
+- **Prometheus UI:** [http://localhost:${PROMETHEUS_PORT:-9090}](http://localhost:9090)
+- **Grafana UI:** [http://localhost:${GRAFANA_PORT:-3000}](http://localhost:3000) (default login `admin`/`admin`)

--- a/docs/prompt_router.md
+++ b/docs/prompt_router.md
@@ -16,5 +16,10 @@ Set the following variables in `.env`:
 - `PROMPT_ROUTER_HOST` – hostname or container name running the router.
 - `PROMPT_ROUTER_PORT` – port the router listens on.
 
+```env
+# excerpt from sample.env
+PROMPT_ROUTER_PORT=8009
+```
+
 The Escalation Engine uses `http://<PROMPT_ROUTER_HOST>:<PROMPT_ROUTER_PORT>/route`
 as the request URL.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Architecture: docs/architecture.md
     - Key Data Flows: docs/key_data_flows.md
     - API Reference: docs/model_adapter_guide.md
+    - Monitoring Stack: docs/monitoring_stack.md
     - Security Scan Helper: docs/security_scan.md
   - Microservices:
     - Tarpit Service: tarpit/README.md


### PR DESCRIPTION
## Summary
- document prompt router configuration
- add monitoring stack page and link it in docs
- mention watchtower, Grafana, and Prometheus port variables

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b99c59ec8321990cf2c6f41af044