### PR TITLE
Potential fix for code scanning alert no. 4874: Full server-side request forgery

### DIFF
--- a/src/pay_per_crawl/proxy.py
+++ b/src/pay_per_crawl/proxy.py
@@ -68,6 +68,11 @@ async def proxy(full_path: str, request: Request):
         raise HTTPException(status_code=402, detail="Payment required")
 
     upstream = urljoin(UPSTREAM_URL.rstrip('/') + '/', full_path.lstrip('/'))
+    # Ensure the upstream URL stays within the intended host and scheme
+    parsed_upstream = urlparse(upstream)
+    parsed_base = urlparse(UPSTREAM_URL)
+    if parsed_upstream.scheme != parsed_base.scheme or parsed_upstream.netloc != parsed_base.netloc:
+        raise HTTPException(status_code=400, detail="Invalid upstream URL")
     headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
     body = await request.body()
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Potential fix for [https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/4874](https://github.com/rhamenator/ai-scraping-defense/security/code-scanning/4874)

To fix this SSRF vulnerability, we need to ensure that the constructed `upstream` URL always points to the intended upstream server and cannot be manipulated by the user to point elsewhere. The best way to do this is:

- After constructing the `upstream` URL, parse it and verify that its scheme and netloc match those of the trusted `UPSTREAM_URL`.
- If they do not match, reject the request.
- This check should be performed after `urljoin`, as `urljoin` can be tricked into producing an absolute URL if the user input starts with `//` or contains a scheme.
- This approach ensures that even if the user tries to bypass the initial validation, the outgoing request will never leave the intended upstream server.

**Required changes:**
- After constructing `upstream`, parse it and compare its scheme and netloc to those of `UPSTREAM_URL`.
- If they do not match, raise an HTTP 400 error.
- Import `urlparse` if not already imported (already present).
- No new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
