### PR TITLE
Future-proof time handling and tar extraction

### DIFF
--- a/scripts/ddos_guard.py
+++ b/scripts/ddos_guard.py
@@ -118,7 +118,9 @@ async def monitor(
         def maybe_report(target_ip: str, source: str, atype: str) -> None:
             if target_ip not in reported:
                 metadata = {
-                    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+                    "timestamp": datetime.datetime.now(datetime.UTC)
+                    .isoformat()
+                    .replace("+00:00", "Z"),
                     "ip": target_ip,
                     "user_agent": ua,
                     "path": req_path,

--- a/src/behavioral/honeypot.py
+++ b/src/behavioral/honeypot.py
@@ -22,7 +22,7 @@ class SessionTracker:
         self.fallback: Dict[str, List[str]] = defaultdict(list)
 
     def log_request(self, ip: str, path: str, timestamp: float | None = None) -> None:
-        timestamp = timestamp or datetime.datetime.utcnow().timestamp()
+        timestamp = timestamp or datetime.datetime.now(datetime.UTC).timestamp()
         entry = f"{timestamp}:{path}"
         if self.redis:
             self.redis.rpush(f"session:{ip}", entry)

--- a/src/util/ddos_protection.py
+++ b/src/util/ddos_protection.py
@@ -66,7 +66,9 @@ async def report_attack(
     # Fall back to local escalation engine
     if metadata is None:
         metadata = {
-            "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.datetime.now(datetime.UTC)
+            .isoformat()
+            .replace("+00:00", "Z"),
             "ip": ip,
             "source": "ddos_guard",
         }

--- a/src/util/rules_fetcher.py
+++ b/src/util/rules_fetcher.py
@@ -148,7 +148,7 @@ def download_and_extract_crs(url: str, dest_dir: str) -> bool:
                                 member.name,
                             )
                             return False
-                        tf.extract(member, tmpdir)
+                        tf.extract(member, tmpdir, filter="data")
         except (tarfile.TarError, zipfile.BadZipFile) as exc:
             logger.error("Failed to extract CRS archive: %s", exc)
             return False

--- a/src/util/suricata_manager.py
+++ b/src/util/suricata_manager.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Dict, List
 
 import httpx
@@ -39,7 +39,7 @@ def parse_eve_alerts(path: str) -> List[Dict[str, Any]]:
 def send_alert_to_escalation(event: Dict[str, Any]) -> bool:
     """Forward a Suricata alert to the escalation engine."""
     payload = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "ip": event.get("src_ip", "0.0.0.0"),
         "source": "suricata",
         "path": None,

--- a/test/behavioral/test_honeypot.py
+++ b/test/behavioral/test_honeypot.py
@@ -8,13 +8,11 @@ class DummyRedis:
         self.store = {}
 
     def rpush(self, key: str, value: str) -> None:
-        # Store value as 'timestamp:path' to match real Redis behavior
-        timestamp = str(int(time.time()))
-        entry = f"{timestamp}:{value}"
-        self.store.setdefault(key, []).append(entry.encode())
+        # Mimic Redis by storing the pre-formatted entry as bytes
+        self.store.setdefault(key, []).append(value.encode())
 
     def lrange(self, key: str, start: int, end: int):
-        return self.store.get(key, [])[start:end+1 if end != -1 else None]
+        return self.store.get(key, [])[start : end + 1 if end != -1 else None]
 
 
 class TestBehavioralHoneypot(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Correct DummyRedis.rpush in tests to store pre-formatted entries without extra timestamps
- Replace deprecated datetime.utcnow calls with timezone-aware datetime.now(datetime.UTC)
- Specify filter="data" when extracting tar archives to align with upcoming Python defaults

## Testing
- `pre-commit run --files scripts/ddos_guard.py src/behavioral/honeypot.py src/captcha/custom_captcha_service.py src/util/ddos_protection.py src/util/rules_fetcher.py src/util/suricata_manager.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897fa5681fc8321bd3db89c1e583a5a