### PR TITLE
Decode Redis session entries

### DIFF
--- a/src/behavioral/honeypot.py
+++ b/src/behavioral/honeypot.py
@@ -34,7 +34,10 @@ class SessionTracker:
             entries = self.redis.lrange(f"session:{ip}", 0, -1)
         else:
             entries = self.fallback[ip]
-        return [e.split(":", 1)[1] for e in entries]
+        return [
+            (e.decode() if isinstance(e, bytes) else e).split(":", 1)[1]
+            for e in entries
+        ]
 
 
 def _seq_features(seq: List[str]) -> List[float]:

--- a/test/behavioral/test_honeypot.py
+++ b/test/behavioral/test_honeypot.py
@@ -3,6 +3,17 @@ import unittest
 from src.behavioral import SessionTracker, train_behavior_model
 
 
+class DummyRedis:
+    def __init__(self) -> None:
+        self.store = {}
+
+    def rpush(self, key: str, value: str) -> None:
+        self.store.setdefault(key, []).append(value.encode())
+
+    def lrange(self, key: str, start: int, end: int):
+        return self.store.get(key, [])
+
+
 class TestBehavioralHoneypot(unittest.TestCase):
     def test_tracking_and_model(self):
         tracker = SessionTracker(redis_db=99)  # likely missing -> fallback
@@ -14,6 +25,14 @@ class TestBehavioralHoneypot(unittest.TestCase):
         labels = {"1.1.1.1": 1, "2.2.2.2": 0}
         model = train_behavior_model(sequences, labels)
         self.assertIsNotNone(model)
+
+    def test_tracking_with_redis_bytes(self):
+        tracker = SessionTracker(redis_db=99)
+        tracker.redis = DummyRedis()
+        tracker.log_request("1.1.1.1", "/a")
+        tracker.log_request("1.1.1.1", "/b")
+        seq = tracker.get_sequence("1.1.1.1")
+        self.assertEqual(seq, ["/a", "/b"])
 
 
 if __name__ == "__main__":

--- a/test/behavioral/test_honeypot.py
+++ b/test/behavioral/test_honeypot.py
@@ -14,7 +14,7 @@ class DummyRedis:
         self.store.setdefault(key, []).append(entry.encode())
 
     def lrange(self, key: str, start: int, end: int):
-        return self.store.get(key, [])
+        return self.store.get(key, [])[start:end+1 if end != -1 else None]
 
 
 class TestBehavioralHoneypot(unittest.TestCase):

--- a/test/behavioral/test_honeypot.py
+++ b/test/behavioral/test_honeypot.py
@@ -8,7 +8,10 @@ class DummyRedis:
         self.store = {}
 
     def rpush(self, key: str, value: str) -> None:
-        self.store.setdefault(key, []).append(value.encode())
+        # Store value as 'timestamp:path' to match real Redis behavior
+        timestamp = str(int(time.time()))
+        entry = f"{timestamp}:{value}"
+        self.store.setdefault(key, []).append(entry.encode())
 
     def lrange(self, key: str, start: int, end: int):
         return self.store.get(key, [])


### PR DESCRIPTION
## Summary
- decode Redis lrange entries and accept plain strings in the fallback session tracker
- cover byte-decoding path with a dummy Redis test

## Testing
- `pre-commit run --files src/behavioral/honeypot.py test/behavioral/test_honeypot.py`
- `SYSTEM_SEED=1 python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f51953ec8321b3cac7c5eb7b8a7c