### PR TITLE
Fix dependencies for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,13 @@ FROM python:3.11-slim
 
 # Install system packages needed for psycopg2 and other compiled dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libpq-dev gcc && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        python3-dev \
+        libpq-dev \
+        libxml2-dev \
+        libxslt1-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container to /app

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,6 +17,8 @@ Below are solutions for common issues encountered when setting up or running the
   - Install dependencies with `pip install -r requirements.txt`
 - **Permission denied writing files**
   - Verify file paths exist and adjust ownership with `chown` or run commands with `sudo`
+- **Could not build wheels for psycopg2 or llama-cpp-python**
+  - Install system build tools inside the container or host: `build-essential`, `cmake`, `python3-dev`, `libpq-dev`, `libxml2-dev`, `libxslt1-dev`
 
 ## Rust build failures
 


### PR DESCRIPTION
## Summary
- ensure Docker image includes build tools for Python packages
- note required packages when wheels fail to build

## Testing
- `pre-commit run --files Dockerfile docs/troubleshooting.md`

------
https://chatgpt.com/codex/tasks/task_e_688acabd5bdc83219b4b1aad66fa7bd5