### PR TITLE
Enforce HTTPS for DDoS provider URL

### DIFF
--- a/src/util/ddos_protection.py
+++ b/src/util/ddos_protection.py
@@ -39,22 +39,28 @@ async def report_attack(
         return False
 
     if DDOS_PROTECTION_PROVIDER_URL and DDOS_PROTECTION_API_KEY:
-        headers = {"Authorization": f"Bearer {DDOS_PROTECTION_API_KEY}"}
-        payload = {"ip": ip}
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.post(
-                    DDOS_PROTECTION_PROVIDER_URL,
-                    headers=headers,
-                    json=payload,
-                    timeout=10.0,
-                )
-                resp.raise_for_status()
-            logger.info(f"Reported IP {ip} to external DDoS provider.")
-            return True
-        except Exception as e:  # pragma: no cover - network/HTTP errors
-            logger.error(f"Failed to report IP {ip} to DDoS provider: {e}")
-            return False
+        if not DDOS_PROTECTION_PROVIDER_URL.startswith("https://"):
+            logger.error(
+                "DDOS_PROTECTION_PROVIDER_URL must start with 'https://'; "
+                "skipping external reporting"
+            )
+        else:
+            headers = {"Authorization": f"Bearer {DDOS_PROTECTION_API_KEY}"}
+            payload = {"ip": ip}
+            try:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.post(
+                        DDOS_PROTECTION_PROVIDER_URL,
+                        headers=headers,
+                        json=payload,
+                        timeout=10.0,
+                    )
+                    resp.raise_for_status()
+                logger.info(f"Reported IP {ip} to external DDoS provider.")
+                return True
+            except Exception as e:  # pragma: no cover - network/HTTP errors
+                logger.error(f"Failed to report IP {ip} to DDoS provider: {e}")
+                return False
 
     # Fall back to local escalation engine
     if metadata is None:

--- a/test/util/test_ddos_protection.py
+++ b/test/util/test_ddos_protection.py
@@ -1,0 +1,64 @@
+import importlib
+import logging
+from typing import List
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_report_attack_valid_url(monkeypatch, caplog):
+    provider_url = "https://provider.example/report"
+    internal_url = "http://internal.example/report"
+
+    monkeypatch.setenv("ENABLE_DDOS_PROTECTION", "true")
+    monkeypatch.setenv("DDOS_PROTECTION_PROVIDER_URL", provider_url)
+    monkeypatch.setenv("DDOS_PROTECTION_API_KEY", "api-key")
+    monkeypatch.setenv("DDOS_INTERNAL_ENDPOINT", internal_url)
+
+    from src.util import ddos_protection
+
+    importlib.reload(ddos_protection)
+
+    called_urls: List[str] = []
+
+    async def mock_post(self, url, *args, **kwargs):
+        called_urls.append(url)
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+
+    result = await ddos_protection.report_attack("1.2.3.4")
+
+    assert result is True
+    assert called_urls == [provider_url]
+
+
+@pytest.mark.asyncio
+async def test_report_attack_invalid_url(monkeypatch, caplog):
+    provider_url = "http://provider.example/report"
+    internal_url = "http://internal.example/report"
+
+    monkeypatch.setenv("ENABLE_DDOS_PROTECTION", "true")
+    monkeypatch.setenv("DDOS_PROTECTION_PROVIDER_URL", provider_url)
+    monkeypatch.setenv("DDOS_PROTECTION_API_KEY", "api-key")
+    monkeypatch.setenv("DDOS_INTERNAL_ENDPOINT", internal_url)
+
+    from src.util import ddos_protection
+
+    importlib.reload(ddos_protection)
+
+    called_urls: List[str] = []
+
+    async def mock_post(self, url, *args, **kwargs):
+        called_urls.append(url)
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+
+    with caplog.at_level(logging.ERROR):
+        result = await ddos_protection.report_attack("1.2.3.4")
+
+    assert result is True
+    assert called_urls == [internal_url]
+    assert "must start with 'https://'" in caplog.text


### PR DESCRIPTION
## Summary
- require DDOS_PROTECTION_PROVIDER_URL to use HTTPS before external reporting
- add tests for valid and invalid provider URL behavior

## Testing
- `pre-commit run --files src/util/ddos_protection.py test/util/test_ddos_protection.py`
- `python -m pytest test/util/test_ddos_protection.py`


------
https://chatgpt.com/codex/tasks/task_e_68945961d2c08321bf5a832a819cc2c3