### PR TITLE
Add IIS module and gateway

### DIFF
--- a/docs/iis_deployment.md
+++ b/docs/iis_deployment.md
@@ -1,0 +1,85 @@
+# Deploying with IIS on Windows
+
+This guide describes how to run the AI Scraping Defense stack on a Windows server using **Internet Information Services (IIS)** instead of Nginx.
+
+## Prerequisites
+
+- Windows Server with IIS installed.
+- [Application Request Routing](https://learn.microsoft.com/iis/extensions/planning-for-arr/) and [URL Rewrite](https://learn.microsoft.com/iis/extensions/url-rewrite-module/) modules enabled.
+- Python installed and able to create virtual environments.
+- Redis and PostgreSQL running locally or accessible on the network.
+
+## 1. Start the Python Services
+
+Run the helper script to launch all required services:
+
+```powershell
+./iis/start_services.ps1
+```
+
+This script resets the virtual environment (unless `-NoReset` is supplied) and
+starts the AI Service, Escalation Engine, Tarpit API, and Admin UI in separate
+PowerShell windows. Ports are read from environment variables or fall back to the
+defaults in `sample.env`.
+
+## 2. Configure IIS as a Reverse Proxy
+
+You can script this setup with `iis/configure_proxy.ps1` or perform the steps manually:
+
+1. Open **IIS Manager** and choose your server in the **Connections** pane.
+2. Double-click **Application Request Routing Cache** and select **Server Proxy Settings**.
+3. Check **Enable proxy** and apply the change.
+4. Under your site, open **URL Rewrite** and add rules that forward traffic to the running Python services. The script will create rules for the Admin UI and a catch‑all backend route automatically.
+
+Example rule for the Admin UI:
+
+| Setting       | Value                                  |
+|---------------|----------------------------------------|
+| Pattern       | `admin/(.*)`                           |
+| Rewrite URL   | `http://localhost:5002/{R:1}`          |
+
+Add similar rules for the other services. A catch‑all rule can forward the rest of the traffic to your main backend on port 8080.
+
+To automate these settings, run:
+
+```powershell
+./iis/configure_proxy.ps1
+```
+
+## 3. Recreating Lua Logic
+
+The Nginx deployment uses Lua scripts for bot detection. With IIS you have two options:
+
+1. **Custom HttpModule** – Compile the sample module in `iis/DefenseModule` and register it with your site. The module checks the Redis blocklist and can escalate suspicious requests to the AI service.
+2. **Gateway Service** – Launch `src/iis_gateway/main.py` to run a lightweight proxy that applies similar checks in Python before forwarding to the real backend.
+
+To build the HttpModule open a Developer Command Prompt for Visual Studio and run:
+
+```cmd
+msbuild iis\DefenseModule\DefenseModule.csproj /p:Configuration=Release
+```
+
+Copy the resulting DLL to your IIS modules folder and add it under **Modules** in IIS Manager.
+
+To start the gateway service:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+python -m src.iis_gateway.main
+```
+
+Set the `BACKEND_URL` environment variable to the address of your application.
+
+## 4. Managing Secrets
+
+Generate required secrets with the PowerShell script:
+
+```powershell
+./Generate-Secrets.ps1
+```
+
+Ensure the resulting environment variables are available to each service when you launch them.
+
+---
+
+Replacing Nginx with IIS requires more manual configuration but allows the stack to run on a pure Windows environment. Once IIS routes are defined and the Python services are running, the system behaves the same as the Docker-based setup.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ To get a full understanding of the project, please review the following document
 - [**Fail2ban**](fail2ban.md)**:** Configuration and deployment instructions for the optional firewall banning service.
 - [**Web Application Firewall**](waf_setup.md)**:** How to load ModSecurity rules and enable request filtering.
 - [**Edge Provider Enhancements**](edge_enhancements.md)**:** Overview of advanced crawler tokens, AI labyrinths, and risk scoring.
+- [**IIS Deployment**](iis_deployment.md)**:** Running the stack on Windows with IIS as the reverse proxy.
 
 ---
 

--- a/iis/DefenseModule/DefenseModule.cs
+++ b/iis/DefenseModule/DefenseModule.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Configuration;
+using System.Threading.Tasks;
+using System.Web;
+using StackExchange.Redis;
+
+namespace AntiScrape.IIS
+{
+    public class DefenseModule : IHttpModule
+    {
+        private static ConnectionMultiplexer _redis;
+
+        public void Init(HttpApplication context)
+        {
+            context.BeginRequest += CheckRequestAsync;
+        }
+
+        private void EnsureRedis()
+        {
+            if (_redis != null) return;
+            var host = ConfigurationManager.AppSettings["REDIS_HOST"] ?? "localhost";
+            var port = ConfigurationManager.AppSettings["REDIS_PORT"] ?? "6379";
+            _redis = ConnectionMultiplexer.Connect($"{host}:{port}");
+        }
+
+        private async void CheckRequestAsync(object sender, EventArgs e)
+        {
+            var app = (HttpApplication)sender;
+            var ctx = app.Context;
+            EnsureRedis();
+
+            var ip = ctx.Request.UserHostAddress;
+            var dbIndex = int.Parse(ConfigurationManager.AppSettings["REDIS_DB_BLOCKLIST"] ?? "2");
+            var tenant = ConfigurationManager.AppSettings["TENANT_ID"] ?? "default";
+            var db = _redis.GetDatabase(dbIndex);
+            var key = $"{tenant}:blocklist:ip:{ip}";
+            if (await db.KeyExistsAsync(key))
+            {
+                ctx.Response.StatusCode = 403;
+                ctx.CompleteRequest();
+                return;
+            }
+
+            if (string.IsNullOrEmpty(ctx.Request.UserAgent))
+            {
+                await EscalateAsync(ip, "MissingUA");
+            }
+        }
+
+        private async Task EscalateAsync(string ip, string reason)
+        {
+            var endpoint = ConfigurationManager.AppSettings["ESCALATION_ENDPOINT"];
+            if (string.IsNullOrEmpty(endpoint)) return;
+            using (var client = new System.Net.Http.HttpClient())
+            {
+                try
+                {
+                    await client.PostAsJsonAsync(endpoint, new { ip, reason });
+                }
+                catch
+                {
+                    // fail open
+                }
+            }
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/iis/DefenseModule/DefenseModule.csproj
+++ b/iis/DefenseModule/DefenseModule.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
+  </ItemGroup>
+</Project>

--- a/iis/configure_proxy.ps1
+++ b/iis/configure_proxy.ps1
@@ -1,0 +1,33 @@
+# Configure-Proxy.ps1
+<##
+.SYNOPSIS
+    Enables Application Request Routing and sets up basic reverse proxy rules in IIS.
+.DESCRIPTION
+    Adds URL Rewrite rules for the Admin UI and a catch-all rule that forwards
+    other traffic to the backend application.
+##>
+param(
+    [string]$SiteName = 'Default Web Site',
+    [string]$BackendUrl = 'http://localhost:8080'
+)
+
+Import-Module WebAdministration
+
+Write-Host 'Enabling ARR proxy...' -ForegroundColor Cyan
+Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST' -filter 'system.webServer/proxy' -name 'enabled' -value 'True'
+
+$sitePath = "MACHINE/WEBROOT/APPHOST/$SiteName"
+$rulesPath = "$sitePath/system.webServer/rewrite/rules"
+
+# Admin UI rule
+if (-not (Get-WebConfigurationProperty -pspath $sitePath -filter "system.webServer/rewrite/rules/rule[@name='AdminUI']" -name 'name' -ErrorAction SilentlyContinue)) {
+    Add-WebConfigurationProperty -pspath $sitePath -filter 'system.webServer/rewrite/rules' -name '.' -value @{name='AdminUI';patternSyntax='ECMAScript';stopProcessing='true';match=@{url='admin/(.*)'};action=@{type='Rewrite';url='http://localhost:5002/{R:1}'}}
+}
+
+# Catch-all backend rule
+if (-not (Get-WebConfigurationProperty -pspath $sitePath -filter "system.webServer/rewrite/rules/rule[@name='BackendCatchAll']" -name 'name' -ErrorAction SilentlyContinue)) {
+    Add-WebConfigurationProperty -pspath $sitePath -filter 'system.webServer/rewrite/rules' -name '.' -value @{name='BackendCatchAll';patternSyntax='ECMAScript';stopProcessing='true';match=@{url='(.*)'};action=@{type='Rewrite';url="$BackendUrl/{R:1}"}}
+}
+
+Write-Host 'Proxy rules configured.' -ForegroundColor Green
+

--- a/iis/start_services.ps1
+++ b/iis/start_services.ps1
@@ -1,0 +1,38 @@
+# Start-Services.ps1
+<##
+.SYNOPSIS
+    Launches the core Python services for the IIS deployment.
+.DESCRIPTION
+    Creates the virtual environment if necessary and starts each service
+    in a new PowerShell window. Ports are read from environment variables or
+    default to the values in sample.env.
+##>
+param([switch]$NoReset)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path "$PSScriptRoot/.."
+Set-Location $repoRoot
+
+if (-not $NoReset) {
+    & "$repoRoot/reset_venv.ps1"
+}
+
+$activate = Join-Path $repoRoot '.venv\Scripts\Activate.ps1'
+$python = Join-Path $repoRoot '.venv\Scripts\python.exe'
+
+$services = @(
+    @{ Name='AI Service';       Module='src.ai_service.ai_webhook:app';      Port=$env:AI_SERVICE_PORT     ?? 8000 },
+    @{ Name='Escalation Engine';Module='src.escalation.escalation_engine:app';Port=$env:ESCALATION_ENGINE_PORT ?? 8003 },
+    @{ Name='Tarpit API';       Module='src.tarpit.tarpit_api:app';          Port=$env:TARPIT_API_PORT     ?? 8001 },
+    @{ Name='Admin UI';         Module='src.admin_ui.admin_ui:app';          Port=$env:ADMIN_UI_PORT       ?? 5002 }
+)
+
+foreach ($svc in $services) {
+    $cmd = "& `"$activate`"; & `"$python`" -m uvicorn $($svc.Module) --host 127.0.0.1 --port $($svc.Port)"
+    $args = "-NoProfile -ExecutionPolicy Bypass -Command `$cmd"
+    Start-Process powershell.exe -ArgumentList $args -WindowStyle Minimized | Out-Null
+    Write-Host "Started $($svc.Name) on port $($svc.Port)" -ForegroundColor Green
+}
+
+Write-Host "All services launched." -ForegroundColor Cyan
+

--- a/src/iis_gateway/main.py
+++ b/src/iis_gateway/main.py
@@ -1,0 +1,89 @@
+"""Simple gateway service to replicate Nginx Lua logic on Windows.
+
+Checks requests against a Redis blocklist and applies basic bot heuristics
+before forwarding to the configured backend. Intended for use with IIS
+when a custom HttpModule is not desired.
+"""
+
+import os
+
+import httpx
+import redis
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import PlainTextResponse
+
+CONFIG = {
+    "BACKEND_URL": os.getenv("BACKEND_URL", "http://localhost:8080"),
+    "ESCALATION_ENDPOINT": os.getenv("ESCALATION_ENDPOINT"),
+    "REDIS_HOST": os.getenv("REDIS_HOST", "localhost"),
+    "REDIS_PORT": int(os.getenv("REDIS_PORT", 6379)),
+    "REDIS_DB_BLOCKLIST": int(os.getenv("REDIS_DB_BLOCKLIST", 2)),
+    "TENANT_ID": os.getenv("TENANT_ID", "default"),
+}
+
+BAD_BOTS = [
+    "GPTBot",
+    "CCBot",
+    "ClaudeBot",
+    "Scrapy",
+    "python-requests",
+    "curl",
+    "wget",
+]
+
+app = FastAPI()
+redis_client = redis.Redis(
+    host=CONFIG["REDIS_HOST"],
+    port=CONFIG["REDIS_PORT"],
+    db=CONFIG["REDIS_DB_BLOCKLIST"],
+    decode_responses=True,
+)
+
+
+async def escalate(ip: str, reason: str) -> None:
+    if not CONFIG["ESCALATION_ENDPOINT"]:
+        return
+    async with httpx.AsyncClient() as client:
+        try:
+            await client.post(
+                CONFIG["ESCALATION_ENDPOINT"], json={"ip": ip, "reason": reason}
+            )
+        except httpx.HTTPError:
+            pass
+
+
+@app.api_route(
+    "/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+)
+async def proxy(path: str, request: Request) -> Response:
+    client_ip = request.client.host
+    block_key = f"{CONFIG['TENANT_ID']}:blocklist:ip:{client_ip}"
+    if redis_client.exists(block_key):
+        return PlainTextResponse("Forbidden", status_code=403)
+
+    ua = request.headers.get("user-agent", "")
+    if not ua:
+        await escalate(client_ip, "MissingUA")
+    elif any(bot.lower() in ua.lower() for bot in BAD_BOTS):
+        await escalate(client_ip, "BadUA")
+        return PlainTextResponse("Forbidden", status_code=403)
+
+    url = f"{CONFIG['BACKEND_URL'].rstrip('/')}/{path}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.request(
+            request.method,
+            url,
+            headers=request.headers.raw,
+            content=await request.body(),
+            params=request.query_params,
+        )
+
+    return Response(
+        content=resp.content, status_code=resp.status_code, headers=resp.headers
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=9000)


### PR DESCRIPTION
## Summary
- create IIS DefenseModule and Python gateway service for Windows deployments
- document how to use them in IIS guide
- automate starting services and proxy setup on Windows

## Testing
- `pre-commit run --files docs/iis_deployment.md iis/start_services.ps1 iis/configure_proxy.ps1 docs/index.md src/iis_gateway/main.py iis/DefenseModule/DefenseModule.cs iis/DefenseModule/DefenseModule.csproj`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a83ea5ddc8321890674878b201bb1