### PR TITLE
Add auth and rate limiting to prompt router

### DIFF
--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -1,10 +1,11 @@
 import asyncio
+import hmac
 import os
 import re
 import time
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 
 LOCAL_LLM_URL = os.getenv("LOCAL_LLM_URL", "http://llama3:11434/api/generate")
 CLOUD_PROXY_URL = os.getenv("CLOUD_PROXY_URL", "http://cloud_proxy:8008/api/chat")
@@ -15,6 +16,11 @@ if not SHARED_SECRET:
     raise RuntimeError("SHARED_SECRET environment variable is required")
 RATE_LIMIT_REQUESTS = int(os.getenv("RATE_LIMIT_REQUESTS", "60"))
 RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))
+TRUST_PROXY_HEADERS = os.getenv("TRUST_PROXY_HEADERS", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 _request_counts: dict[str, tuple[int, float]] = {}
 _rate_lock = asyncio.Lock()
@@ -34,37 +40,63 @@ async def health() -> dict[str, str]:
 
 
 def get_client_ip(request: Request) -> str:
-    x_forwarded_for = request.headers.get("X-Forwarded-For")
-    if x_forwarded_for:
-        return x_forwarded_for.split(",")[0].strip()
-    x_real_ip = request.headers.get("X-Real-IP")
-    if x_real_ip:
-        return x_real_ip
+    if TRUST_PROXY_HEADERS:
+        x_forwarded_for = request.headers.get("X-Forwarded-For")
+        if x_forwarded_for:
+            return x_forwarded_for.split(",")[0].strip()
+        x_real_ip = request.headers.get("X-Real-IP")
+        if x_real_ip:
+            return x_real_ip
     return request.client.host if request.client else "unknown"
 
 
+def calculate_window_reset(now: float, window: int = RATE_LIMIT_WINDOW) -> int:
+    return int(now // window * window + window)
+
+
 def _cleanup_expired_requests(now: float) -> None:
+    """Remove expired rate-limit entries.
+
+    Caller must hold ``_rate_lock``.
+    """
     expired = [ip for ip, (_, reset) in _request_counts.items() if now > reset]
     for ip in expired:
         del _request_counts[ip]
 
 
 @app.post("/route")
-async def route_prompt(request: Request) -> dict:
+async def route_prompt(request: Request, response: Response) -> dict:
     auth_header = request.headers.get("Authorization", "")
-    if auth_header != f"Bearer {SHARED_SECRET}":
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    token = auth_header.split(" ", 1)[1]
+    if not hmac.compare_digest(token, SHARED_SECRET):
         raise HTTPException(status_code=401, detail="Unauthorized")
     client_ip = get_client_ip(request)
     now = time.time()
-    window_reset = int(now // RATE_LIMIT_WINDOW * RATE_LIMIT_WINDOW + RATE_LIMIT_WINDOW)
+    window_reset = calculate_window_reset(now)
     async with _rate_lock:
         _cleanup_expired_requests(now)
         count, reset = _request_counts.get(client_ip, (0, window_reset))
         if now > reset:
             count, reset = 0, window_reset
         if count + 1 > RATE_LIMIT_REQUESTS:
-            raise HTTPException(status_code=429, detail="Too Many Requests")
+            retry_after = int(reset - now)
+            headers = {
+                "X-RateLimit-Limit": str(RATE_LIMIT_REQUESTS),
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(int(reset)),
+                "Retry-After": str(retry_after),
+            }
+            raise HTTPException(
+                status_code=429, detail="Too Many Requests", headers=headers
+            )
         _request_counts[client_ip] = (count + 1, reset)
+        remaining = RATE_LIMIT_REQUESTS - (count + 1)
+
+    response.headers["X-RateLimit-Limit"] = str(RATE_LIMIT_REQUESTS)
+    response.headers["X-RateLimit-Remaining"] = str(remaining)
+    response.headers["X-RateLimit-Reset"] = str(int(reset))
 
     payload = await request.json()
     prompt = payload.get("prompt", "")

--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -1,5 +1,8 @@
+import asyncio
 import os
 import re
+import time
+
 import httpx
 from fastapi import FastAPI, HTTPException, Request
 
@@ -7,12 +10,21 @@ LOCAL_LLM_URL = os.getenv("LOCAL_LLM_URL", "http://llama3:11434/api/generate")
 CLOUD_PROXY_URL = os.getenv("CLOUD_PROXY_URL", "http://cloud_proxy:8008/api/chat")
 MAX_LOCAL_TOKENS = int(os.getenv("MAX_LOCAL_TOKENS", "1000"))
 TOKEN_PATTERN = re.compile(r"\w+|[^\w\s]")
+SHARED_SECRET = os.getenv("SHARED_SECRET", "")
+RATE_LIMIT_REQUESTS = int(os.getenv("RATE_LIMIT_REQUESTS", "60"))
+RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))
+
+_request_counts: dict[str, tuple[int, float]] = {}
+_rate_lock = asyncio.Lock()
+
 
 def count_tokens(text: str) -> int:
     """Approximate the number of tokens in ``text`` using a simple heuristic."""
     return len(TOKEN_PATTERN.findall(text))
 
+
 app = FastAPI()
+
 
 @app.get("/health")
 async def health() -> dict[str, str]:
@@ -21,6 +33,20 @@ async def health() -> dict[str, str]:
 
 @app.post("/route")
 async def route_prompt(request: Request) -> dict:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header != f"Bearer {SHARED_SECRET}":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    client_ip = request.client.host if request.client else "unknown"
+    now = time.time()
+    async with _rate_lock:
+        count, reset = _request_counts.get(client_ip, (0, now + RATE_LIMIT_WINDOW))
+        if now > reset:
+            count, reset = 0, now + RATE_LIMIT_WINDOW
+        if count + 1 > RATE_LIMIT_REQUESTS:
+            raise HTTPException(status_code=429, detail="Too Many Requests")
+        _request_counts[client_ip] = (count + 1, reset)
+
     payload = await request.json()
     prompt = payload.get("prompt", "")
     prompt_tokens = count_tokens(prompt)

--- a/test/prompt_router/test_prompt_router.py
+++ b/test/prompt_router/test_prompt_router.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import sys
+import time
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -117,6 +118,147 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.json(), {"route": "cloud"})
         client_inst = DummyClient.instances[-1]
         self.assertIn("http://cloud", [c[0] for c in client_inst.post_calls])
+
+
+class TestAuthAndRateLimit(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.env = patch.dict(
+            os.environ,
+            {
+                "MAX_LOCAL_TOKENS": "10",
+                "LOCAL_LLM_URL": "http://local",
+                "CLOUD_PROXY_URL": "http://cloud",
+                "SHARED_SECRET": "secret",
+                "RATE_LIMIT_REQUESTS": "2",
+                "RATE_LIMIT_WINDOW": "10",
+            },
+        )
+        self.env.start()
+        spec.loader.exec_module(pr_module)
+        global app
+        app = pr_module.app
+
+    def tearDown(self):
+        self.env.stop()
+
+    async def _post(self, headers=None, json=None):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"ok": True}
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+
+        async_client = AsyncMock()
+        async_client.__aenter__.return_value = async_client
+        async_client.post.return_value = mock_resp
+
+        with patch.object(pr_module, "httpx") as httpx_mod:
+            httpx_mod.AsyncClient.return_value = async_client
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as ac:
+                return await ac.post(
+                    "/route", json=json or {"prompt": "hi"}, headers=headers or {}
+                )
+
+    async def test_missing_auth_returns_401(self):
+        resp = await self._post()
+        self.assertEqual(resp.status_code, 401)
+
+    async def test_rate_limit_headers_and_429(self):
+        headers = {"Authorization": "Bearer secret"}
+        resp1 = await self._post(headers=headers)
+        self.assertEqual(resp1.status_code, 200)
+        self.assertEqual(resp1.headers["X-RateLimit-Limit"], "2")
+        self.assertEqual(resp1.headers["X-RateLimit-Remaining"], "1")
+        resp2 = await self._post(headers=headers)
+        self.assertEqual(resp2.status_code, 200)
+        resp3 = await self._post(headers=headers)
+        self.assertEqual(resp3.status_code, 429)
+        self.assertEqual(resp3.headers["X-RateLimit-Remaining"], "0")
+        self.assertIn("Retry-After", resp3.headers)
+
+    async def test_window_rollover_resets_counter(self):
+        headers = {"Authorization": "Bearer secret"}
+        real_time = time.time
+
+        class FakeTime:
+            def __init__(self, values):
+                self.values = iter(values)
+
+            def time(self):
+                try:
+                    return next(self.values)
+                except StopIteration:
+                    return real_time()
+
+        with patch.object(pr_module, "time", FakeTime([0, 11])):
+            resp1 = await self._post(headers=headers)
+            self.assertEqual(resp1.status_code, 200)
+            resp2 = await self._post(headers=headers)
+            self.assertEqual(resp2.status_code, 200)
+
+    async def test_proxy_headers_ignored_by_default(self):
+        with patch.dict(os.environ, {"RATE_LIMIT_REQUESTS": "1"}):
+            spec.loader.exec_module(pr_module)
+            global app
+            app = pr_module.app
+            headers1 = {"Authorization": "Bearer secret", "X-Forwarded-For": "1.1.1.1"}
+            resp1 = await self._post(headers=headers1)
+            self.assertEqual(resp1.status_code, 200)
+            headers2 = {"Authorization": "Bearer secret", "X-Forwarded-For": "2.2.2.2"}
+            resp2 = await self._post(headers=headers2)
+            self.assertEqual(resp2.status_code, 429)
+
+    async def test_proxy_headers_used_when_trusted(self):
+        with patch.dict(
+            os.environ, {"TRUST_PROXY_HEADERS": "true", "RATE_LIMIT_REQUESTS": "1"}
+        ):
+            spec.loader.exec_module(pr_module)
+            global app
+            app = pr_module.app
+            resp1 = await self._post(
+                headers={"Authorization": "Bearer secret", "X-Forwarded-For": "1.1.1.1"}
+            )
+            resp2 = await self._post(
+                headers={"Authorization": "Bearer secret", "X-Forwarded-For": "2.2.2.2"}
+            )
+        self.assertEqual(resp1.status_code, 200)
+        self.assertEqual(resp2.status_code, 200)
+
+    async def test_cleanup_removes_old_ips(self):
+        with patch.dict(
+            os.environ, {"TRUST_PROXY_HEADERS": "true", "RATE_LIMIT_REQUESTS": "1"}
+        ):
+            spec.loader.exec_module(pr_module)
+            global app
+            app = pr_module.app
+            real_time = time.time
+
+            class FakeTime:
+                def __init__(self, values):
+                    self.values = iter(values)
+
+                def time(self):
+                    try:
+                        return next(self.values)
+                    except StopIteration:
+                        return real_time()
+
+            with patch.object(pr_module, "time", FakeTime([0, 11])):
+                await self._post(
+                    headers={
+                        "Authorization": "Bearer secret",
+                        "X-Forwarded-For": "1.1.1.1",
+                    }
+                )
+                await self._post(
+                    headers={
+                        "Authorization": "Bearer secret",
+                        "X-Forwarded-For": "2.2.2.2",
+                    }
+                )
+        self.assertNotIn("1.1.1.1", pr_module._request_counts)
 
 
 if __name__ == "__main__":

--- a/test/prompt_router/test_prompt_router.py
+++ b/test/prompt_router/test_prompt_router.py
@@ -10,6 +10,7 @@ import httpx
 MODULE_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "prompt-router", "main.py")
 )
+os.environ["SHARED_SECRET"] = "secret"
 spec = importlib.util.spec_from_file_location("prompt_router.main", MODULE_PATH)
 pr_module = importlib.util.module_from_spec(spec)
 sys.modules["prompt_router.main"] = pr_module
@@ -26,6 +27,7 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
                 "MAX_LOCAL_TOKENS": "10",
                 "LOCAL_LLM_URL": "http://local",
                 "CLOUD_PROXY_URL": "http://cloud",
+                "SHARED_SECRET": "secret",
             },
         )
         self.env.start()
@@ -66,7 +68,11 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
             ) as ac:
-                resp = await ac.post("/route", json={"prompt": "short"})
+                resp = await ac.post(
+                    "/route",
+                    json={"prompt": "short"},
+                    headers={"Authorization": "Bearer secret"},
+                )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"route": "local"})
         client_inst = DummyClient.instances[-1]
@@ -102,7 +108,11 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
                 transport=transport, base_url="http://test"
             ) as ac:
                 long_prompt = " ".join(["x"] * 20)
-                resp = await ac.post("/route", json={"prompt": long_prompt})
+                resp = await ac.post(
+                    "/route",
+                    json={"prompt": long_prompt},
+                    headers={"Authorization": "Bearer secret"},
+                )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"route": "cloud"})
         client_inst = DummyClient.instances[-1]


### PR DESCRIPTION
## Summary
- require a shared secret in Authorization header
- add simple in-memory IP rate limiting

## Testing
- `pre-commit run --files prompt-router/main.py`
- `python -m pytest prompt-router`

------
https://chatgpt.com/codex/tasks/task_e_6895a51fe0a08321874a8bd0c0c60714