### PR TITLE
Use dedicated RNG for labyrinth

### DIFF
--- a/src/tarpit/labyrinth.py
+++ b/src/tarpit/labyrinth.py
@@ -14,12 +14,12 @@ from .obfuscation import (
 
 
 def generate_labyrinth_page(seed: str, depth: int = 5) -> str:
-    random.seed(seed)
+    rng = random.Random(seed)
     links = []
     for i in range(depth):
         token = hashlib.sha256(f"{seed}-{i}".encode()).hexdigest()[:8]
         links.append(f"/tarpit/{token}")
-    random.shuffle(links)
+    rng.shuffle(links)
     body = "".join(f"<a href='{link}'>Next</a><br/>" for link in links)
     css = generate_obfuscated_css()
     js = generate_obfuscated_js()


### PR DESCRIPTION
## Summary
- initialize a `Random` instance per seed and use it for shuffling links

## Testing
- `pre-commit run --files src/tarpit/labyrinth.py`
- `python -m pytest` *(fails: SYSTEM_SEED is set to the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_689826010ccc8321bd1413baa83b7419