### PR TITLE
Run app as non-root user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,9 @@ ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 COPY --chown=appuser:appuser requirements.txt constraints.txt ./
 
+USER appuser
 RUN pip install --no-cache-dir -r requirements.txt -c constraints.txt && \
-    rm -rf /root/.cache/pip
+    rm -rf /home/appuser/.cache/pip
 COPY --chown=appuser:appuser src/ /app/src/
 
 # Copy the pre-built shared libraries from the builder stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,25 +39,30 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Create a dedicated non-root user
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
 RUN pip check
 
 WORKDIR /app
 
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 
-COPY requirements.txt constraints.txt ./
+COPY --chown=appuser:appuser requirements.txt constraints.txt ./
 
 RUN pip install --no-cache-dir -r requirements.txt -c constraints.txt && \
     rm -rf /root/.cache/pip
-COPY src/ /app/src/
+COPY --chown=appuser:appuser src/ /app/src/
 
 # Copy the pre-built shared libraries from the builder stage
-COPY --from=builder /build/tarpit-rs/target/release/libtarpit_rs.so /app/tarpit_rs.so
-COPY --from=builder /build/frequency-rs/target/release/libfrequency_rs.so /app/frequency_rs.so
-COPY --from=builder /build/markov-train-rs/target/release/libmarkov_train_rs.so /app/markov_train_rs.so
+COPY --chown=appuser:appuser --from=builder /build/tarpit-rs/target/release/libtarpit_rs.so /app/tarpit_rs.so
+COPY --chown=appuser:appuser --from=builder /build/frequency-rs/target/release/libfrequency_rs.so /app/frequency_rs.so
+COPY --chown=appuser:appuser --from=builder /build/markov-train-rs/target/release/libmarkov_train_rs.so /app/markov_train_rs.so
 
-COPY docker-entrypoint.sh /app/docker-entrypoint.sh
-RUN chmod +x /app/docker-entrypoint.sh
+COPY --chown=appuser:appuser docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh && \
+    chown -R appuser:appuser /app
 
-# The CMD or ENTRYPOINT to run the specific service will be provided
-# in the docker-compose.yaml or Kubernetes manifest.
+# Drop privileges and set entrypoint
+USER appuser
+ENTRYPOINT ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- add dedicated appuser user/group after installing packages
- ensure copied application files are owned by appuser
- drop root privileges and run docker-entrypoint.sh as appuser

## Testing
- `pre-commit run --files Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_68940b2036088321abaa7176a7766ee6