### PR TITLE
Add GitHub runner deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Runner Deployment
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Runner Deployment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build deployment artifact
+        run: |
+          echo "Deploying $GITHUB_SHA to runner environment" > deployment.txt
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployment-artifact
+          path: deployment.txt

--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ To deploy the stack to a managed Kubernetes service such as Google Kubernetes En
 ./gke_deploy.sh       # or .\gke_deploy.ps1 on Windows
 ```
 
+### GitHub Actions Runner Deployment
+
+A workflow named `deploy.yml` now demonstrates a deployment to the GitHub runner environment. Trigger it from the **Actions** tab to see a deployment artifact uploaded. See [docs/github_actions_deployment.md](docs/github_actions_deployment.md) for more information.
+
 
 ## Load Testing Helpers
 

--- a/docs/github_actions_deployment.md
+++ b/docs/github_actions_deployment.md
@@ -1,0 +1,7 @@
+# GitHub Actions Runner Deployment
+
+The repository provides a minimal workflow that demonstrates how a deployment step can run entirely in GitHub Actions. The workflow file is located at `.github/workflows/deploy.yml` and can be triggered manually from the **Actions** tab.
+
+When executed, the job checks out the repository, creates a small deployment artifact, and uploads it to the workflow run. This keeps everything self-contained on the GitHub runner so you can experiment safely with environments and approvals.
+
+This example is a starting point for building a full deployment pipeline. You can adapt the workflow to push Docker images or apply Kubernetes manifests once you have the necessary credentials.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - Key Data Flows: docs/key_data_flows.md
     - API Reference: docs/model_adapter_guide.md
     - Monitoring Stack: docs/monitoring_stack.md
+    - GitHub Actions Runner Deployment: docs/github_actions_deployment.md
     - Security Scan Helper: docs/security_scan.md
   - Microservices:
     - Tarpit Service: tarpit/README.md


### PR DESCRIPTION
## Summary
- rename workflow to `deploy.yml`
- build and upload an artifact to simulate a deployment
- document the new runner deployment workflow in README and docs
- adjust mkdocs navigation entry

## Testing
- `pre-commit run --files README.md mkdocs.yml .github/workflows/deploy.yml docs/github_actions_deployment.md`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6889a90370d483219fceaa283f69ed29