### PR TITLE
Require proxy key for chat endpoint

### DIFF
--- a/cloud-proxy/main.py
+++ b/cloud-proxy/main.py
@@ -21,7 +21,7 @@ async def proxy_chat(payload: dict, x_proxy_key: str | None = Header(None)) -> d
         raise HTTPException(status_code=500, detail="API key not configured")
     if not PROXY_KEY:
         raise HTTPException(status_code=500, detail="Proxy key not configured")
-    if x_proxy_key != PROXY_KEY:
+    if not secrets.compare_digest(x_proxy_key or "", PROXY_KEY or ""):
         raise HTTPException(status_code=401, detail="Invalid proxy key")
     headers = {"Authorization": f"Bearer {API_KEY}"}
     try:

--- a/cloud-proxy/main.py
+++ b/cloud-proxy/main.py
@@ -1,28 +1,39 @@
 import os
+
 import httpx
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Header, HTTPException
 
 API_KEY = os.getenv("OPENAI_API_KEY")
 LLM_URL = os.getenv("CLOUD_LLM_API_URL", "https://api.openai.com/v1/chat/completions")
+PROXY_KEY = os.getenv("PROXY_KEY")
 
 app = FastAPI()
+
 
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
 
+
 @app.post("/api/chat")
-async def proxy_chat(payload: dict) -> dict:
+async def proxy_chat(payload: dict, x_proxy_key: str | None = Header(None)) -> dict:
     if not API_KEY:
         raise HTTPException(status_code=500, detail="API key not configured")
+    if not PROXY_KEY:
+        raise HTTPException(status_code=500, detail="Proxy key not configured")
+    if x_proxy_key != PROXY_KEY:
+        raise HTTPException(status_code=401, detail="Invalid proxy key")
     headers = {"Authorization": f"Bearer {API_KEY}"}
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.post(LLM_URL, json=payload, headers=headers, timeout=60)
+            response = await client.post(
+                LLM_URL, json=payload, headers=headers, timeout=60
+            )
             response.raise_for_status()
             return response.json()
     except httpx.HTTPError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/docs/prompt_router.md
+++ b/docs/prompt_router.md
@@ -15,6 +15,7 @@ Set the following variables in `.env`:
 
 - `PROMPT_ROUTER_HOST` – hostname or container name running the router.
 - `PROMPT_ROUTER_PORT` – port the router listens on.
+- `PROXY_KEY` – shared secret sent to the cloud proxy via the `X-Proxy-Key` header.
 
 ```env
 # excerpt from sample.env
@@ -23,3 +24,7 @@ PROMPT_ROUTER_PORT=8009
 
 The Escalation Engine uses `http://<PROMPT_ROUTER_HOST>:<PROMPT_ROUTER_PORT>/route`
 as the request URL.
+
+When forwarding a prompt to the cloud proxy, the router includes `X-Proxy-Key`
+with the value of `PROXY_KEY`. Requests missing this header or providing the
+wrong key are rejected with **401 Unauthorized**.


### PR DESCRIPTION
## Summary
- require `X-Proxy-Key` header for `/api/chat`
- document proxy key requirement for cloud proxy

## Testing
- `pre-commit run --files cloud-proxy/main.py docs/prompt_router.md`
- `python -m pytest` *(fails: SYSTEM_SEED is set to the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68963224aa4883219e8ce24bf07a45d0