### PR TITLE
Add minimal env template

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ graph TD
 ## Beginner Quickstart
 
 Below are platform-specific steps to install the prerequisites and run the helper script. The
-script copies `sample.env`, generates secrets, installs dependencies, and starts Docker
-Compose. See [docs/getting_started.md](docs/getting_started.md) for a deeper walkthrough.
+script copies `sample.env` (use `sample.env.min` for a minimal config), generates secrets,
+installs dependencies, and starts Docker Compose. See
+[docs/getting_started.md](docs/getting_started.md) for a deeper walkthrough.
 
 ### Linux
 1. [Install Docker Engine](https://docs.docker.com/engine/install/) and ensure it is running.

--- a/docs/env_cheatsheet.md
+++ b/docs/env_cheatsheet.md
@@ -1,6 +1,6 @@
 # Environment Variable Cheat Sheet
 
-The following variables from `.env` are the minimum values to review or set manually before starting the stack. Most defaults work for local testing, but production deployments may require changes.
+The following variables from `.env` are the minimum values to review or set manually before starting the stack. Most defaults work for local testing, but production deployments may require changes. A template with just these settings is provided in `sample.env.min`.
 
 | Variable | Purpose |
 | --- | --- |

--- a/sample.env.min
+++ b/sample.env.min
@@ -1,0 +1,35 @@
+# sample.env.min
+#
+# Minimal variables for local testing.
+# Copy this file to .env and fill in your values.
+
+# Detection model configuration
+MODEL_URI=sklearn:///app/models/bot_detection_rf_model.joblib
+
+# Optional API keys for model providers
+OPENAI_API_KEY=
+MISTRAL_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+COHERE_API_KEY=
+
+# Optional integration key
+EXTERNAL_API_KEY=
+
+# Service ports
+NGINX_HTTP_PORT=80
+NGINX_HTTPS_PORT=443
+ADMIN_UI_PORT=5002
+PROMPT_ROUTER_HOST=prompt_router
+PROMPT_ROUTER_PORT=8009
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+WATCHTOWER_INTERVAL=60
+
+# Backend targets
+REAL_BACKEND_HOSTS=http://localhost:8082
+REAL_BACKEND_HOST=http://localhost:8082
+
+# SMTP alert credentials
+ALERT_SMTP_PASSWORD_FILE=/run/secrets/smtp_password.txt
+# Alternatively set ALERT_SMTP_PASSWORD=


### PR DESCRIPTION
## Summary
- provide `sample.env.min` with only the variables required for local testing
- reference the new template from the Beginner Quickstart
- mention the template in `docs/env_cheatsheet.md`

## Testing
- `python test/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68882240e1d08321bfd06bcaaf78dbd5