### PR TITLE
Update secrets script

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,12 @@ For a full walkthrough of bringing the stack live, review [docs/test_to_producti
     ```
 
 4. **Generate Secrets:**
-    Run the secret generation script to create passwords for the database, Admin UI, and other services. It writes a `kubernetes/secrets.yaml` file and prints the credentials to your console. If you used `interactive_setup.py` above, this step has already been performed.
+    Run the secret generation script to create passwords for the database, Admin UI, and other services. It writes a `kubernetes/secrets.yaml` file and prints the credentials to your console. When run with `--update-env` (as in the interactive setup), the script also updates `.env` and writes the database and Redis passwords to `secrets/pg_password.txt` and `secrets/redis_password.txt` for Docker Compose.
 
     *On Linux or macOS:*
 
     ```bash
-    bash ./generate_secrets.sh
+    bash ./generate_secrets.sh --update-env
     # export credentials to a JSON file
     bash ./generate_secrets.sh --export-path my_secrets.json
     ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -111,13 +111,12 @@ This script will create a virtual environment in the .venv directory, install al
 
 ### **4. Generate Local Secrets**
 
-The application requires several secrets to run (e.g., database passwords). A script is provided to generate these securely. It creates `kubernetes/secrets.yaml` and prints the credentials to your console. By default it **does not** modify your `.env` file. If you used the interactive setup script, this step is performed automatically.
+The application requires several secrets to run (e.g., database passwords). A script is provided to generate these securely. It creates `kubernetes/secrets.yaml` and prints the credentials to your console. By default it **does not** modify your `.env` file. When run with `--update-env`, it updates the file and writes the database and Redis passwords to `secrets/pg_password.txt` and `secrets/redis_password.txt` for Docker Compose. If you used the interactive setup script, this step is performed automatically.
 
 * **On Linux or macOS:**
 
 ```  bash
-  ./generate_secrets.sh
-  # optionally update your .env automatically
+  # update .env and create secret files
   ./generate_secrets.sh --update-env
   # save credentials to a JSON file
   ./generate_secrets.sh --export-path my_secrets.json

--- a/generate_secrets.sh
+++ b/generate_secrets.sh
@@ -199,6 +199,14 @@ if [ "$update_env" = true ]; then
   update_var EXTERNAL_API_KEY "$EXTERNAL_API_KEY" "$ENV_FILE"
   update_var IP_REPUTATION_API_KEY "$IP_REPUTATION_API_KEY" "$ENV_FILE"
   update_var COMMUNITY_BLOCKLIST_API_KEY "$COMMUNITY_BLOCKLIST_API_KEY" "$ENV_FILE"
+
+  # Write secret files for Docker Compose
+  SECRETS_DIR="$SCRIPT_DIR/secrets"
+  mkdir -p "$SECRETS_DIR"
+  echo -n "$POSTGRES_PASSWORD" > "$SECRETS_DIR/pg_password.txt"
+  echo -n "$REDIS_PASSWORD" > "$SECRETS_DIR/redis_password.txt"
+  chmod 600 "$SECRETS_DIR/pg_password.txt" "$SECRETS_DIR/redis_password.txt"
+  echo -e "${CYAN}Secret files written to ${SECRETS_DIR}${NC}"
 fi
 
 echo -e "${GREEN}Secrets Generation Complete!${NC}"


### PR DESCRIPTION
## Summary
- generate secret files when `--update-env` is used
- document the new behavior in README and getting started guide

## Testing
- `pre-commit run --files generate_secrets.sh README.md docs/getting_started.md`

------
https://chatgpt.com/codex/tasks/task_e_688b382d8b248321991085ff175b4920