### PR TITLE
Validate IP address in admin block endpoints

### DIFF
--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -620,7 +620,7 @@ async def unblock_ip(request: Request, user: str = Depends(require_admin)):
     if not ip:
         return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
     try:
-        ip = str(ip_address(ip))
+        normalized_ip = str(ip_address(ip))
     except ValueError:
         return JSONResponse({"error": "Invalid ip"}, status_code=400)
 

--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -14,6 +14,7 @@ import secrets
 import time
 from base64 import b64decode
 from collections import deque
+from ipaddress import ip_address
 from uuid import uuid4
 
 import pyotp
@@ -593,6 +594,10 @@ async def block_ip(request: Request, user: str = Depends(require_admin)):
     ip = json_data.get("ip")
     if not ip:
         return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
+    try:
+        ip = str(ip_address(ip))
+    except ValueError:
+        return JSONResponse({"error": "Invalid ip"}, status_code=400)
 
     redis_conn = get_redis_connection()
     if not redis_conn:
@@ -614,6 +619,10 @@ async def unblock_ip(request: Request, user: str = Depends(require_admin)):
     ip = json_data.get("ip")
     if not ip:
         return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
+    try:
+        ip = str(ip_address(ip))
+    except ValueError:
+        return JSONResponse({"error": "Invalid ip"}, status_code=400)
 
     redis_conn = get_redis_connection()
     if not redis_conn:

--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -595,7 +595,7 @@ async def block_ip(request: Request, user: str = Depends(require_admin)):
     if not ip:
         return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
     try:
-        ip = str(ip_address(ip))
+        normalized_ip = str(ip_address(ip))
     except ValueError:
         return JSONResponse({"error": "Invalid ip"}, status_code=400)
 


### PR DESCRIPTION
## Summary
- validate IP addresses for `/block` and `/unblock` endpoints using `ipaddress.ip_address`
- return HTTP 400 when IP validation fails

## Testing
- `pre-commit run --files src/admin_ui/admin_ui.py`
- `SYSTEM_SEED=123 python -m pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6897e83bed508321940064d2adc55820