### PR TITLE
Enforce explicit CORS origins in admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project provides a multi-layered, microservice-based defense system against
 - **Audit Logging:** Sensitive actions are written to a rotating `audit.log` for forensic review.
 - **RBAC Controls:** Admin endpoints verify an `ADMIN_UI_ROLE` environment variable and reject non-admin users.
 - **Model Version Metrics:** Prometheus gauge `model_version_info` exposes the running ML model version.
-- **CORS & CSP Headers:** The Admin UI sets CORS policies and a default Content-Security-Policy header.
+- **CORS & CSP Headers:** The Admin UI sets CORS policies and a default Content-Security-Policy header. `ADMIN_UI_CORS_ORIGINS` defaults to `http://localhost` and must list explicit origins; wildcard `*` is rejected when credentials are allowed.
 - **Additional Security Headers:** Nginx now sends `Referrer-Policy`, `Permissions-Policy`, and `X-Permitted-Cross-Domain-Policies` headers by default.
 
 ## Repository Structure

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,5 +32,6 @@ We may recognize your contribution publicly once the vulnerability is addressed,
 * We strive to follow secure coding practices.
 * Dependencies are periodically reviewed (consider adding automated checks like Dependabot).
 * Container images are built from trusted base images.
+* The Admin UI requires explicit CORS origins. Set `ADMIN_UI_CORS_ORIGINS` to allowed hosts (default `http://localhost`) and avoid using `*` when credentials are allowed.
 
 Thank you for helping keep the AI Scraping Defense Stack secure!

--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -122,8 +122,21 @@ def _discover_plugins() -> list[str]:
 
 
 BASE_DIR = os.path.dirname(__file__)
+
+
+def _get_allowed_origins() -> list[str]:
+    """Return a validated list of CORS origins for the Admin UI."""
+    raw = os.getenv("ADMIN_UI_CORS_ORIGINS", "http://localhost")
+    origins = [o.strip() for o in raw.split(",") if o.strip()]
+    if "*" in origins:
+        raise ValueError(
+            "ADMIN_UI_CORS_ORIGINS cannot include '*' when allow_credentials is True"
+        )
+    return origins
+
+
+allowed_origins = _get_allowed_origins()
 app = FastAPI()
-allowed_origins = os.getenv("ADMIN_UI_CORS_ORIGINS", "*").split(",")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,

--- a/test/admin_ui/test_admin_ui.py
+++ b/test/admin_ui/test_admin_ui.py
@@ -21,6 +21,12 @@ class TestAdminUIComprehensive(unittest.TestCase):
         self.client = TestClient(admin_ui.app)
         self.auth = ("admin", "testpass")
 
+    def test_reject_wildcard_cors_origin(self):
+        """Wildcard CORS origin should be rejected when credentials are allowed."""
+        with patch.dict(os.environ, {"ADMIN_UI_CORS_ORIGINS": "*"}):
+            with self.assertRaises(ValueError):
+                admin_ui._get_allowed_origins()
+
     def test_index_route_success(self):
         """Test the main dashboard page serves HTML correctly and contains key elements."""
         response = self.client.get("/", auth=self.auth)


### PR DESCRIPTION
## Summary
- default Admin UI CORS origins to `http://localhost` and reject `*` when credentials allowed
- document requirement for explicit `ADMIN_UI_CORS_ORIGINS` configuration
- test that wildcard origins are refused

## Testing
- `pre-commit run --files src/admin_ui/admin_ui.py README.md SECURITY.md`
- `pre-commit run --files test/admin_ui/test_admin_ui.py`
- `python -m pytest test/admin_ui`


------
https://chatgpt.com/codex/tasks/task_e_68941e87e570832197191de73e8b8c49