### PR TITLE
Securely handle postgres password in entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,8 @@ MODEL_FILE="${MODEL_PATH:-/app/models/bot_detection_rf_model.joblib}"
 # Ensures the database is ready before any application logic runs.
 echo "Waiting for postgres..."
 # The password file is used securely without exporting the password.
-while ! PGPASSWORD=$(cat "$PG_PASSWORD_FILE") pg_isready -h "$PG_HOST" -p 5432 -q -U "$PG_USER"; do
+PGPASSWORD_VALUE=$(cat "$PG_PASSWORD_FILE")
+while ! PGPASSWORD="$PGPASSWORD_VALUE" pg_isready -h "$PG_HOST" -p 5432 -q -U "$PG_USER"; do
   echo "PostgreSQL is unavailable - sleeping"
   sleep 2
 done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,4 +36,4 @@ fi
 
 # Execute the main command passed to the container (e.g., uvicorn, gunicorn).
 echo "Launching main command: $@"
-PGPASSWORD=$(cat "$PG_PASSWORD_FILE") exec "$@"
+PGPASSWORD="$PGPASSWORD_VALUE" exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,7 +28,7 @@ if [ "$RUN_MODEL_TRAINING" == "true" ] && [ ! -f "$MODEL_FILE" ]; then
   # Ensure the target directory exists.
   mkdir -p /app/models
   # Run the training script from its new location in src/
-  PGPASSWORD=$(cat "$PG_PASSWORD_FILE") python src/rag/training.py
+  PGPASSWORD="$PGPASSWORD" python src/rag/training.py
   echo "Training complete. Model saved to $MODEL_FILE"
 else
   echo "Skipping bot detection model training."


### PR DESCRIPTION
## Summary
- avoid exporting PostgreSQL password globally in entrypoint
- pass password inline to commands that require database access

## Testing
- `pre-commit run --files docker-entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_689474ea9adc83219c6b4977b972f3f7