### PR TITLE
Add audit logging and RBAC enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ This project provides a multi-layered, microservice-based defense system against
 - **Plugin API:** Drop-in Python modules allow custom rules to extend detection logic.
 - **Anomaly Detection via AI:** Move beyond heuristics and integrate anomaly detection models for more adaptive security. ✅
 - **Automated Configuration Recommendations:** AI-driven service that analyzes traffic patterns and suggests firewall and tarpit tuning.
+- **Audit Logging:** Sensitive actions are written to a rotating `audit.log` for forensic review.
+- **RBAC Controls:** Admin endpoints verify an `ADMIN_UI_ROLE` environment variable and reject non-admin users.
+- **Model Version Metrics:** Prometheus gauge `model_version_info` exposes the running ML model version.
+- **CORS & CSP Headers:** The Admin UI sets CORS policies and a default Content-Security-Policy header.
 
 ## Architecture Overview
 

--- a/src/escalation/escalation_engine.py
+++ b/src/escalation/escalation_engine.py
@@ -91,6 +91,7 @@ try:
         RF_MODEL_ERRORS,
         RF_MODEL_PREDICTIONS,
         SCORE_ADJUSTED_IP_REPUTATION,
+        MODEL_VERSION_INFO,
         get_metrics,
         increment_counter_metric,
     )
@@ -153,6 +154,7 @@ except ImportError:
     HUMANS_DETECTED_LOCAL_LLM = DummyCounter()
     BOTS_DETECTED_EXTERNAL_API = DummyCounter()
     HUMANS_DETECTED_EXTERNAL_API = DummyCounter()
+    MODEL_VERSION_INFO = DummyCounter()
     METRICS_SYSTEM_AVAILABLE = False
 
 # --- Configuration (Preserved) ---
@@ -267,6 +269,8 @@ try:
     if model_adapter and model_adapter.model:
         MODEL_LOADED = True
         logger.info(f"Model adapter '{os.getenv('MODEL_TYPE')}' loaded successfully.")
+        if METRICS_SYSTEM_AVAILABLE and CONFIG.MODEL_VERSION:
+            MODEL_VERSION_INFO.labels(version=CONFIG.MODEL_VERSION).set(1)
     else:
         logger.warning(
             "Model adapter failed to initialize or load model. Heuristic scoring only."

--- a/src/shared/audit.py
+++ b/src/shared/audit.py
@@ -1,0 +1,23 @@
+import json
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+LOG_PATH = os.getenv("AUDIT_LOG_FILE", "/app/logs/audit.log")
+os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+
+logger = logging.getLogger("audit")
+if not logger.handlers:
+    handler = RotatingFileHandler(LOG_PATH, maxBytes=1_000_000, backupCount=3)
+    formatter = logging.Formatter("%(asctime)s %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def log_event(user: str, action: str, details: dict | None = None) -> None:
+    """Write an audit log entry."""
+    msg = f"{user}\t{action}"
+    if details:
+        msg += "\t" + json.dumps(details, sort_keys=True)
+    logger.info(msg)

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -329,6 +329,10 @@ class Config:
     ANOMALY_MODEL_PATH: Optional[str] = field(
         default_factory=lambda: os.getenv("ANOMALY_MODEL_PATH")
     )
+
+    MODEL_VERSION: Optional[str] = field(
+        default_factory=lambda: os.getenv("MODEL_VERSION")
+    )
     ANOMALY_THRESHOLD: float = field(
         default_factory=lambda: float(os.getenv("ANOMALY_THRESHOLD", 0.7))
     )

--- a/src/shared/metrics.py
+++ b/src/shared/metrics.py
@@ -374,6 +374,12 @@ QUEUE_LENGTH = Gauge(
     ["queue_name"],
     registry=REGISTRY,
 )
+MODEL_VERSION_INFO = Gauge(
+    "model_version_info",
+    "Version of the ML model in use.",
+    ["version"],
+    registry=REGISTRY,
+)
 UPTIME_SECONDS = Gauge(
     "uptime_seconds_total", "System uptime in seconds.", registry=REGISTRY
 )


### PR DESCRIPTION
## Summary
- introduce audit logging facility
- enforce RBAC in Admin UI and add CORS/CSP headers
- expose model version metric and configuration
- document new capabilities
- test RBAC denial

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ab4d421083219981f5e7cebe8f3a