### PR TITLE
Validate CRS extraction paths

### DIFF
--- a/src/util/rules_fetcher.py
+++ b/src/util/rules_fetcher.py
@@ -85,12 +85,33 @@ def download_and_extract_crs(url: str, dest_dir: str) -> bool:
             f.write(response.content)
 
         try:
+            real_tmpdir = os.path.realpath(tmpdir)
             if url.endswith(".zip"):
                 with zipfile.ZipFile(archive_path) as zf:
-                    zf.extractall(tmpdir)
+                    for member in zf.infolist():
+                        target_path = os.path.realpath(
+                            os.path.join(tmpdir, member.filename)
+                        )
+                        if not target_path.startswith(real_tmpdir + os.sep):
+                            logger.error(
+                                "Archive member outside extraction directory: %s",
+                                member.filename,
+                            )
+                            return False
+                        zf.extract(member, tmpdir)
             else:
                 with tarfile.open(archive_path, "r:gz") as tf:
-                    tf.extractall(tmpdir)
+                    for member in tf.getmembers():
+                        target_path = os.path.realpath(
+                            os.path.join(tmpdir, member.name)
+                        )
+                        if not target_path.startswith(real_tmpdir + os.sep):
+                            logger.error(
+                                "Archive member outside extraction directory: %s",
+                                member.name,
+                            )
+                            return False
+                        tf.extract(member, tmpdir)
         except (tarfile.TarError, zipfile.BadZipFile) as exc:
             logger.error("Failed to extract CRS archive: %s", exc)
             return False


### PR DESCRIPTION
## Summary
- ensure CRS extraction checks each archive member stays within target directory
- add tests for CRS archive path traversal attempts

## Testing
- `pre-commit run --files src/util/rules_fetcher.py test/util/test_rules_fetcher.py`
- `python -m pytest test/util/test_rules_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6894189bef4083218d6c98af3295e6f7