### PR TITLE
Add post-takeover WordPress scripts

### DIFF
--- a/post_takeover_wordpress.ps1
+++ b/post_takeover_wordpress.ps1
@@ -1,0 +1,52 @@
+# Attach WordPress after quick_takeover
+# Assumes quick_takeover has already launched the AI Scraping Defense stack.
+param()
+$ErrorActionPreference = 'Stop'
+Set-Location -Path $PSScriptRoot
+
+Write-Host "=== Attaching WordPress after quick_takeover ===" -ForegroundColor Cyan
+
+# Update REAL_BACKEND_HOST
+$content = Get-Content '.env'
+if ($content -match '^REAL_BACKEND_HOST=') {
+    $content = $content -replace '^REAL_BACKEND_HOST=.*', 'REAL_BACKEND_HOST=http://wordpress:80'
+    $content | Set-Content '.env'
+} else {
+    Add-Content '.env' 'REAL_BACKEND_HOST=http://wordpress:80'
+}
+
+$networkName = (docker network ls --filter name=defense_network -q | Select-Object -First 1)
+if (-not $networkName) {
+    Write-Error 'Could not locate the defense_network. Did quick_takeover run?'
+    exit 1
+}
+
+# Launch MariaDB
+if (-not (docker ps -q -f name=wordpress_db)) {
+    docker run -d --name wordpress_db `
+        --network $networkName `
+        -e MYSQL_ROOT_PASSWORD=example `
+        -e MYSQL_DATABASE=wordpress `
+        -e MYSQL_USER=wordpress `
+        -e MYSQL_PASSWORD=wordpress `
+        mariadb:10
+} else {
+    Write-Host 'wordpress_db container already running'
+}
+
+# Launch WordPress
+if (-not (docker ps -q -f name=wordpress)) {
+    docker run -d --name wordpress `
+        --network $networkName `
+        -p 8082:80 `
+        -e WORDPRESS_DB_HOST=wordpress_db:3306 `
+        -e WORDPRESS_DB_USER=wordpress `
+        -e WORDPRESS_DB_PASSWORD=wordpress `
+        -e WORDPRESS_DB_NAME=wordpress `
+        wordpress:php8.1-apache
+} else {
+    Write-Host 'wordpress container already running'
+}
+
+Write-Host 'WordPress available at http://localhost:8082'
+Write-Host 'Proxy via AI Scraping Defense at http://localhost:8080'

--- a/post_takeover_wordpress.sh
+++ b/post_takeover_wordpress.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# =============================================================================
+#  post_takeover_wordpress.sh - attach WordPress after quick_takeover
+#
+#  Assumes quick_takeover.sh has already launched the AI Scraping Defense stack
+#  on the defense_network. This script updates REAL_BACKEND_HOST and starts
+#  WordPress and MariaDB containers on that network.
+# =============================================================================
+set -e
+
+# Update REAL_BACKEND_HOST to point at the WordPress container
+if grep -q '^REAL_BACKEND_HOST=' .env; then
+  sed -i.bak 's|^REAL_BACKEND_HOST=.*|REAL_BACKEND_HOST=http://wordpress:80|' .env && rm -f .env.bak
+else
+  echo 'REAL_BACKEND_HOST=http://wordpress:80' >> .env
+fi
+
+# Determine the Docker network created by quick_takeover
+NETWORK_NAME=$(docker network ls --filter name=defense_network -q | head -n 1)
+if [ -z "$NETWORK_NAME" ]; then
+  echo "Could not locate the defense_network. Did quick_takeover run?"
+  exit 1
+fi
+
+# Launch MariaDB for WordPress
+if [ ! "$(docker ps -q -f name=wordpress_db)" ]; then
+  docker run -d --name wordpress_db \
+    --network "$NETWORK_NAME" \
+    -e MYSQL_ROOT_PASSWORD=example \
+    -e MYSQL_DATABASE=wordpress \
+    -e MYSQL_USER=wordpress \
+    -e MYSQL_PASSWORD=wordpress \
+    mariadb:10
+else
+  echo "wordpress_db container already running"
+fi
+
+# Launch the WordPress container
+if [ ! "$(docker ps -q -f name=wordpress)" ]; then
+  docker run -d --name wordpress \
+    --network "$NETWORK_NAME" \
+    -p 8082:80 \
+    -e WORDPRESS_DB_HOST=wordpress_db:3306 \
+    -e WORDPRESS_DB_USER=wordpress \
+    -e WORDPRESS_DB_PASSWORD=wordpress \
+    -e WORDPRESS_DB_NAME=wordpress \
+    wordpress:php8.1-apache
+else
+  echo "wordpress container already running"
+fi
+
+echo "WordPress available at http://localhost:8082"
+echo "Proxy via AI Scraping Defense at http://localhost:8080"


### PR DESCRIPTION
## Summary
- add shell and PowerShell helpers to launch WordPress after `quick_takeover`
- set `REAL_BACKEND_HOST=http://wordpress:80` and spin up `wordpress_db` and `wordpress` on `defense_network`

## Testing
- `pre-commit run --files post_takeover_wordpress.sh post_takeover_wordpress.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68900b1c84b083219d28cba9f1fe6a76