### PR TITLE
Require API key for webhook endpoint

### DIFF
--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -555,10 +555,8 @@ async def send_alert(event_data: WebhookEvent):
 @app.post("/webhook")
 async def webhook_receiver(request: Request):
     """Handle blocklist/flag actions from the escalation engine tests."""
-    if (
-        WEBHOOK_API_KEY is not None
-        and request.headers.get("X-API-Key") != WEBHOOK_API_KEY
-    ):
+    api_key = request.headers.get("X-API-Key")
+    if not WEBHOOK_API_KEY or api_key != WEBHOOK_API_KEY:
         raise HTTPException(status_code=401, detail="Unauthorized")
     payload = (
         await request.json()

--- a/test/ai_webhook/test_ai_webhook.py
+++ b/test/ai_webhook/test_ai_webhook.py
@@ -1,7 +1,9 @@
 # test/ai_webhook/test_ai_webhook.py
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from fastapi.testclient import TestClient
+
 from src.ai_service import ai_webhook
 
 
@@ -10,6 +12,9 @@ class TestAIWebhookComprehensive(unittest.TestCase):
     def setUp(self):
         """Set up the FastAPI test client and patch dependencies."""
         self.client = TestClient(ai_webhook.app)
+        self.api_key = "test-api-key"
+        ai_webhook.WEBHOOK_API_KEY = self.api_key
+        self.headers = {"X-API-Key": self.api_key}
 
         # The function is imported from shared.redis_client into the ai_webhook module.
         # Therefore, we must patch it where it is used.
@@ -23,6 +28,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
     def tearDown(self):
         """Stop all patches."""
         patch.stopall()
+        ai_webhook.WEBHOOK_API_KEY = None
 
     def test_webhook_receiver_block_ip_success(self):
         """Test a successful 'block_ip' action."""
@@ -33,7 +39,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
             "source": "escalation-engine",
         }
         self.mock_redis_client.sadd.return_value = 1
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -48,7 +54,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         """Test a successful 'allow_ip' action."""
         payload = {"action": "allow_ip", "ip": "20.0.0.2"}
         self.mock_redis_client.srem.return_value = 1
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -67,7 +73,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
             "reason": "Suspicious activity",
         }
         self.mock_redis_client.set.return_value = True
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -82,7 +88,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         """Test a successful 'unflag_ip' action."""
         payload = {"action": "unflag_ip", "ip": "40.0.0.4"}
         self.mock_redis_client.delete.return_value = 1
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -95,24 +101,40 @@ class TestAIWebhookComprehensive(unittest.TestCase):
     def test_webhook_receiver_invalid_action(self):
         """Test that an unsupported action returns a 400 error."""
         payload = {"action": "reboot_server", "ip": "1.2.3.4"}
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
         self.assertEqual(response.status_code, 400)
         self.assertIn("Invalid action", response.json()["detail"])
 
     def test_webhook_receiver_payload_missing_ip(self):
         """Test that a payload missing the 'ip' field returns a 400 error."""
         payload = {"action": "block_ip", "reason": "No IP here."}
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()["detail"], "Missing 'ip' in payload for action 'block_ip'."
         )
 
+    def test_webhook_receiver_missing_api_key(self):
+        """Request without the API key should be unauthorized."""
+        payload = {"action": "block_ip", "ip": "1.2.3.4"}
+        response = self.client.post("/webhook", json=payload)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "Unauthorized")
+
+    def test_webhook_receiver_invalid_api_key(self):
+        """Request with an incorrect API key should be unauthorized."""
+        payload = {"action": "block_ip", "ip": "1.2.3.4"}
+        response = self.client.post(
+            "/webhook", json=payload, headers={"X-API-Key": "wrong"}
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "Unauthorized")
+
     def test_webhook_receiver_redis_unavailable(self):
         """Test that a 503 error is returned if the Redis connection fails."""
         self.mock_get_redis.return_value = None
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()["detail"], "Redis service unavailable")
 
@@ -121,7 +143,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         """Test that a 500 error is returned if a Redis command fails."""
         self.mock_redis_client.sadd.side_effect = Exception("Redis command failed")
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
-        response = self.client.post("/webhook", json=payload)
+        response = self.client.post("/webhook", json=payload, headers=self.headers)
 
         self.assertEqual(response.status_code, 500)
         self.assertIn("Failed to execute action", response.json()["detail"])


### PR DESCRIPTION
## Summary
- Reject webhook requests unless `X-API-Key` matches configured `WEBHOOK_API_KEY`
- Update webhook tests to include API key handling and cover missing/invalid scenarios

## Testing
- `pre-commit run --files src/ai_service/ai_webhook.py test/ai_webhook/test_ai_webhook.py`
- `python -m pytest test/ai_webhook/test_ai_webhook.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68943cc8202c832186de2da24eb1d47c