### PR TITLE
Require HTTPS for rules fetcher

### DIFF
--- a/docs/waf_setup.md
+++ b/docs/waf_setup.md
@@ -8,6 +8,8 @@ This project supports an optional ModSecurity-based Web Application Firewall (WA
 2. Extract `crs-setup.conf` and the `rules` folder into the repository's `waf/` directory.
 3. Optionally add custom ModSecurity rules in the same folder.
 
+Alternatively, you can provide a `RULES_DOWNLOAD_URL` environment variable to fetch a remote rules file at startup. The URL must begin with `https://`. To restrict which hosts can be used, set `RULES_ALLOWED_DOMAINS` to a comma-separated list of permitted domains.
+
 ## Enabling with Docker Compose
 
 1. Edit `.env` and set:

--- a/sample.env
+++ b/sample.env
@@ -186,6 +186,10 @@ TLS_KEY_PATH=./nginx/certs/tls.key
 
 ENABLE_WAF=true
 WAF_RULES_PATH=/etc/nginx/waf_rules.conf
+# URL to download custom WAF rules (must use HTTPS)
+RULES_DOWNLOAD_URL=https://example.com/custom.rules
+# Optional comma-separated list of allowed domains for rule downloads
+RULES_ALLOWED_DOMAINS=example.com
 
 # --- Adaptive Rate Limiting ---
 BASE_RATE_LIMIT=60

--- a/sample.env.min
+++ b/sample.env.min
@@ -34,6 +34,10 @@ WATCHTOWER_INTERVAL=60
 # Backend targets
 REAL_BACKEND_HOSTS=http://localhost:8082
 REAL_BACKEND_HOST=http://localhost:8082
+# URL to download custom WAF rules (must use HTTPS)
+RULES_DOWNLOAD_URL=https://example.com/custom.rules
+# Optional comma-separated list of allowed domains for rule downloads
+RULES_ALLOWED_DOMAINS=example.com
 
 # SMTP alert credentials
 ALERT_SMTP_PASSWORD_FILE=/run/secrets/smtp_password.txt


### PR DESCRIPTION
## Summary
- enforce HTTPS for rule downloads and optionally restrict allowed hosts
- document new rule download environment variables
- test rule fetching validations

## Testing
- `pre-commit run --files src/util/rules_fetcher.py test/util/test_rules_fetcher.py sample.env sample.env.min docs/waf_setup.md`
- `SYSTEM_SEED=testing python -m pytest` *(fails: NameError and async errors)*
- `SYSTEM_SEED=testing python -m pytest test/util/test_rules_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_689484b301c88321a0797412ec5b98ef