### PR TITLE
Restrict audit log permissions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ This page documents all environment variables consumed by the Python services. D
 
 | Variable | Default | Service |
 | --- | --- | --- |
-| `AUDIT_LOG_FILE` | `/app/logs/audit.log` | Shared audit logger |
+| `AUDIT_LOG_FILE` | `/app/logs/audit.log` | Shared audit logger (created with 600 permissions) |
 | `HONEYPOT_LOG_FILE` | `/app/logs/honeypot_hits.log` | Honeypot logger |
 | `CAPTCHA_SUCCESS_LOG` | `/app/logs/captcha_success.log` | CAPTCHA services |
 | `BLOCK_LOG_FILE` | `/app/logs/block_events.log` | Admin UI |

--- a/src/shared/audit.py
+++ b/src/shared/audit.py
@@ -9,6 +9,7 @@ os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
 logger = logging.getLogger("audit")
 if not logger.handlers:
     handler = RotatingFileHandler(LOG_PATH, maxBytes=1_000_000, backupCount=3)
+    os.chmod(LOG_PATH, 0o600)
     formatter = logging.Formatter("%(asctime)s %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- ensure audit log file is created with 600 permissions
- document audit log file permission requirement

## Testing
- `pre-commit run --files src/shared/audit.py docs/configuration.md`
- `python -m pytest` *(fails: SyntaxError in admin_ui and missing SYSTEM_SEED env var)*

------
https://chatgpt.com/codex/tasks/task_e_6896a258947c83218892bbfc2cef01f1