### PR TITLE
Use token length for routing

### DIFF
--- a/docs/prompt_router.md
+++ b/docs/prompt_router.md
@@ -5,9 +5,9 @@ should be handled by a local LLM container or forwarded to the cloud proxy. The
 Escalation Engine sends all classification prompts to this service rather than
 talking to the models directly.
 
-The router reads the length of the prompt and, if it exceeds `MAX_LOCAL_TOKENS`,
-it forwards the payload to the cloud proxy. Otherwise it targets the local LLM
-endpoint.
+The router counts the tokens in the prompt and, if the count exceeds
+`MAX_LOCAL_TOKENS`, it forwards the payload to the cloud proxy. Otherwise it
+targets the local LLM endpoint.
 
 ## Configuration
 

--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
@@ -6,6 +7,15 @@ from fastapi import FastAPI, HTTPException, Request
 LOCAL_LLM_URL = os.getenv("LOCAL_LLM_URL", "http://llama3:11434/api/generate")
 CLOUD_PROXY_URL = os.getenv("CLOUD_PROXY_URL", "http://cloud_proxy:8008/api/chat")
 MAX_LOCAL_TOKENS = int(os.getenv("MAX_LOCAL_TOKENS", "1000"))
+
+TOKEN_PATTERN = re.compile(r"\w+|[^\w\s]")
+
+
+def count_tokens(text: str) -> int:
+    """Approximate the number of tokens in ``text`` using a simple heuristic."""
+
+    return len(TOKEN_PATTERN.findall(text))
+
 
 app = FastAPI()
 
@@ -19,7 +29,8 @@ async def health() -> dict[str, str]:
 async def route_prompt(request: Request) -> dict:
     payload = await request.json()
     prompt = payload.get("prompt", "")
-    target = LOCAL_LLM_URL if len(prompt) <= MAX_LOCAL_TOKENS else CLOUD_PROXY_URL
+    prompt_tokens = count_tokens(prompt)
+    target = LOCAL_LLM_URL if prompt_tokens <= MAX_LOCAL_TOKENS else CLOUD_PROXY_URL
     try:
         async with httpx.AsyncClient() as client:
             resp = await client.post(target, json=payload, timeout=60)

--- a/test/prompt_router/test_prompt_router.py
+++ b/test/prompt_router/test_prompt_router.py
@@ -101,7 +101,8 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
             ) as ac:
-                resp = await ac.post("/route", json={"prompt": "x" * 20})
+                long_prompt = " ".join(["x"] * 20)
+                resp = await ac.post("/route", json={"prompt": long_prompt})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"route": "cloud"})
         client_inst = DummyClient.instances[-1]

--- a/test/prompt_router/test_routing_behavior.py
+++ b/test/prompt_router/test_routing_behavior.py
@@ -53,7 +53,9 @@ class TestRoutingBehavior(unittest.IsolatedAsyncioTestCase):
         with patch.object(pr_module, "httpx") as httpx_mod:
             httpx_mod.AsyncClient.return_value = async_client
             transport = httpx.ASGITransport(app=app)
-            async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as ac:
                 await ac.post("/route", json={"prompt": prompt})
         return calls
 
@@ -62,7 +64,7 @@ class TestRoutingBehavior(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(calls[0][0], "http://local")
 
     async def test_long_prompt_goes_cloud(self):
-        calls = await self._send_prompt("x" * 10)
+        calls = await self._send_prompt(" ".join(["x"] * 6))
         self.assertEqual(calls[0][0], "http://cloud")
 
 


### PR DESCRIPTION
## Summary
- use a simple regex-based tokenizer in `prompt-router/main.py`
- update docs and tests to reflect token-based routing

## Testing
- `pre-commit run --files prompt-router/main.py docs/prompt_router.md test/prompt_router/test_prompt_router.py test/prompt_router/test_routing_behavior.py`
- `pytest test/prompt_router -q`

------
https://chatgpt.com/codex/tasks/task_e_6885c16231948321b0b8df875cf728d6