### PR TITLE
Add threat model doc and dependency scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/jszip-rs"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/markov-train-rs"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,28 @@
+name: pip-audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pip-audit
+      - name: Run pip-audit
+        run: |
+          pip-audit -r requirements.txt -f sarif -o pip-audit.sarif
+      - name: Upload results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: pip-audit.sarif

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,4 +1,7 @@
 name: pip-audit
+permissions:
+  contents: read
+  security-events: write
 
 on:
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* **Threat Model Document:** Added docs/threat_model.md and linked from the README.
+* **Automated Dependency Scanning:** Added Dependabot configuration and pip-audit workflow.
+
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ graph TD
 
     TarpitAPI -- "Reads" --> Postgres
 ```
+## Threat Model
+
+See [docs/threat_model.md](docs/threat_model.md) for the adversaries and attack vectors this project targets.
+
+
 
 ## Beginner Quickstart
 

--- a/docs/hardware_requirements.md
+++ b/docs/hardware_requirements.md
@@ -30,3 +30,8 @@ Both containers store their downloads in `models/shared-data`, so ensure adequat
 ## Performance Benchmarks
 
 On an 8-core VM with 16&nbsp;GB of RAM the stack handled roughly **3,000 req/s** when only the tarpit service was active. Running the full suite of analysis services reduced throughput to around **1,500 req/s**. Actual performance varies based on network latency and storage speed.
+
+## Scaling Recommendations
+
+For high traffic deployments, run multiple instances of the microservices and Nginx behind a load balancer.
+Redis and PostgreSQL can be clustered for reliability. Monitor resource usage with Prometheus and add replicas as needed.

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -1,0 +1,16 @@
+# Threat Model
+
+This document outlines the primary threats considered when deploying the AI Scraping Defense stack.
+
+## Goals
+- Prevent large-scale scraping of FOSS and documentation sites.
+- Detect malicious automation without harming legitimate users.
+
+## Threats
+- **Automated Web Scrapers:** Bots that harvest site content without permission.
+- **Malicious Probing:** Attackers scanning for exploitable vulnerabilities.
+- **Credential Stuffing:** Attempts to reuse leaked credentials against login forms.
+- **Evasive Bots:** Tools that rotate IPs or user agents to bypass simple filters.
+
+## Out of Scope
+- Protection against targeted exploitation of unrelated backend services.


### PR DESCRIPTION
## Summary
- document the threat model and link from README
- detail scaling recommendations in hardware requirements
- add Dependabot updates and pip-audit workflow
- record these additions in CHANGELOG

## Testing
- `pre-commit run --files .github/dependabot.yml .github/workflows/pip-audit.yml docs/threat_model.md docs/hardware_requirements.md README.md CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6889376c95bc8321b7298e10ed978e7e