### PR TITLE
Add payment gateway tokenization and audit logging

### DIFF
--- a/docs/pay_per_crawl.md
+++ b/docs/pay_per_crawl.md
@@ -27,4 +27,8 @@ credentials from environment variables (`STRIPE_API_KEY`, `PAYPAL_API_KEY`,
 `AUTHORIZE_NET_API_KEY`, or `PAYMENT_GATEWAY_KEY`). The gateway exposes helpers for
 creating crawler accounts, charging or refunding credits, and retrieving
 balances. Credentials are never logged in full—only a short prefix is retained
-in error messages—and HTTPS endpoints are used by default.
+in error messages—and HTTPS endpoints are used by default. Card numbers are
+never stored; use `tokenize_card` to generate reusable tokens from raw numbers.
+API keys can be rotated at runtime with `rotate_api_key`, and each gateway
+operation writes to an audit log (`PAYMENT_GATEWAY_AUDIT_LOG`) with sensitive
+values redacted.

--- a/src/pay_per_crawl/__init__.py
+++ b/src/pay_per_crawl/__init__.py
@@ -1,16 +1,17 @@
 from .db import add_credit, charge, get_crawler, init_db, register_crawler
-from .pricing import PricingEngine, load_pricing
 from .payment_gateway import (
-    PaymentGateway,
-    HTTPPaymentGateway,
-    StripeGateway,
-    PayPalGateway,
-    BraintreeGateway,
-    SquareGateway,
     AdyenGateway,
     AuthorizeNetGateway,
+    BraintreeGateway,
+    HTTPPaymentGateway,
+    PaymentGateway,
+    PayPalGateway,
+    SquareGateway,
+    StripeGateway,
     get_payment_gateway,
 )
+from .pricing import PricingEngine, load_pricing
+from .tokens import tokenize_card
 
 __all__ = [
     "init_db",
@@ -29,4 +30,5 @@ __all__ = [
     "AdyenGateway",
     "AuthorizeNetGateway",
     "get_payment_gateway",
+    "tokenize_card",
 ]

--- a/src/pay_per_crawl/tokens.py
+++ b/src/pay_per_crawl/tokens.py
@@ -1,0 +1,20 @@
+"""Tokenization helpers for payment data."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Optional
+
+
+def tokenize_card(card_number: str, *, salt: Optional[str] = None) -> str:
+    """Return a SHA-256 token for ``card_number``.
+
+    Raw card numbers should never be stored. This helper hashes the
+    provided number with an optional ``salt`` to produce a consistent
+    token that can safely be stored or logged.
+    """
+    digest = hashlib.sha256()
+    if salt:
+        digest.update(salt.encode("utf-8"))
+    digest.update(card_number.encode("utf-8"))
+    return digest.hexdigest()


### PR DESCRIPTION
## Summary
- add SHA-256 tokenization helper for card numbers
- audit gateway operations with redacted logs
- allow API key rotation and token-based card charging

## Testing
- `pre-commit run --files src/pay_per_crawl/tokens.py src/pay_per_crawl/payment_gateway.py src/pay_per_crawl/__init__.py test/pay_per_crawl/test_gateway.py docs/pay_per_crawl.md`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892e300fcc88321b824d62a9a3ed98a