### PR TITLE
Handle invalid captcha answers

### DIFF
--- a/src/captcha/custom_captcha_service.py
+++ b/src/captcha/custom_captcha_service.py
@@ -126,7 +126,11 @@ async def solve(
         datetime.datetime.now(datetime.UTC).timestamp()
     ):
         return JSONResponse({"success": False})
-    if int(answer) != data.get("ans"):
+    try:
+        ans_int = int(answer)
+    except ValueError:
+        return JSONResponse({"success": False})
+    if ans_int != data.get("ans"):
         return JSONResponse({"success": False})
     ip = request.client.host if request and request.client else "unknown"
     fingerprint = fp_id or data.get("fp") or ""

--- a/test/captcha/test_custom_captcha_service.py
+++ b/test/captcha/test_custom_captcha_service.py
@@ -21,6 +21,7 @@ class TestCustomCaptcha(unittest.TestCase):
         token = resp.text[start:].split("'")[0]
         # parse numbers from challenge
         import re
+
         m = re.search(r"What is (\d+) \+ (\d+)", resp.text)
         answer = str(int(m.group(1)) + int(m.group(2))) if m else "0"
         solve = self.client.post(
@@ -34,6 +35,20 @@ class TestCustomCaptcha(unittest.TestCase):
             "/verify", params={"token": data["token"], "ip": "testclient"}
         )
         self.assertTrue(verify.json()["success"])
+
+    def test_invalid_answer(self):
+        resp = self.client.get("/challenge")
+        self.assertEqual(resp.status_code, 200)
+        token_marker = "name='token' value='"
+        start = resp.text.find(token_marker) + len(token_marker)
+        token = resp.text[start:].split("'")[0]
+        solve = self.client.post(
+            "/solve",
+            data={"answer": "abc", "token": token},
+            headers={"User-Agent": "pytest"},
+        )
+        data = solve.json()
+        self.assertFalse(data["success"])
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- handle non-numeric captcha answers without raising an exception
- test that non-numeric answers return `success: False`

## Testing
- `pre-commit run --files src/captcha/custom_captcha_service.py test/captcha/test_custom_captcha_service.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68980eca42348321b90e7175453fbf74