### PR TITLE
Enhance security and add Codex setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ python scripts/validate_env.py
 sudo ./quickstart_dev.sh   # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
 ```
 
+For the Codex testing environment, a helper `setup.sh` script installs all Python requirements and security tools used by `security_scan.sh`.
+
 On Windows, open an **Administrator PowerShell** window and run `quickstart_dev.ps1` instead.
 
 The script generates secrets, installs Python requirements with
@@ -243,6 +245,8 @@ Several integrations are disabled by default to keep the stack lightweight. You 
 - `Dockerfile`: A single Dockerfile used to build the base image for all Python services.
 - `jszip-rs/`: Rust implementation of the fake JavaScript archive generator.
 - `markov-train-rs/`: Rust implementation of the Markov training utility.
+
+When running in Codex, execute `./setup.sh` first to install all dependencies required for the unit tests and security scans.
 
 ### Running Multiple Tenants
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -173,7 +173,7 @@ MailHog is used to capture emails sent by the application for testing purposes. 
 
 ### **6.3. Adding Custom Rule Plugins**
 
-You can extend the detection heuristics by placing Python modules inside the `plugins/` directory. Set `ENABLE_PLUGINS=true` in your `.env` file and restart the stack. Each module should define a `check(metadata)` function returning a numeric adjustment.
+You can extend the detection heuristics by placing Python modules inside the `plugins/` directory. Set `ENABLE_PLUGINS=true` in your `.env` file and restart the stack. Each module should define a `check(metadata)` function returning a numeric adjustment. For security, only modules listed in the `ALLOWED_PLUGINS` environment variable will be loaded.
 
 ### **6.4. Running a WordPress Test Site**
 

--- a/sample.env
+++ b/sample.env
@@ -98,8 +98,9 @@ PG_DBNAME=markov_db
 PG_USER=postgres
 PG_PASSWORD_FILE=./secrets/pg_password.txt
 REDIS_PASSWORD_FILE=./secrets/redis_password.txt
-ADMIN_UI_USERNAME=your_username
-ADMIN_UI_PASSWORD=your_admin_password
+ADMIN_UI_USERNAME=change_me_username
+# Replace with a strong password before deployment
+ADMIN_UI_PASSWORD=change_me_password
 SYSTEM_SEED=your_long_random_system_seed
 
 # --- LLM & External Service API Keys ---

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+# Install tools used by security_scan.sh
+apt-get update
+apt-get install -y nmap nikto zaproxy sqlmap lynis
+curl -L https://github.com/aquasecurity/trivy/releases/latest/download/trivy_0.50.1_Linux-64bit.tar.gz | tar -xz -C /usr/local/bin --strip-components=1 trivy
+apt-get clean

--- a/src/admin_ui/templates/settings.html
+++ b/src/admin_ui/templates/settings.html
@@ -46,6 +46,7 @@
                 </div>
 
                 <form method="post" class="mt-6 space-y-4">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                     {% if updated %}
                     <div class="text-green-700">Settings updated.</div>
                     {% endif %}

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -2,6 +2,10 @@ import importlib
 import os
 from typing import Callable, List
 
+# Only load plugins that are explicitly allowed. This prevents arbitrary code
+# execution if untrusted files are placed in the plugin directory.
+ALLOWED_PLUGINS = os.getenv("ALLOWED_PLUGINS", "ua_blocker").split(",")
+
 PLUGIN_DIR = os.getenv("PLUGIN_DIR", "/app/plugins")
 
 
@@ -14,6 +18,11 @@ def load_plugins() -> List[Callable[[object], float]]:
         if not filename.endswith(".py") or filename.startswith("_"):
             continue
         module_name = filename[:-3]
+        if module_name not in ALLOWED_PLUGINS:
+            continue
+        path = os.path.join(PLUGIN_DIR, filename)
+        if os.path.islink(path):
+            continue
         try:
             module = importlib.import_module(f"plugins.{module_name}")
             func = getattr(module, "check", None)


### PR DESCRIPTION
## Summary
- add CSRF protection to admin settings page
- restrict plugin loading to an allowlist
- update sample.env placeholders
- document new setup script and Codex instructions
- create setup.sh for installing dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ce1b68b08321b6ece75967caf6f6