### PR TITLE
Rename setup script and add security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ python scripts/validate_env.py
 sudo ./quickstart_dev.sh   # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
 ```
 
-For the security testing environment, a helper `setup.sh` script installs all Python requirements and security tools used by `security_scan.sh`.
+For the security testing environment, a helper `security_setup.sh` script installs all Python requirements and security tools used by `security_scan.sh`.
 
 On Windows, open an **Administrator PowerShell** window and run `quickstart_dev.ps1` instead.
 
@@ -261,7 +261,7 @@ Several integrations are disabled by default to keep the stack lightweight. You 
 - `jszip-rs/`: Rust implementation of the fake JavaScript archive generator.
 - `markov-train-rs/`: Rust implementation of the Markov training utility.
 
-When running in Codex, execute `./setup.sh` first to install all dependencies required for the unit tests and security scans.
+When running in Codex, execute `./security_setup.sh` first to install all dependencies required for the unit tests and security scans.
 
 ### Running Multiple Tenants
 

--- a/security_setup.ps1
+++ b/security_setup.ps1
@@ -1,0 +1,34 @@
+<#
+.SYNOPSIS
+Installs Python requirements and common security tools needed for security_scan.ps1.
+#>
+
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+$tools = @(
+    'nmap','nikto','zaproxy','sqlmap','lynis','hydra','masscan','gobuster','enum4linux',
+    'wpscan','ffuf','wfuzz','testssl.sh','whatweb','gvm','rkhunter','chkrootkit','clamav'
+)
+
+if (Get-Command choco -ErrorAction SilentlyContinue) {
+    choco install -y $tools
+} elseif (Get-Command winget -ErrorAction SilentlyContinue) {
+    foreach ($t in $tools) {
+        winget install --accept-package-agreements --accept-source-agreements -e --id $t
+    }
+} else {
+    Write-Warning "Install the following tools manually: $($tools -join ', ')"
+}
+
+Invoke-WebRequest -Uri 'https://github.com/aquasecurity/trivy/releases/latest/download/trivy_0.50.1_Windows-64bit.zip' -OutFile trivy.zip
+Expand-Archive trivy.zip -DestinationPath $Env:ProgramFiles
+Remove-Item trivy.zip
+
+Invoke-WebRequest -Uri 'https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_amd64.exe' -OutFile $Env:ProgramFiles\gitleaks.exe
+
+Invoke-WebRequest -Uri 'https://github.com/anchore/grype/releases/latest/download/grype_windows_amd64.zip' -OutFile grype.zip
+Expand-Archive grype.zip -DestinationPath $Env:ProgramFiles
+Remove-Item grype.zip
+
+pip install bandit sslyze sublist3r pip-audit

--- a/security_setup.sh
+++ b/security_setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+# Install tools used by security_scan.sh
+apt-get update
+apt-get install -y \
+    nmap nikto zaproxy sqlmap lynis hydra masscan gobuster enum4linux \
+    wpscan ffuf wfuzz testssl.sh whatweb gvm rkhunter chkrootkit clamav
+
+# Additional tools from GitHub
+curl -L https://github.com/aquasecurity/trivy/releases/latest/download/trivy_0.50.1_Linux-64bit.tar.gz \
+  | tar -xz -C /usr/local/bin --strip-components=1 trivy
+curl -L https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks-linux-amd64 \
+  -o /usr/local/bin/gitleaks && chmod +x /usr/local/bin/gitleaks
+curl -L https://github.com/anchore/grype/releases/latest/download/grype_linux_amd64.tar.gz \
+  | tar -xz -C /usr/local/bin grype
+
+pip install bandit sslyze sublist3r pip-audit
+apt-get clean

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-python -m pip install --upgrade pip
-pip install -r requirements.txt
-# Install tools used by security_scan.sh
-apt-get update
-apt-get install -y nmap nikto zaproxy sqlmap lynis
-curl -L https://github.com/aquasecurity/trivy/releases/latest/download/trivy_0.50.1_Linux-64bit.tar.gz | tar -xz -C /usr/local/bin --strip-components=1 trivy
-apt-get clean


### PR DESCRIPTION
## Summary
- rename `setup.sh` to `security_setup.sh`
- create Windows script `security_setup.ps1`
- update README to reference the new script

## Testing
- `python -m pip install -r requirements.txt -c constraints.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880143cb20832184118794bef29f7d