### PR TITLE
Handle Redis connection errors in ai_webhook get_redis_connection

### DIFF
--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -176,6 +176,26 @@ app = FastAPI()
 
 def get_redis_connection():
     """Wrapper for tests to patch the Redis client."""
+    global redis_client_blocklist, BLOCKLISTING_ENABLED
+    redis_client_blocklist = shared_get_redis_connection(db_number=REDIS_DB_BLOCKLIST)
+    if not redis_client_blocklist:
+        logger.error(
+            "Redis connection for blocklisting returned None. Blocklisting disabled."
+        )
+        BLOCKLISTING_ENABLED = False
+        return None
+    try:
+        redis_client_blocklist.ping()
+        BLOCKLISTING_ENABLED = True
+        logger.info(
+            f"Connected to Redis for blocklisting at {REDIS_HOST}:{REDIS_PORT}, DB: {REDIS_DB_BLOCKLIST}"
+        )
+    except (ConnectionError, RedisError) as e:
+        logger.error(
+            f"Redis connection failed for Blocklisting: {e}. Blocklisting disabled."
+        )
+        redis_client_blocklist = None
+        BLOCKLISTING_ENABLED = False
     return redis_client_blocklist
 
 


### PR DESCRIPTION
## Summary
- ping Redis connection in `get_redis_connection`
- disable blocklisting when Redis is unreachable

## Testing
- `pre-commit run --files src/ai_service/ai_webhook.py`
- `python -m pytest` (fails: `SYSTEM_SEED is set to the default placeholder. Set a unique value via the SYSTEM_SEED environment variable.`)


------
https://chatgpt.com/codex/tasks/task_e_689ec497604883218f51cdc220d16891