### PR TITLE
Organize imports in Wikipedia updater

### DIFF
--- a/src/util/corpus_wikipedia_updater.py
+++ b/src/util/corpus_wikipedia_updater.py
@@ -1,9 +1,9 @@
 # util/corpus_wikipedia_updater.py
-import os
-import sys
 import logging
+import os
 import re
 import time
+
 import wikipedia
 from wikipedia.exceptions import DisambiguationError, PageError
 
@@ -110,7 +110,7 @@ def fetch_random_wikipedia_articles(num_articles: int) -> list[str]:
         except DisambiguationError as e:
             logger.warning(f"Skipping '{e.title}' because it's a disambiguation page.")
         except PageError:
-            logger.warning(f"Could not find a page for a random title, skipping.")
+            logger.warning("Could not find a page for a random title, skipping.")
         except Exception as e:
             logger.error(
                 f"An unexpected error occurred while fetching an article: {e}",


### PR DESCRIPTION
## Summary
- import os and tidy imports in corpus updater
- fix PageError warning string

## Testing
- `pre-commit run --files src/util/corpus_wikipedia_updater.py`
- `python -m pytest` *(fails: SYSTEM_SEED is set to the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68982b1e26a883219d71d768489037fd