### PR TITLE
Add post-takeover test site scripts

### DIFF
--- a/post_takeover_test_site.ps1
+++ b/post_takeover_test_site.ps1
@@ -1,0 +1,57 @@
+# Attach simple test site after quick_takeover
+param()
+$ErrorActionPreference = 'Stop'
+Set-Location -Path $PSScriptRoot
+
+Write-Host "=== Attaching test site after quick_takeover ===" -ForegroundColor Cyan
+
+# Update REAL_BACKEND_HOST
+$content = Get-Content '.env'
+if ($content -match '^REAL_BACKEND_HOST=') {
+    $content = $content -replace '^REAL_BACKEND_HOST=.*', 'REAL_BACKEND_HOST=http://fake_website:80'
+    $content | Set-Content '.env'
+} else {
+    Add-Content '.env' 'REAL_BACKEND_HOST=http://fake_website:80'
+}
+
+$networkName = (docker network ls --filter name=defense_network -q | Select-Object -First 1)
+if (-not $networkName) {
+    Write-Error 'Could not locate the defense_network. Did quick_takeover run?'
+    exit 1
+}
+
+# Create a simple test page
+$siteDir = Join-Path (Get-Location) 'test_site'
+if (-not (Test-Path $siteDir)) {
+    New-Item -ItemType Directory -Path $siteDir | Out-Null
+}
+$htmlPath = Join-Path $siteDir 'index.html'
+if (-not (Test-Path $htmlPath)) {
+@"
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"UTF-8\">
+<title>Test Site</title>
+</head>
+<body>
+  <h1>Hello from the Test Site!</h1>
+  <p>If you see this page through the proxy, the stack is working.</p>
+</body>
+</html>
+"@ | Set-Content $htmlPath
+}
+
+# Launch nginx container
+if (-not (docker ps -q -f name=fake_website)) {
+    docker run -d --name fake_website `
+        --network $networkName `
+        -p 8081:80 `
+        -v "$siteDir:/usr/share/nginx/html:ro" `
+        nginx:alpine
+} else {
+    Write-Host 'fake_website container already running'
+}
+
+Write-Host 'Test site available at http://localhost:8081'
+Write-Host 'Proxy via AI Scraping Defense at http://localhost:8080'

--- a/post_takeover_test_site.sh
+++ b/post_takeover_test_site.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# =============================================================================
+#  post_takeover_test_site.sh - attach simple test site after quick_takeover
+#
+#  Assumes quick_takeover.sh has already launched the AI Scraping Defense stack
+#  on the defense_network. This script updates REAL_BACKEND_HOST and starts
+#  a minimal Nginx server on that network.
+# =============================================================================
+set -e
+
+# Update REAL_BACKEND_HOST to point at the fake_website container
+if grep -q '^REAL_BACKEND_HOST=' .env; then
+  sed -i.bak 's|^REAL_BACKEND_HOST=.*|REAL_BACKEND_HOST=http://fake_website:80|' .env && rm -f .env.bak
+else
+  echo 'REAL_BACKEND_HOST=http://fake_website:80' >> .env
+fi
+
+# Determine the Docker network created by quick_takeover
+NETWORK_NAME=$(docker network ls --filter name=defense_network -q | head -n 1)
+if [ -z "$NETWORK_NAME" ]; then
+  echo "Could not locate the defense_network. Did quick_takeover run?"
+  exit 1
+fi
+
+# Create a simple test page
+mkdir -p test_site
+if [ ! -f test_site/index.html ]; then
+cat > test_site/index.html <<'HTML'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Test Site</title>
+</head>
+<body>
+  <h1>Hello from the Test Site!</h1>
+  <p>If you see this page through the proxy, the stack is working.</p>
+</body>
+</html>
+HTML
+fi
+
+# Launch the test site container
+if [ ! "$(docker ps -q -f name=fake_website)" ]; then
+  docker run -d --name fake_website \
+    --network "$NETWORK_NAME" \
+    -p 8081:80 \
+    -v "$(pwd)/test_site:/usr/share/nginx/html:ro" \
+    nginx:alpine
+else
+  echo "fake_website container already running"
+fi
+
+echo "Test site available at http://localhost:8081"
+echo "Proxy via AI Scraping Defense at http://localhost:8080"


### PR DESCRIPTION
## Summary
- add shell script to attach a simple Nginx test site after `quick_takeover`
- add PowerShell equivalent

## Testing
- `pre-commit run --files post_takeover_test_site.sh post_takeover_test_site.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68903508b8f8832186e4cb3ef28d6d66