### PR TITLE
Validate webhook URL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,8 @@ This page documents all environment variables consumed by the Python services. D
 | --- | --- | --- |
 | `ESCALATION_THRESHOLD` | `0.8` | Score needed to block a request |
 | `ESCALATION_API_KEY` | *(none)* | Key required for Escalation Engine API |
-| `ESCALATION_WEBHOOK_URL` | *(none)* | Webhook destination for escalations |
+| `ESCALATION_WEBHOOK_URL` | *(none)* | HTTPS endpoint for escalations; must start with `https://` |
+| `ESCALATION_WEBHOOK_ALLOWED_DOMAINS` | *(none)* | Comma-separated list of approved webhook domains |
 | `LOCAL_LLM_API_URL` | *(none)* | URL of local LLM API |
 | `LOCAL_LLM_MODEL` | *(none)* | Model name for local LLM API |
 | `LOCAL_LLM_TIMEOUT` | `45.0` | Timeout in seconds for local LLM |

--- a/sample.env
+++ b/sample.env
@@ -222,6 +222,8 @@ ESCALATION_THRESHOLD=0.8
 # API key required to access escalation engine endpoints
 ESCALATION_API_KEY=
 ESCALATION_WEBHOOK_URL=
+# Comma-separated domains allowed for webhook URL
+ESCALATION_WEBHOOK_ALLOWED_DOMAINS=
 # --- Cybersecurity Partnerships ---
 PARTNER_THREAT_FEED_URL=
 PARTNER_THREAT_FEED_API_KEY=

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 def get_secret(file_variable_name: str) -> Optional[str]:
@@ -205,6 +205,13 @@ class Config:
     )
     ESCALATION_WEBHOOK_URL: Optional[str] = field(
         default_factory=lambda: os.getenv("ESCALATION_WEBHOOK_URL")
+    )
+    ESCALATION_WEBHOOK_ALLOWED_DOMAINS: List[str] = field(
+        default_factory=lambda: [
+            d.strip()
+            for d in os.getenv("ESCALATION_WEBHOOK_ALLOWED_DOMAINS", "").split(",")
+            if d.strip()
+        ]
     )
     LOCAL_LLM_API_URL: Optional[str] = field(
         default_factory=lambda: os.getenv("LOCAL_LLM_API_URL")


### PR DESCRIPTION
## Summary
- ensure escalation webhook URLs use HTTPS and optionally match approved domains
- document webhook domain restrictions in configuration docs

## Testing
- `pre-commit run --files src/shared/config.py src/escalation/escalation_engine.py`
- `pre-commit run --files docs/configuration.md sample.env`
- `python -m pytest` *(fails: SYSTEM_SEED is set to the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68948075d8448321bbbba7b2886ee6ee