### PR TITLE
Document build tool dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update && \
         python3-dev \
         libpq-dev \
         libxml2-dev \
-        libxslt1-dev && \
+        libxslt1-dev \
+        libc6-dev \
+        git && \
     rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container to /app

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ Below are solutions for common issues encountered when setting up or running the
 - **Permission denied writing files**
   - Verify file paths exist and adjust ownership with `chown` or run commands with `sudo`
 - **Could not build wheels for psycopg2 or llama-cpp-python**
-  - Install system build tools inside the container or host: `build-essential`, `cmake`, `python3-dev`, `libpq-dev`, `libxml2-dev`, `libxslt1-dev`
+  - Install system build tools inside the container or host: `build-essential`, `cmake`, `python3-dev`, `libpq-dev`, `libxml2-dev`, `libxslt1-dev`, `libc6-dev`, `git`
 
 ## Rust build failures
 


### PR DESCRIPTION
## Summary
- document additional build dependencies for psycopg2 and llama-cpp-python

## Testing
- `pre-commit run --files Dockerfile docs/troubleshooting.md`

------
https://chatgpt.com/codex/tasks/task_e_688ad0f3fc148321b3ada6e70d95182b