### PR TITLE
Fix insecure Traefik dashboard

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -348,7 +348,8 @@ services:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
-      - --api.insecure=true
+      - --api.dashboard=true
+      - --api.insecure=false
     ports:
       - "8005:80"
       - "8081:8080"


### PR DESCRIPTION
## Summary
- disable public Traefik API
- keep dashboard available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885e04b7e048321a718a8f429e573ba