### PR TITLE
Persist state in Redis

### DIFF
--- a/src/bot_control/crawler_auth.py
+++ b/src/bot_control/crawler_auth.py
@@ -1,19 +1,31 @@
-"""Simple crawler registry for token-based authentication."""
+"""Simple crawler registry for token-based authentication backed by Redis."""
+
 from __future__ import annotations
 
 from typing import Dict, Optional
 
-_registered: Dict[str, Dict[str, str]] = {}
+from src.shared.config import tenant_key
+from src.shared.redis_client import get_redis_connection
+
+
+def _key(token: str) -> str:
+    return tenant_key(f"crawler:token:{token}")
 
 
 def register_crawler(name: str, token: str, purpose: str) -> None:
     """Register or update a crawler token."""
-    _registered[token] = {"name": name, "purpose": purpose}
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        raise RuntimeError("Redis unavailable")
+    redis_conn.hset(_key(token), mapping={"name": name, "purpose": purpose})
 
 
 def verify_crawler(token: str, purpose: str | None = None) -> bool:
     """Return True if the token exists and (optionally) matches the given purpose."""
-    info = _registered.get(token)
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        raise RuntimeError("Redis unavailable")
+    info = redis_conn.hgetall(_key(token))
     if not info:
         return False
     if purpose and info.get("purpose") != purpose:
@@ -23,4 +35,8 @@ def verify_crawler(token: str, purpose: str | None = None) -> bool:
 
 def get_crawler_info(token: str) -> Optional[Dict[str, str]]:
     """Return crawler info if registered."""
-    return _registered.get(token)
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        raise RuntimeError("Redis unavailable")
+    info = redis_conn.hgetall(_key(token))
+    return info or None

--- a/src/bot_control/pricing.py
+++ b/src/bot_control/pricing.py
@@ -1,25 +1,38 @@
-"""Minimal pay-per-crawl accounting."""
+"""Minimal pay-per-crawl accounting backed by Redis."""
+
 from __future__ import annotations
 
-from typing import Dict
+from src.shared.config import tenant_key
+from src.shared.redis_client import get_redis_connection
 
 _default_price = 0.001
-_prices: Dict[str, float] = {}
-_usage: Dict[str, float] = {}
+PRICES_KEY = tenant_key("crawler:prices")
+USAGE_KEY = tenant_key("crawler:usage")
 
 
 def set_price(purpose: str, price: float) -> None:
     """Set the crawl price for a specific purpose."""
-    _prices[purpose] = max(0.0, price)
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        raise RuntimeError("Redis unavailable")
+    redis_conn.hset(PRICES_KEY, purpose, max(0.0, price))
 
 
 def record_crawl(token: str, purpose: str) -> float:
     """Record a crawl and return the charge for this request."""
-    price = _prices.get(purpose, _default_price)
-    _usage[token] = _usage.get(token, 0.0) + price
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        raise RuntimeError("Redis unavailable")
+    raw = redis_conn.hget(PRICES_KEY, purpose)
+    price = float(raw) if raw is not None else _default_price
+    redis_conn.hincrbyfloat(USAGE_KEY, token, price)
     return price
 
 
 def get_usage(token: str) -> float:
     """Return the current owed balance for a token."""
-    return _usage.get(token, 0.0)
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        raise RuntimeError("Redis unavailable")
+    raw = redis_conn.hget(USAGE_KEY, token)
+    return float(raw) if raw is not None else 0.0

--- a/src/cloud_dashboard/cloud_dashboard_api.py
+++ b/src/cloud_dashboard/cloud_dashboard_api.py
@@ -1,15 +1,19 @@
 """FastAPI service for hosted monitoring across installations."""
 
-from typing import Dict, Any, List
 import asyncio
+import json
+from typing import Any, Dict, List
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 
+from src.shared.config import tenant_key
+from src.shared.redis_client import get_redis_connection
+
 app = FastAPI()
 
-# In-memory storage of metrics per installation
-INSTALLATIONS: Dict[str, Dict[str, Any]] = {}
+# Redis-backed storage of metrics per installation with TTL
+METRICS_TTL = 60
 WATCHERS: Dict[str, List[WebSocket]] = {}
 
 WEBSOCKET_METRICS_INTERVAL = 5
@@ -20,7 +24,11 @@ async def register_installation(payload: Dict[str, Any]):
     installation_id = payload.get("installation_id")
     if not installation_id:
         return JSONResponse({"error": "installation_id required"}, status_code=400)
-    INSTALLATIONS.setdefault(installation_id, {"metrics": {}})
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        return JSONResponse({"error": "storage unavailable"}, status_code=500)
+    key = tenant_key(f"cloud:install:{installation_id}")
+    redis_conn.set(key, json.dumps({}), ex=METRICS_TTL)
     return {"status": "registered", "installation_id": installation_id}
 
 
@@ -30,8 +38,11 @@ async def push_metrics(payload: Dict[str, Any]):
     metrics = payload.get("metrics")
     if not installation_id or not isinstance(metrics, dict):
         return JSONResponse({"error": "invalid payload"}, status_code=400)
-    entry = INSTALLATIONS.setdefault(installation_id, {"metrics": {}})
-    entry["metrics"] = metrics
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        return JSONResponse({"error": "storage unavailable"}, status_code=500)
+    key = tenant_key(f"cloud:install:{installation_id}")
+    redis_conn.set(key, json.dumps(metrics), ex=METRICS_TTL)
     for ws in list(WATCHERS.get(installation_id, [])):
         try:
             await ws.send_json(metrics)
@@ -42,7 +53,12 @@ async def push_metrics(payload: Dict[str, Any]):
 
 @app.get("/metrics/{installation_id}")
 async def get_metrics(installation_id: str):
-    return INSTALLATIONS.get(installation_id, {}).get("metrics", {})
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        return JSONResponse({"error": "storage unavailable"}, status_code=500)
+    key = tenant_key(f"cloud:install:{installation_id}")
+    raw = redis_conn.get(key)
+    return json.loads(raw) if raw else {}
 
 
 @app.websocket("/ws/{installation_id}")
@@ -50,12 +66,20 @@ async def metrics_websocket(websocket: WebSocket, installation_id: str):
     await websocket.accept()
     WATCHERS.setdefault(installation_id, []).append(websocket)
     try:
+        redis_conn = get_redis_connection()
+        if not redis_conn:
+            await websocket.send_json({"error": "storage unavailable"})
+            await websocket.close()
+            return
         # Send initial metrics if available
-        metrics = INSTALLATIONS.get(installation_id, {}).get("metrics", {})
+        key = tenant_key(f"cloud:install:{installation_id}")
+        raw = redis_conn.get(key)
+        metrics = json.loads(raw) if raw else {}
         await websocket.send_json(metrics)
         while True:
             await asyncio.sleep(WEBSOCKET_METRICS_INTERVAL)
-            metrics = INSTALLATIONS.get(installation_id, {}).get("metrics", {})
+            raw = redis_conn.get(key)
+            metrics = json.loads(raw) if raw else {}
             await websocket.send_json(metrics)
     except WebSocketDisconnect:
         pass


### PR DESCRIPTION
## Summary
- Return storage errors for cloud dashboard metrics when Redis is unavailable
- Fail fast in crawler auth and pricing when Redis cannot be reached

## Testing
- `pre-commit run --files src/cloud_dashboard/cloud_dashboard_api.py src/bot_control/crawler_auth.py src/bot_control/pricing.py`
- `python -m pytest` *(fails: SYSTEM_SEED is set to the default placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_689e9e355a30832187e9b5085a3b3c5c