### PR TITLE
Add optional pay-per-crawl note

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project provides a multi-layered, microservice-based defense system against
 - **Plugin API:** Drop-in Python modules allow custom rules to extend detection logic.
 - **Anomaly Detection via AI:** Move beyond heuristics and integrate anomaly detection models for more adaptive security.
 - **API Sequence Anomaly Detection:** Markov-based scoring highlights unusual request patterns.
-- **Crawler Authentication & Pay-Per-Crawl:** Token registry and usage accounting enable monetization experiments.
+- **Crawler Authentication & Pay-Per-Crawl:** Token registry and usage accounting enable monetization experiments. Whether you actually permit bots to pay for access or keep them blocked is entirely your choice.
 - **Payment Gateway Integration:** Multi-provider gateways (`StripeGateway`,
   `PayPalGateway`, `BraintreeGateway`, `SquareGateway`,
   `AdyenGateway`, `AuthorizeNetGateway`, or a generic HTTP backend) handle crawler account creation,

--- a/docs/edge_enhancements.md
+++ b/docs/edge_enhancements.md
@@ -4,7 +4,7 @@ This release adds new features inspired by services offered by large CDN provide
 
 ## Crawler Tokens
 
-`src/bot_control/crawler_auth.py` implements a simple in-memory registry for crawl tokens. A crawler can register a token and purpose which is later validated for every request. Combined with `src/bot_control/pricing.py`, usage can be tracked for pay-per-crawl experiments.
+`src/bot_control/crawler_auth.py` implements a simple in-memory registry for crawl tokens. A crawler can register a token and purpose which is later validated for every request. Combined with `src/bot_control/pricing.py`, usage can be tracked for pay-per-crawl experiments. Allowing these paying crawlers through is optional and fully under your control.
 
 ## AI Labyrinth Honeypots
 

--- a/docs/pay_per_crawl.md
+++ b/docs/pay_per_crawl.md
@@ -2,6 +2,11 @@
 
 This proxy charges registered crawlers per request using HTTP 402 when payment is required. Pricing rules are loaded from `config/pricing.yaml`.
 
+This monetization approach is optional. You can continue blocking automated
+traffic entirely, or allow certain bots to proceed only if they pay according to
+your own policies. The system merely tracks usage and handles payments; whether
+to grant paying bots access is ultimately your decision.
+
 ```yaml
 # pricing.yaml
 # path prefix : price in USD


### PR DESCRIPTION
## Summary
- clarify that pay-per-crawl is optional in `README.md`
- document user choice in `docs/pay_per_crawl.md`
- mention optional nature in `docs/edge_enhancements.md`

## Testing
- `pre-commit run --files README.md docs/edge_enhancements.md docs/pay_per_crawl.md`

------
https://chatgpt.com/codex/tasks/task_e_688932a08c2083218a9fcc5cb70e3229