### PR TITLE
Delay blocklisting until Redis ping succeeds

### DIFF
--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -117,7 +117,8 @@ COMMUNITY_BLOCKLIST_API_KEY = CONFIG.COMMUNITY_BLOCKLIST_API_KEY
 
 # --- Setup Clients & Validate Config ---
 # Redis connection is initialized lazily to avoid network I/O on import.
-BLOCKLISTING_ENABLED = True
+# Blocklisting is disabled until a successful Redis connection is established.
+BLOCKLISTING_ENABLED = False
 redis_client_blocklist = None
 
 if ALERT_METHOD == "smtp" and not ALERT_SMTP_PASSWORD and ALERT_SMTP_USER:
@@ -158,8 +159,6 @@ app = FastAPI()
 def get_redis_connection():
     """Return a Redis connection, creating it on first use with retries."""
     global redis_client_blocklist, BLOCKLISTING_ENABLED
-    if not BLOCKLISTING_ENABLED:
-        return None
 
     if redis_client_blocklist is None:
         try:
@@ -167,9 +166,18 @@ def get_redis_connection():
                 db_number=REDIS_DB_BLOCKLIST
             )
             if redis_client_blocklist:
-                logger.info(
-                    f"Connected to Redis for blocklisting at {REDIS_HOST}:{REDIS_PORT}, DB: {REDIS_DB_BLOCKLIST}"
-                )
+                try:
+                    redis_client_blocklist.ping()
+                    BLOCKLISTING_ENABLED = True
+                    logger.info(
+                        f"Connected to Redis for blocklisting at {REDIS_HOST}:{REDIS_PORT}, DB: {REDIS_DB_BLOCKLIST}"
+                    )
+                except (ConnectionError, RedisError) as e:
+                    logger.error(
+                        f"Redis ping failed for Blocklisting: {e}. Blocklisting disabled."
+                    )
+                    BLOCKLISTING_ENABLED = False
+                    redis_client_blocklist = None
             else:
                 logger.error(
                     "Redis connection for blocklisting returned None. Blocklisting disabled."
@@ -180,11 +188,16 @@ def get_redis_connection():
                 f"Redis connection failed for Blocklisting: {e}. Blocklisting disabled."
             )
             BLOCKLISTING_ENABLED = False
+            redis_client_blocklist = None
         except Exception as e:
             logger.error(
                 f"Unexpected error connecting to Redis for Blocklisting: {e}. Blocklisting disabled."
             )
             BLOCKLISTING_ENABLED = False
+            redis_client_blocklist = None
+
+    if not BLOCKLISTING_ENABLED:
+        return None
 
     return redis_client_blocklist
 


### PR DESCRIPTION
## Summary
- Start with blocklisting disabled and enable only after a successful Redis ping
- Attempt Redis connection on first use and disable blocklisting if ping fails

## Testing
- `pre-commit run --files src/ai_service/ai_webhook.py`
- `SYSTEM_SEED=testing python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2e3c3994c83218554207bb575cfeb