### PR TITLE
Update Docker strategy docs

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -4,7 +4,7 @@ This project leverages Docker for containerization, ensuring a consistent and re
 
 ## **The Core Principle: A Single Base Image**
 
-Instead of creating a separate, complex Dockerfile for each microservice, we use a single Dockerfile located in the root of the project.
+Instead of creating a separate, complex Dockerfile for each microservice, we use a single Dockerfile located in the root of the project. Python services share this root Dockerfile, while separate Dockerfiles reside in `proxy/`, `cloud-proxy/`, and `prompt-router`.
 
 **File:** Dockerfile
 


### PR DESCRIPTION
## Summary
- clarify that each Python service uses the root Dockerfile
- mention separate Dockerfiles for `proxy/`, `cloud-proxy/`, and `prompt-router`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883416aa4c83219af889669825f176