### PR TITLE
Verify security tool downloads

### DIFF
--- a/security_setup.sh
+++ b/security_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 python -m pip install --upgrade pip
 pip install -r requirements.txt
@@ -8,15 +8,47 @@ pip install -r requirements.txt
 apt-get update
 apt-get install -y \
     nmap nikto zaproxy sqlmap lynis hydra masscan gobuster enum4linux \
-    wpscan ffuf wfuzz testssl.sh whatweb gvm rkhunter chkrootkit clamav
+    wpscan ffuf wfuzz testssl.sh whatweb gvm rkhunter chkrootkit clamav jq
 
-# Additional tools from GitHub
-curl -L https://github.com/aquasecurity/trivy/releases/latest/download/trivy_0.50.1_Linux-64bit.tar.gz \
-  | tar -xz -C /usr/local/bin --strip-components=1 trivy
-curl -L https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks-linux-amd64 \
-  -o /usr/local/bin/gitleaks && chmod +x /usr/local/bin/gitleaks
-curl -L https://github.com/anchore/grype/releases/latest/download/grype_linux_amd64.tar.gz \
-  | tar -xz -C /usr/local/bin grype
+# Additional tools from GitHub with checksum verification
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Trivy
+TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest \
+  | jq -r '.tag_name' | sed 's/^v//')
+TRIVY_TAR="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+curl -fsSL -o "$TMP_DIR/$TRIVY_TAR" \
+  "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/$TRIVY_TAR"
+curl -fsSL -o "$TMP_DIR/trivy_checksums.txt" \
+  "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
+(cd "$TMP_DIR" && grep "$TRIVY_TAR" trivy_checksums.txt | sha256sum -c -)
+tar -xz -C /usr/local/bin -f "$TMP_DIR/$TRIVY_TAR" trivy
+rm "$TMP_DIR/$TRIVY_TAR" "$TMP_DIR/trivy_checksums.txt"
+
+# Gitleaks
+GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+  | jq -r '.tag_name' | sed 's/^v//')
+GITLEAKS_TAR="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+curl -fsSL -o "$TMP_DIR/$GITLEAKS_TAR" \
+  "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/$GITLEAKS_TAR"
+curl -fsSL -o "$TMP_DIR/gitleaks_checksums.txt" \
+  "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+(cd "$TMP_DIR" && grep "$GITLEAKS_TAR" gitleaks_checksums.txt | sha256sum -c -)
+tar -xz -C /usr/local/bin -f "$TMP_DIR/$GITLEAKS_TAR" gitleaks
+rm "$TMP_DIR/$GITLEAKS_TAR" "$TMP_DIR/gitleaks_checksums.txt"
+
+# Grype
+GRYPE_VERSION=$(curl -s https://api.github.com/repos/anchore/grype/releases/latest \
+  | jq -r '.tag_name' | sed 's/^v//')
+GRYPE_TAR="grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+curl -fsSL -o "$TMP_DIR/$GRYPE_TAR" \
+  "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/$GRYPE_TAR"
+curl -fsSL -o "$TMP_DIR/grype_checksums.txt" \
+  "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
+(cd "$TMP_DIR" && grep "$GRYPE_TAR" grype_checksums.txt | sha256sum -c -)
+tar -xz -C /usr/local/bin -f "$TMP_DIR/$GRYPE_TAR" grype
+rm "$TMP_DIR/$GRYPE_TAR" "$TMP_DIR/grype_checksums.txt"
 
 pip install bandit sslyze sublist3r pip-audit
 apt-get clean


### PR DESCRIPTION
## Summary
- validate Trivy, Gitleaks, and Grype against published checksums before installation
- fail fast with strict bash options and cleanup

## Testing
- `python -m pre_commit run --files security_setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6894787375dc8321bc33b83446c53058