### PR TITLE
Fix docker compose env var warnings

### DIFF
--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -34,10 +34,12 @@ done
 
 update_var() {
   local key="$1" value="$2" file="$3"
+  # Escape dollar signs so docker compose doesn't treat them as variables
+  local escaped="${value//\$/\$\$}"
   if grep -q "^${key}=" "$file"; then
-    sed -i.bak "s|^${key}=.*|${key}=${value}|" "$file" && rm -f "${file}.bak"
+    sed -i.bak "s|^${key}=.*|${key}=${escaped}|" "$file" && rm -f "${file}.bak"
   else
-    echo "${key}=${value}" >> "$file"
+    echo "${key}=${escaped}" >> "$file"
   fi
 }
 


### PR DESCRIPTION
## Summary
- escape `$` characters in generated env values to prevent docker compose warnings

## Testing
- `pre-commit run --files generate_secrets.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b2dea72608321966fde266a351544