### PR TITLE
Fix /app permission errors in tests

### DIFF
--- a/.github/workflows/linux-deploy.yml
+++ b/.github/workflows/linux-deploy.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Generate local secrets
         run: bash ./generate_secrets.sh --update-env
 
+      - name: Create /app directories for tests
+        run: |
+          sudo mkdir -p /app/logs /app/data
+          sudo chown $(id -u):$(id -g) /app /app/logs /app/data
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- ensure `/app/logs` and `/app/data` exist on the runner so imports don't fail

## Testing
- `pre-commit run --files .github/workflows/linux-deploy.yml`

------
https://chatgpt.com/codex/tasks/task_e_688b2226676083219c721ab3c68805a6