### PR TITLE
Enforce non-default system seed in tarpit API

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,11 +54,13 @@ This page documents all environment variables consumed by the Python services. D
 | `ESCALATION_ENDPOINT` | `http://escalation_engine:8003/escalate` | URL used by Nginx Lua to send escalation data |
 | `TAR_PIT_MIN_DELAY_SEC` | `0.6` | Minimum tarpit delay |
 | `TAR_PIT_MAX_DELAY_SEC` | `1.2` | Maximum tarpit delay |
-| `SYSTEM_SEED` | `default_system_seed_value_change_me` | Seed for tarpit text generation |
+| `SYSTEM_SEED` | `default_system_seed_value_change_me` | Seed for tarpit text generation; **must be overridden** |
 | `TAR_PIT_MAX_HOPS` | `250` | Max recorded tarpit hops |
 | `TAR_PIT_HOP_WINDOW_SECONDS` | `86400` | Sliding window for hop counts |
 | `BLOCKLIST_TTL_SECONDS` | `86400` | How long IPs remain blocked |
 | `ENABLE_TARPIT_CATCH_ALL` | `true` | Send unmatched requests to the tarpit |
+
+> **Note:** `SYSTEM_SEED` must be set to a unique value. The Tarpit API raises an error if the default placeholder is used.
 
 ## Alerts and Webhooks
 

--- a/src/tarpit/tarpit_api.py
+++ b/src/tarpit/tarpit_api.py
@@ -114,6 +114,15 @@ ESCALATION_ENDPOINT = CONFIG.ESCALATION_ENDPOINT
 MIN_STREAM_DELAY_SEC = CONFIG.TAR_PIT_MIN_DELAY_SEC
 MAX_STREAM_DELAY_SEC = CONFIG.TAR_PIT_MAX_DELAY_SEC
 SYSTEM_SEED = CONFIG.SYSTEM_SEED
+DEFAULT_SYSTEM_SEED = "default_system_seed_value_change_me"
+
+if SYSTEM_SEED == DEFAULT_SYSTEM_SEED:
+    msg = (
+        "SYSTEM_SEED is set to the default placeholder. "
+        "Set a unique value via the SYSTEM_SEED environment variable."
+    )
+    logger.error(msg)
+    raise RuntimeError(msg)
 
 TAR_PIT_MAX_HOPS = CONFIG.TAR_PIT_MAX_HOPS
 TAR_PIT_HOP_WINDOW_SECONDS = CONFIG.TAR_PIT_HOP_WINDOW_SECONDS

--- a/test/tarpit/test_tarpit_api.py
+++ b/test/tarpit/test_tarpit_api.py
@@ -164,7 +164,7 @@ class TestTarpitAPIComprehensive(unittest.IsolatedAsyncioTestCase):
         """Importing with the placeholder seed should raise an error."""
         code = (
             "import os\n"
-            "os.environ['SYSTEM_SEED']='default_system_seed_value_change_me'\n"
+            f"os.environ['SYSTEM_SEED']={repr(DEFAULT_SYSTEM_SEED)}\n"
             "import src.tarpit.tarpit_api\n"
         )
         env = {

--- a/test/tarpit/test_tarpit_api.py
+++ b/test/tarpit/test_tarpit_api.py
@@ -8,8 +8,6 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import httpx
 from fastapi.testclient import TestClient
 
-os.environ.setdefault("SYSTEM_SEED", "unit_test_seed")
-
 from src.tarpit.tarpit_api import app
 
 

--- a/test/tarpit/test_tarpit_api.py
+++ b/test/tarpit/test_tarpit_api.py
@@ -1,8 +1,14 @@
 # test/tarpit/tarpit_api.test.py
+import os
+import subprocess
+import sys
 import unittest
-from unittest.mock import patch, MagicMock, AsyncMock, ANY
-from fastapi.testclient import TestClient
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
 import httpx
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SYSTEM_SEED", "unit_test_seed")
 
 from src.tarpit.tarpit_api import app
 
@@ -155,6 +161,23 @@ class TestTarpitAPIComprehensive(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["status"], "error")
         self.assertTrue(data["redis_hops_connected"])
         self.assertFalse(data["redis_blocklist_connected"])
+
+    def test_import_fails_with_default_seed(self):
+        """Importing with the placeholder seed should raise an error."""
+        code = (
+            "import os\n"
+            "os.environ['SYSTEM_SEED']='default_system_seed_value_change_me'\n"
+            "import src.tarpit.tarpit_api\n"
+        )
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.getcwd() + os.pathsep + os.environ.get("PYTHONPATH", ""),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, env=env
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("SYSTEM_SEED", result.stderr.decode())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- error when `SYSTEM_SEED` uses placeholder value
- document `SYSTEM_SEED` requirement
- test for default `SYSTEM_SEED` and set non-default in tests

## Testing
- `pre-commit run --files src/tarpit/tarpit_api.py docs/configuration.md test/tarpit/test_tarpit_api.py`
- `SYSTEM_SEED=test_seed python -m pytest test/tarpit/test_tarpit_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6894539dae848321bf406e5b1733e111