### PR TITLE
Validate IP before blocklisting

### DIFF
--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -257,6 +257,13 @@ def add_ip_to_blocklist(
             )
         return False
     try:
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        logger.warning(
+            f"Attempted to blocklist invalid IP {ip_address}. Reason: {reason}. Details: {event_details}"
+        )
+        return False
+    try:
         block_key = f"{BLOCKLIST_KEY_PREFIX}{ip_address}"
         block_metadata = json.dumps(
             {

--- a/test/ai_webhook/test_ai_webhook.py
+++ b/test/ai_webhook/test_ai_webhook.py
@@ -122,6 +122,16 @@ class TestAIWebhookComprehensive(unittest.TestCase):
                 redis_mock.assert_not_called()
                 redis_mock.reset_mock()
 
+    def test_add_ip_to_blocklist_rejects_invalid_ip(self):
+        """add_ip_to_blocklist should return False and not touch Redis for invalid IPs."""
+        ai_webhook.BLOCKLISTING_ENABLED = True
+        result = ai_webhook.add_ip_to_blocklist(
+            "999.999.999.999", "bad", event_details=None
+        )
+        self.assertFalse(result)
+        self.mock_redis_client.exists.assert_not_called()
+        self.mock_redis_client.setex.assert_not_called()
+
     def test_webhook_receiver_invalid_action(self):
         """Test that an unsupported action returns a 400 error."""
         payload = {"action": "reboot_server", "ip": "1.2.3.4"}


### PR DESCRIPTION
## Summary
- verify IPs with `ipaddress.ip_address` before blocklisting
- test that `add_ip_to_blocklist` rejects invalid IPs

## Testing
- `pre-commit run --files src/ai_service/ai_webhook.py test/ai_webhook/test_ai_webhook.py`
- `python -m pytest` *(fails: RuntimeError: SYSTEM_SEED is set to the default placeholder)*
- `python -m pytest test/ai_webhook/test_ai_webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4ce1aeb38832193de25a6913a57c2