### PR TITLE
Strip control chars from headers

### DIFF
--- a/src/tarpit/tarpit_api.py
+++ b/src/tarpit/tarpit_api.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import os
 import random
+import re
 import sys
 from typing import Dict
 
@@ -194,7 +195,8 @@ def sanitize_headers(headers: Dict[str, str]) -> Dict[str, str]:
     for k, v in headers.items():
         if k.lower() in SENSITIVE_HEADERS:
             continue
-        sanitized[k] = str(v).replace("\n", " ").replace("\r", " ")
+        cleaned = re.sub(r"[\x00-\x1f\x7f]", "", str(v))
+        sanitized[k] = cleaned
     return sanitized
 
 

--- a/test/tarpit/__init__.py
+++ b/test/tarpit/__init__.py
@@ -1,12 +1,15 @@
 # Ensure tests import modules from the real tarpit package under ``src``.
+import os
+
+os.environ.setdefault("SYSTEM_SEED", "test-seed")
 from src.tarpit import (
+    bad_api_generator,
     ip_flagger,
     js_zip_generator,
     markov_generator,
-    rotating_archive,
     obfuscation,
+    rotating_archive,
     tarpit_api,
-    bad_api_generator,
 )
 
 __all__ = [

--- a/test/tarpit/test_sanitize_headers.py
+++ b/test/tarpit/test_sanitize_headers.py
@@ -1,5 +1,7 @@
+import os
 import unittest
 
+os.environ.setdefault("SYSTEM_SEED", "test-seed")
 from src.tarpit import tarpit_api
 
 
@@ -15,7 +17,7 @@ class TestSanitizeHeaders(unittest.TestCase):
         result = tarpit_api.sanitize_headers(headers)
         self.assertIn("User-Agent", result)
         self.assertIn("X-Custom", result)
-        self.assertEqual(result["multiline"], "line1 line2 line3")
+        self.assertEqual(result["multiline"], "line1line2line3")
         self.assertNotIn("Authorization", result)
         self.assertNotIn("Cookie", result)
 

--- a/test/tarpit/test_tarpit_api.py
+++ b/test/tarpit/test_tarpit_api.py
@@ -8,7 +8,8 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import httpx
 from fastapi.testclient import TestClient
 
-from src.tarpit.tarpit_api import DEFAULT_SYSTEM_SEED, app
+os.environ.setdefault("SYSTEM_SEED", "test-seed")
+from src.tarpit.tarpit_api import DEFAULT_SYSTEM_SEED, app, sanitize_headers
 
 
 class TestTarpitAPIComprehensive(unittest.IsolatedAsyncioTestCase):
@@ -159,6 +160,11 @@ class TestTarpitAPIComprehensive(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["status"], "error")
         self.assertTrue(data["redis_hops_connected"])
         self.assertFalse(data["redis_blocklist_connected"])
+
+    def test_sanitize_headers_removes_control_chars(self):
+        headers = {"X-Test": "va\tlu\ne\rwith\x0bcontrols"}
+        result = sanitize_headers(headers)
+        self.assertEqual(result["X-Test"], "valuewithcontrols")
 
     def test_import_fails_with_default_seed(self):
         """Importing with the placeholder seed should raise an error."""


### PR DESCRIPTION
## Summary
- sanitize headers by removing all ASCII control characters
- test header sanitization against control characters

## Testing
- `pre-commit run --files src/tarpit/tarpit_api.py test/tarpit/test_sanitize_headers.py test/tarpit/test_tarpit_api.py test/tarpit/__init__.py`
- `python -m pytest test/tarpit/test_sanitize_headers.py test/tarpit/test_tarpit_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68958cfc3ec48321a7811ebf90470d2c