### PR TITLE
Add optional fingerprinting script

### DIFF
--- a/docs/edge_enhancements.md
+++ b/docs/edge_enhancements.md
@@ -10,6 +10,10 @@ This release adds experimental features inspired by services offered by large CD
 
 `src/tarpit/labyrinth.py` generates deterministic maze pages. When `ENABLE_AI_LABYRINTH=true`, the Tarpit API will serve these pages to suspicious clients.
 
+### Browser Fingerprinting
+
+`src/tarpit.labyrinth.generate_labyrinth_page` can optionally embed a fingerprinting script that collects extensive browser details. Set `ENABLE_FINGERPRINTING=true` in your environment to include this JavaScript in responses.
+
 ## Risk and Attack Scoring
 
 `src/security/risk_scoring.py` and `src/security/attack_score.py` provide placeholder scoring logic that can feed into future Zero Trust models and WAF policies.

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -1,8 +1,8 @@
 """Central configuration dataclass and helpers for environment settings."""
 
-from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, Optional
 import os
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
 
 
 def get_secret(file_variable_name: str) -> Optional[str]:
@@ -299,7 +299,11 @@ class Config:
     KNOWN_BAD_UAS: str = field(
         default_factory=lambda: os.getenv(
             "KNOWN_BAD_UAS",
-            "python-requests,curl,wget,scrapy,java/,ahrefsbot,semrushbot,mj12bot,dotbot,petalbot,bytespider,gptbot,ccbot,claude-web,google-extended,dataprovider,purebot,scan,masscan,zgrab,nmap",
+            (
+                "python-requests,curl,wget,scrapy,java/,ahrefsbot,semrushbot,"
+                "mj12bot,dotbot,petalbot,bytespider,gptbot,ccbot,claude-web,"
+                "google-extended,dataprovider,purebot,scan,masscan,zgrab,nmap"
+            ),
         )
     )
     KNOWN_BENIGN_CRAWLERS_UAS: str = field(
@@ -326,10 +330,15 @@ class Config:
     )
 
     ENABLE_AI_LABYRINTH: bool = field(
-        default_factory=lambda: os.getenv("ENABLE_AI_LABYRINTH", "false").lower() == "true"
+        default_factory=lambda: os.getenv("ENABLE_AI_LABYRINTH", "false").lower()
+        == "true"
     )
     TARPIT_LABYRINTH_DEPTH: int = field(
         default_factory=lambda: int(os.getenv("TARPIT_LABYRINTH_DEPTH", 5))
+    )
+    ENABLE_FINGERPRINTING: bool = field(
+        default_factory=lambda: os.getenv("ENABLE_FINGERPRINTING", "false").lower()
+        == "true"
     )
 
     # Anomaly Detection

--- a/src/tarpit/labyrinth.py
+++ b/src/tarpit/labyrinth.py
@@ -1,12 +1,15 @@
 """Generate endless labyrinth pages for bots."""
+
 from __future__ import annotations
 
 import hashlib
+import os
 import random
+
 from .obfuscation import (
+    generate_fingerprinting_script,
     generate_obfuscated_css,
     generate_obfuscated_js,
-    generate_fingerprinting_script,
 )
 
 
@@ -20,7 +23,9 @@ def generate_labyrinth_page(seed: str, depth: int = 5) -> str:
     body = "".join(f"<a href='{link}'>Next</a><br/>" for link in links)
     css = generate_obfuscated_css()
     js = generate_obfuscated_js()
-    fp = generate_fingerprinting_script()
+    fp = ""
+    if os.getenv("ENABLE_FINGERPRINTING", "false").lower() == "true":
+        fp = generate_fingerprinting_script()
     return (
         "<html><head><title>Loading...</title>" + css + "</head>"
         "<body>" + body + js + fp + "</body></html>"


### PR DESCRIPTION
## Summary
- make labyrinth fingerprinting optional via `ENABLE_FINGERPRINTING`
- refactor obfuscation.js generator to avoid eval
- test labyrinth page generation for both fingerprinting modes
- document ENABLE_FINGERPRINTING configuration

## Testing
- `pre-commit run --files docs/edge_enhancements.md src/tarpit/obfuscation.py src/tarpit/labyrinth.py test/bot_control/test_crawler_features.py src/shared/config.py`
- `python test/run_all_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68870fae8ce08321ad491d74ef8ccb5f