### PR TITLE
Add optional 2FA to Admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Several integrations are disabled by default to keep the stack lightweight. You 
     - **CAPTCHA Verification** – Populate `CAPTCHA_SECRET` to activate reCAPTCHA challenges.
 - **Fail2ban** – Start the `fail2ban` container to insert firewall rules based on blocked IPs. See [docs/fail2ban.md](docs/fail2ban.md) for details.
 - **LLM Tarpit Pages** (`ENABLE_TARPIT_LLM_GENERATOR`) – Use an LLM to generate fake pages when a model URI is provided.
+- **Admin UI Two-Factor Auth** – Set `ADMIN_UI_2FA_SECRET` (or `ADMIN_UI_2FA_SECRET_FILE`) and provide a TOTP in the `X-2FA-Code` header.
 
 ## Project Structure
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -242,6 +242,7 @@ The `.env` file also contains toggles for several optional integrations:
 - **Managed TLS** (`ENABLE_MANAGED_TLS`) automatically issues certificates using `TLS_PROVIDER` and `TLS_EMAIL`.
 - **CAPTCHA Verification** activates when `CAPTCHA_SECRET` is supplied.
 - **LLM-Generated Tarpit Pages** (`ENABLE_TARPIT_LLM_GENERATOR`) require a `TARPIT_LLM_MODEL_URI`.
+- **Admin UI Two-Factor Auth** requires `ADMIN_UI_2FA_SECRET` and a TOTP in the `X-2FA-Code` header.
 
 ## **Running Local LLM Containers**
 

--- a/env.txt
+++ b/env.txt
@@ -38,6 +38,8 @@ ESCALATION_CHECK_INTERVAL=60  # in seconds
 # Admin UI Configuration
 ADMIN_UI_USERNAME=admin
 ADMIN_UI_PASSWORD_FILE=/run/secrets/admin_ui_password.txt
+# ADMIN_UI_2FA_SECRET can be set to require a TOTP code via the X-2FA-Code header
+ADMIN_UI_2FA_SECRET=
 
 # Logging Configuration
 LOG_LEVEL=INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ xgboost>=2.0,<3.0
 user-agents~=2.2
 schedule~=1.2
 geoip2~=4.7
+pyotp~=2.9
 
 # HTTP and Web Scraping
 httpx~=0.27

--- a/sample.env
+++ b/sample.env
@@ -100,6 +100,8 @@ REDIS_PASSWORD_FILE=./secrets/redis_password.txt
 ADMIN_UI_USERNAME=change_me_username
 # Replace with a strong password before deployment
 ADMIN_UI_PASSWORD=change_me_password
+# Optional base32 secret to enable 2FA for the Admin UI
+ADMIN_UI_2FA_SECRET=
 SYSTEM_SEED=your_long_random_system_seed
 
 # --- LLM & External Service API Keys ---


### PR DESCRIPTION
## Summary
- support TOTP based 2FA in admin_ui
- document 2FA variables in README and getting started guide
- expose `ADMIN_UI_2FA_SECRET` in sample.env and env.txt
- add `pyotp` dependency
- test Admin UI 2FA logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868c882a708321ba836ed52a24f28f