### PR TITLE
Handle invalid Redis blocklist responses

### DIFF
--- a/src/admin_ui/blocklist.py
+++ b/src/admin_ui/blocklist.py
@@ -107,11 +107,14 @@ async def get_blocklist(user: str = Depends(require_auth)):
     blocklist_set = redis_conn.smembers(tenant_key("blocklist"))
     if asyncio.iscoroutine(blocklist_set):
         blocklist_set = await blocklist_set
-
-    if blocklist_set and isinstance(blocklist_set, (set, list)):
+    if isinstance(blocklist_set, (set, list)):
         return JSONResponse(list(blocklist_set))
-    else:
-        return JSONResponse([])
+
+    logger.error(
+        "Unexpected blocklist response type from Redis: %s",
+        type(blocklist_set).__name__,
+    )
+    return JSONResponse({"error": "Redis returned invalid data"}, status_code=503)
 
 
 @router.post("/block")

--- a/test/admin_ui/test_admin_ui.py
+++ b/test/admin_ui/test_admin_ui.py
@@ -146,6 +146,19 @@ class TestAdminUIComprehensive(unittest.TestCase):
         self.assertEqual(response.json(), {"error": "Redis service unavailable"})
 
     @patch("src.admin_ui.blocklist.get_redis_connection")
+    def test_get_blocklist_invalid_response(self, mock_get_redis):
+        """Test the /blocklist endpoint handles invalid Redis responses."""
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.smembers.return_value = "oops"
+        mock_get_redis.return_value = mock_redis_instance
+
+        response = self.client.get(
+            "/blocklist", auth=self.auth, headers=self._totp_headers()
+        )
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json(), {"error": "Redis returned invalid data"})
+
+    @patch("src.admin_ui.blocklist.get_redis_connection")
     def test_block_ip_success(self, mock_get_redis):
         """Test manually blocking an IP address."""
         mock_redis_instance = MagicMock()


### PR DESCRIPTION
## Summary
- validate Redis blocklist responses and return 503 for invalid data
- test blocklist endpoint behavior when Redis returns invalid types

## Testing
- `pre-commit run --files src/admin_ui/blocklist.py test/admin_ui/test_admin_ui.py`
- `SYSTEM_SEED=abcd python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eafe50b8883218042e9f2af5690e0