### PR TITLE
Use SCAN to count blocklist entries in admin UI

### DIFF
--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -553,6 +553,7 @@ async def block_stats(user: str = Depends(require_auth)):
             blocked_ips = redis_conn.smembers(tenant_key("blocklist")) or set()
             pattern = tenant_key("blocklist:ip:*")
             cursor = 0
+            temp_block_count = 0
             while True:
                 cursor, keys = redis_conn.scan(cursor=cursor, match=pattern, count=1000)
                 temp_block_count += len(keys)


### PR DESCRIPTION
## Summary
- replace `keys` with an iterative `SCAN` loop for counting temporary blocks

## Testing
- `python -m pre_commit run --files src/admin_ui/admin_ui.py`
- `python -m pytest` *(fails: SYSTEM_SEED is set to the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_689e8fc2409c83218369a1bb1cf78969