### PR TITLE
Harden plugin loader path validation

### DIFF
--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,37 +1,61 @@
 import importlib
+import importlib.util
 import os
+import sys
+from pathlib import Path
 from typing import Callable, List
 
 # Only load plugins that are explicitly allowed. This prevents arbitrary code
 # execution if untrusted files are placed in the plugin directory.
 DEFAULT_ALLOWED_PLUGINS = os.getenv("ALLOWED_PLUGINS", "ua_blocker").split(",")
 
-PLUGIN_DIR = os.getenv("PLUGIN_DIR", "/app/plugins")
+PLUGIN_DIR = Path(os.getenv("PLUGIN_DIR", "/app/plugins"))
 
 
-def load_plugins(allowed_plugins: List[str] | None = None) -> List[Callable[[object], float]]:
+def _is_within(base: Path, target: Path) -> bool:
+    try:
+        target.resolve().relative_to(base.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def load_plugins(
+    allowed_plugins: List[str] | None = None,
+) -> List[Callable[[object], float]]:
     """Load plugin check functions from the plugins directory."""
     if allowed_plugins is None:
         allowed_plugins = DEFAULT_ALLOWED_PLUGINS
     plugins: List[Callable[[object], float]] = []
-    if not os.path.isdir(PLUGIN_DIR):
+    if not PLUGIN_DIR.is_dir():
         return plugins
-    for filename in os.listdir(PLUGIN_DIR):
-        if not filename.endswith(".py") or filename.startswith("_"):
+    base = PLUGIN_DIR.resolve()
+    for entry in PLUGIN_DIR.iterdir():
+        if entry.name.startswith("_") or entry.suffix != ".py" or not entry.is_file():
             continue
-        module_name = filename[:-3]
+        module_name = entry.stem
         if module_name not in allowed_plugins:
             continue
-        path = os.path.join(PLUGIN_DIR, filename)
-        if os.path.islink(path):
+        if entry.is_symlink() or not _is_within(base, entry):
             continue
+        spec = importlib.util.spec_from_file_location(
+            f"plugins.{module_name}", str(entry)
+        )
+        if not spec or not spec.loader:
+            continue
+        name = spec.name
         try:
-            module = importlib.import_module(f"plugins.{module_name}")
+            if name in sys.modules:
+                del sys.modules[name]
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)
             func = getattr(module, "check", None)
             if callable(func):
                 plugins.append(func)
         except Exception as e:  # pragma: no cover - unexpected
+            sys.modules.pop(name, None)
             import logging
 
-            logging.error("Failed to load plugin %s: %s", filename, e)
+            logging.error("Failed to load plugin %s: %s", entry.name, e)
     return plugins

--- a/test/plugins/test_loader.py
+++ b/test/plugins/test_loader.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def _reload_plugins(monkeypatch, plugin_dir: Path):
+    monkeypatch.setenv("PLUGIN_DIR", str(plugin_dir))
+    from src import plugins as plugins_module
+
+    importlib.reload(plugins_module)
+    for name in list(sys.modules):
+        if name.startswith("plugins."):
+            del sys.modules[name]
+    return plugins_module
+
+
+def test_loads_valid_plugin(monkeypatch, tmp_path):
+    plugin_path = tmp_path / "valid.py"
+    plugin_path.write_text("def check(req):\n    return 0.5\n")
+    plugins_module = _reload_plugins(monkeypatch, tmp_path)
+    plugins = plugins_module.load_plugins(["valid"])
+    assert len(plugins) == 1
+    assert plugins[0](object()) == 0.5
+
+
+def test_skips_symlink_outside(monkeypatch, tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "evil.py").write_text("def check(req):\n    return 1\n")
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "evil.py").symlink_to(outside / "evil.py")
+    plugins_module = _reload_plugins(monkeypatch, plugin_dir)
+    assert plugins_module.load_plugins(["evil"]) == []
+
+
+def test_skips_plugin_missing_check(monkeypatch, tmp_path):
+    (tmp_path / "nocheck.py").write_text("x = 1\n")
+    plugins_module = _reload_plugins(monkeypatch, tmp_path)
+    assert plugins_module.load_plugins(["nocheck"]) == []
+
+
+def test_no_duplicate_sys_modules(monkeypatch, tmp_path):
+    plugin_path = tmp_path / "dup.py"
+    plugin_path.write_text("def check(req):\n    return 0.1\n")
+    plugins_module = _reload_plugins(monkeypatch, tmp_path)
+    first = plugins_module.load_plugins(["dup"])
+    assert len(first) == 1
+    before = [name for name in sys.modules if name.startswith("plugins.")]
+    second = plugins_module.load_plugins(["dup"])
+    after = [name for name in sys.modules if name.startswith("plugins.")]
+    assert len(second) == 1
+    assert before == after


### PR DESCRIPTION
## Summary
- load plugins with explicit path checks and safe module reloading
- add tests for valid load, symlink/traversal rejection, and repeated calls

## Testing
- `pre-commit run --files src/plugins/__init__.py test/plugins/test_loader.py`
- `SYSTEM_SEED=1 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ae33ffbc832189c19db32429fdc6