### PR TITLE
Log error file write failures as critical

### DIFF
--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -222,7 +222,6 @@ def log_error(message: str, exception: Optional[Exception] = None):
             ERROR_LOG_FILE,
             log_e,
             log_entry,
-            exc_info=True,
         )
 
 

--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -22,7 +22,6 @@ from typing import Any, Dict, Optional, Union
 
 import httpx
 import requests
-import ipaddress
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -218,8 +217,12 @@ def log_error(message: str, exception: Optional[Exception] = None):
         with open(ERROR_LOG_FILE, "a", encoding="utf-8") as f:
             f.write(log_entry + "\n")
     except Exception as log_e:
-        print(
-            f"FATAL: Could not write to error log file {ERROR_LOG_FILE}: {log_e}\nOriginal error: {log_entry}"
+        logger.critical(
+            "FATAL: Could not write to error log file %s: %s | Original error: %s",
+            ERROR_LOG_FILE,
+            log_e,
+            log_entry,
+            exc_info=True,
         )
 
 


### PR DESCRIPTION
## Summary
- log error log write failures with `logger.critical` instead of printing to stdout

## Testing
- `pre-commit run --files src/ai_service/ai_webhook.py`
- `python -m pytest` *(fails: SYSTEM_SEED is set to the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d274fce4832193a0e1182668c4e0