### PR TITLE
Add macOS zsh setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ installs dependencies, and starts Docker Compose. See
    ```bash
    git clone https://github.com/your-username/ai-scraping-defense.git
    cd ai-scraping-defense
-   sudo ./quickstart_dev.sh
+   ./quickstart_dev.zsh
    ```
 4. When the containers finish starting, visit [http://localhost:5002](http://localhost:5002) to open the Admin UI.
 5. If containers fail to start, confirm Docker Desktop is running by opening the Docker menu.
+6. For a step-by-step walkthrough, including security tooling, see the [macOS setup guide](docs/macos_setup.md).
 
 ### Windows
 1. Install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop) and ensure it is running.
@@ -180,7 +181,9 @@ cd ai-scraping-defense
 cp sample.env .env
 python scripts/validate_env.py
 
-sudo ./quickstart_dev.sh   # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
+sudo ./quickstart_dev.sh   # Linux
+./quickstart_dev.zsh   # macOS
+
 ```
 
 For the security testing environment, a helper `security_setup.sh` script installs all Python requirements and security tools used by `security_scan.sh`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,7 +9,8 @@ Run the helper script after cloning the repository:
 ```bash
 git clone https://github.com/your-username/ai-scraping-defense.git
 cd ai-scraping-defense
-sudo ./quickstart_dev.sh  # use sudo on Linux/macOS; run quickstart_dev.ps1 on Windows
+sudo ./quickstart_dev.sh  # Linux
+./quickstart_dev.zsh      # macOS
 ```
 
 On Windows, run `quickstart_dev.ps1` from an **Administrator PowerShell** window instead of the shell script.

--- a/docs/macos_setup.md
+++ b/docs/macos_setup.md
@@ -1,0 +1,53 @@
+# macOS Setup Guide
+
+This guide explains how to run the AI Scraping Defense system on macOS using the provided zsh helper scripts.
+
+## Prerequisites
+- macOS with [Homebrew](https://brew.sh/) installed
+- [Docker Desktop](https://www.docker.com/products/docker-desktop) running
+- Python 3.10 or newer (`brew install python`)
+
+## Clone the Repository
+```bash
+git clone https://github.com/your-username/ai-scraping-defense.git
+cd ai-scraping-defense
+```
+
+## Prepare the Virtual Environment
+Use the `reset_venv.zsh` script to create a fresh virtual environment and install dependencies:
+```zsh
+./reset_venv.zsh
+source .venv/bin/activate
+```
+The script verifies Homebrew, installs required XML libraries (`libxml2` and `libxslt`), and installs project requirements inside `.venv/`.
+
+## Start the Stack
+With Docker Desktop running, launch the development stack:
+```zsh
+./quickstart_dev.zsh
+```
+After the containers start, open <http://localhost:5002> to access the Admin UI.
+
+## Install Security Tools
+`security_setup.zsh` installs macOS-compatible binaries of Trivy, Gitleaks, and Grype. Run it once to fetch the tools:
+```zsh
+./security_setup.zsh
+```
+
+## Run Security Scans
+After installing the tools, `security_scan.zsh` can audit the repository and Docker images:
+```zsh
+./security_scan.zsh
+```
+The script runs Trivy, Gitleaks, and Grype scans and stores reports in the `security_scan_reports/` directory.
+
+## Additional Helper Scripts
+- `quick_deploy.zsh` – deploy the stack to a Kubernetes cluster.
+- `quick_proxy.zsh` – start the stack with a reverse proxy.
+- `quick_takeover.zsh` – stop local web servers and expose the stack on port 80.
+- `setup_fake_website.zsh` – launch a fake backend site for testing.
+- `post_takeover_test_site.zsh` – attach a sample site after running `quick_takeover.zsh`.
+
+## Updating Dependencies
+Re-run `./reset_venv.zsh` whenever Python dependencies change. To update security tools, run `./security_setup.zsh` again.
+

--- a/generate_secrets.zsh
+++ b/generate_secrets.zsh
@@ -1,0 +1,215 @@
+#!/bin/zsh
+#
+# Creates a complete Kubernetes secrets manifest for the entire application stack.
+
+# --- Configuration ---
+GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+K8S_DIR="$SCRIPT_DIR/kubernetes"; mkdir -p "$K8S_DIR"; OUTPUT_FILE="$K8S_DIR/secrets.yaml"
+HTPASSWD_OUTPUT_FILE="$SCRIPT_DIR/nginx/.htpasswd"
+
+# --- Functions ---
+generate_password() {
+  LC_ALL=C tr -dc 'A-Za-z0-9_!@#$%^&*' < /dev/urandom | head -c "${1:-24}"
+}
+
+update_env=false
+export_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --update-env)
+      update_env=true
+      shift
+      ;;
+    --export-path)
+      export_path="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+update_var() {
+  local key="$1" value="$2" file="$3"
+  # Escape dollar signs so docker compose doesn't treat them as variables
+  local escaped="${value//\$/\$\$}"
+  if grep -q "^${key}=" "$file"; then
+    sed -i.bak "s|^${key}=.*|${key}=${escaped}|" "$file" && rm -f "${file}.bak"
+  else
+    echo "${key}=${escaped}" >> "$file"
+  fi
+}
+
+# --- Main Logic ---
+echo -e "${CYAN}Generating secrets for Kubernetes...${NC}"
+
+# Generate all values
+POSTGRES_USER="postgres"; POSTGRES_DB="markov_db"; POSTGRES_PASSWORD=$(generate_password)
+REDIS_PASSWORD=$(generate_password)
+ADMIN_UI_USERNAME=${SUDO_USER:-$USER}; if [ -z "$ADMIN_UI_USERNAME" ]; then ADMIN_UI_USERNAME="defense-admin"; fi
+ADMIN_UI_PASSWORD=$(generate_password)
+ADMIN_UI_PASSWORD_HASH=$(htpasswd -nbBC 12 "$ADMIN_UI_USERNAME" "$ADMIN_UI_PASSWORD" | cut -d: -f2 | tr -d '\n')
+SYSTEM_SEED=$(generate_password 48)
+NGINX_PASSWORD=$(generate_password 32)
+EXTERNAL_API_KEY="key-for-$(generate_password)"; IP_REPUTATION_API_KEY="key-for-$(generate_password)"; COMMUNITY_BLOCKLIST_API_KEY="key-for-$(generate_password)"
+OPENAI_API_KEY="sk-$(generate_password 40)"; ANTHROPIC_API_KEY="sk-ant-$(generate_password 40)"; GOOGLE_API_KEY="AIza$(generate_password 35)"; COHERE_API_KEY="coh-$(generate_password 40)"; MISTRAL_API_KEY="mistral-$(generate_password 40)"
+
+# Create Nginx htpasswd content using bcrypt
+HTPASSWD_FILE_CONTENT=$(htpasswd -nbBC 12 "$ADMIN_UI_USERNAME" "$NGINX_PASSWORD" | tr -d '\n')
+# Write htpasswd file for local Docker Compose usage
+echo "$HTPASSWD_FILE_CONTENT" > "$HTPASSWD_OUTPUT_FILE"
+
+# Write YAML to file
+cat > "$OUTPUT_FILE" << EOL
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: ai-defense
+type: Opaque
+data:
+  POSTGRES_USER: $(echo -n "$POSTGRES_USER" | base64 | tr -d '\n')
+  POSTGRES_DB: $(echo -n "$POSTGRES_DB" | base64 | tr -d '\n')
+  POSTGRES_PASSWORD: $(echo -n "$POSTGRES_PASSWORD" | base64 | tr -d '\n')
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-credentials
+  namespace: ai-defense
+type: Opaque
+data:
+  REDIS_PASSWORD: $(echo -n "$REDIS_PASSWORD" | base64 | tr -d '\n')
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-ui-credentials
+  namespace: ai-defense
+type: Opaque
+data:
+  ADMIN_UI_USERNAME: $(echo -n "$ADMIN_UI_USERNAME" | base64 | tr -d '\n')
+  ADMIN_UI_PASSWORD_HASH: $(echo -n "$ADMIN_UI_PASSWORD_HASH" | base64 | tr -d '\n')
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: system-seed-secret
+  namespace: ai-defense
+type: Opaque
+data:
+  SYSTEM_SEED: $(echo -n "$SYSTEM_SEED" | base64 | tr -d '\n')
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nginx-auth
+  namespace: ai-defense
+type: Opaque
+data:
+  .htpasswd: $(echo -n "$HTPASSWD_FILE_CONTENT" | base64 | tr -d '\n')
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-api-keys
+  namespace: ai-defense
+type: Opaque
+data:
+  EXTERNAL_API_KEY: $(echo -n "$EXTERNAL_API_KEY" | base64 | tr -d '\n')
+  OPENAI_API_KEY: $(echo -n "$OPENAI_API_KEY" | base64 | tr -d '\n')
+  ANTHROPIC_API_KEY: $(echo -n "$ANTHROPIC_API_KEY" | base64 | tr -d '\n')
+  GOOGLE_API_KEY: $(echo -n "$GOOGLE_API_KEY" | base64 | tr -d '\n')
+  COHERE_API_KEY: $(echo -n "$COHERE_API_KEY" | base64 | tr -d '\n')
+  MISTRAL_API_KEY: $(echo -n "$MISTRAL_API_KEY" | base64 | tr -d '\n')
+  IP_REPUTATION_API_KEY: $(echo -n "$IP_REPUTATION_API_KEY" | base64 | tr -d '\n')
+  COMMUNITY_BLOCKLIST_API_KEY: $(echo -n "$COMMUNITY_BLOCKLIST_API_KEY" | base64 | tr -d '\n')
+EOL
+
+if [ -n "$export_path" ]; then
+  cat > "$export_path" << EOF2
+{
+  "ADMIN_UI_USERNAME": "$ADMIN_UI_USERNAME",
+  "ADMIN_UI_PASSWORD": "$ADMIN_UI_PASSWORD",
+  "NGINX_PASSWORD": "$NGINX_PASSWORD",
+  "POSTGRES_PASSWORD": "$POSTGRES_PASSWORD",
+  "REDIS_PASSWORD": "$REDIS_PASSWORD",
+  "SYSTEM_SEED": "$SYSTEM_SEED",
+  "OPENAI_API_KEY": "$OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY": "$ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY": "$GOOGLE_API_KEY",
+  "COHERE_API_KEY": "$COHERE_API_KEY",
+  "MISTRAL_API_KEY": "$MISTRAL_API_KEY",
+  "EXTERNAL_API_KEY": "$EXTERNAL_API_KEY",
+  "IP_REPUTATION_API_KEY": "$IP_REPUTATION_API_KEY",
+  "COMMUNITY_BLOCKLIST_API_KEY": "$COMMUNITY_BLOCKLIST_API_KEY"
+}
+EOF2
+  chmod 600 "$export_path"
+  echo -e "${GREEN}Credentials exported to: ${export_path}${NC}"
+fi
+
+# Output credentials
+echo -e "\nSuccessfully created Kubernetes secrets file at: ${GREEN}${OUTPUT_FILE}${NC}"
+echo -e "${YELLOW}--- IMPORTANT: Save the following credentials in a secure place! ---${NC}"
+echo -e "${CYAN}NGINX / Admin UI Credentials:${NC}"
+echo "  Username: $ADMIN_UI_USERNAME"
+echo "  Password: $NGINX_PASSWORD"
+echo -e "${CYAN}Service Passwords & Keys:${NC}"
+echo "  PostgreSQL Password: $POSTGRES_PASSWORD"
+echo "  Redis Password:      $REDIS_PASSWORD"
+echo "  System Seed:         $SYSTEM_SEED"
+echo -e "${CYAN}LLM API Keys (placeholders, replace with real keys if needed):${NC}"
+echo "  OpenAI API Key:    $OPENAI_API_KEY"
+echo "  Anthropic API Key: $ANTHROPIC_API_KEY"
+echo "  Google API Key:    $GOOGLE_API_KEY"
+echo "  Cohere API Key:    $COHERE_API_KEY"
+echo "  Mistral API Key:   $MISTRAL_API_KEY"
+echo -e "${CYAN}IP Reputation API Key: ${NC}"
+echo "  $IP_REPUTATION_API_KEY"
+echo -e "${CYAN}Community Blocklist API Key: ${NC}"
+echo "  $COMMUNITY_BLOCKLIST_API_KEY"
+echo -e "${CYAN}External API Key: ${NC}"
+echo "  $EXTERNAL_API_KEY"
+echo -e "${NC}"
+echo -e "${YELLOW}--- End of credentials ---${NC}"
+echo -e "${GREEN}Kubernetes secrets manifest file created at: ${OUTPUT_FILE}${NC}"
+echo -e "${YELLOW}You can now apply the secrets to your Kubernetes cluster using:${NC}"
+echo -e "  kubectl apply -f ${OUTPUT_FILE}${NC}"
+# Optionally update .env with generated values
+if [ "$update_env" = true ]; then
+  ENV_FILE="$SCRIPT_DIR/.env"
+  if [ ! -f "$ENV_FILE" ] && [ -f "$SCRIPT_DIR/sample.env" ]; then
+    cp "$SCRIPT_DIR/sample.env" "$ENV_FILE"
+  fi
+  echo -e "${CYAN}Updating ${ENV_FILE} with generated values...${NC}"
+  update_var POSTGRES_PASSWORD "$POSTGRES_PASSWORD" "$ENV_FILE"
+  update_var REDIS_PASSWORD "$REDIS_PASSWORD" "$ENV_FILE"
+  update_var ADMIN_UI_USERNAME "$ADMIN_UI_USERNAME" "$ENV_FILE"
+  update_var ADMIN_UI_PASSWORD_HASH "$ADMIN_UI_PASSWORD_HASH" "$ENV_FILE"
+  update_var SYSTEM_SEED "$SYSTEM_SEED" "$ENV_FILE"
+  update_var NGINX_PASSWORD "$NGINX_PASSWORD" "$ENV_FILE"
+  update_var OPENAI_API_KEY "$OPENAI_API_KEY" "$ENV_FILE"
+  update_var ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" "$ENV_FILE"
+  update_var GOOGLE_API_KEY "$GOOGLE_API_KEY" "$ENV_FILE"
+  update_var COHERE_API_KEY "$COHERE_API_KEY" "$ENV_FILE"
+  update_var MISTRAL_API_KEY "$MISTRAL_API_KEY" "$ENV_FILE"
+  update_var EXTERNAL_API_KEY "$EXTERNAL_API_KEY" "$ENV_FILE"
+  update_var IP_REPUTATION_API_KEY "$IP_REPUTATION_API_KEY" "$ENV_FILE"
+  update_var COMMUNITY_BLOCKLIST_API_KEY "$COMMUNITY_BLOCKLIST_API_KEY" "$ENV_FILE"
+
+  # Write secret files for Docker Compose
+  SECRETS_DIR="$SCRIPT_DIR/secrets"
+  mkdir -p "$SECRETS_DIR"
+  echo -n "$POSTGRES_PASSWORD" > "$SECRETS_DIR/pg_password.txt"
+  echo -n "$REDIS_PASSWORD" > "$SECRETS_DIR/redis_password.txt"
+  chmod 600 "$SECRETS_DIR/pg_password.txt" "$SECRETS_DIR/redis_password.txt"
+  echo -e "${CYAN}Secret files written to ${SECRETS_DIR}${NC}"
+fi
+
+echo -e "${GREEN}Secrets Generation Complete!${NC}"
+echo -e "${NC}"
+# End of script

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - User Guide:
     - Overview: docs/index.md # The landing page specifically for docs
     - Getting Started (Docker): docs/getting_started.md
+    - macOS Setup: docs/macos_setup.md
     - Kubernetes Deployment: docs/kubernetes_deployment.md
     - Architecture: docs/architecture.md
     - Key Data Flows: docs/key_data_flows.md

--- a/post_takeover_test_site.zsh
+++ b/post_takeover_test_site.zsh
@@ -1,0 +1,55 @@
+#!/bin/zsh
+# =============================================================================
+#  post_takeover_test_site.zsh - attach simple test site after quick_takeover
+#
+#  Assumes quick_takeover.zsh has already launched the AI Scraping Defense stack
+#  on the defense_network. This script updates REAL_BACKEND_HOST and starts
+#  a minimal Nginx server on that network.
+# =============================================================================
+set -e
+
+# Update REAL_BACKEND_HOST to point at the fake_website container
+if grep -q '^REAL_BACKEND_HOST=' .env; then
+  sed -i.bak 's|^REAL_BACKEND_HOST=.*|REAL_BACKEND_HOST=http://fake_website:80|' .env && rm -f .env.bak
+else
+  echo 'REAL_BACKEND_HOST=http://fake_website:80' >> .env
+fi
+
+# Determine the Docker network created by quick_takeover
+NETWORK_NAME=$(docker network ls --filter name=defense_network -q | head -n 1)
+if [ -z "$NETWORK_NAME" ]; then
+  echo "Could not locate the defense_network. Did quick_takeover run?"
+  exit 1
+fi
+
+# Create a simple test page
+mkdir -p test_site
+if [ ! -f test_site/index.html ]; then
+cat > test_site/index.html <<'HTML'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Test Site</title>
+</head>
+<body>
+  <h1>Hello from the Test Site!</h1>
+  <p>If you see this page through the proxy, the stack is working.</p>
+</body>
+</html>
+HTML
+fi
+
+# Launch the test site container
+if [ ! "$(docker ps -q -f name=fake_website)" ]; then
+  docker run -d --name fake_website \
+    --network "$NETWORK_NAME" \
+    -p 8081:80 \
+    -v "$(pwd)/test_site:/usr/share/nginx/html:ro" \
+    nginx:alpine
+else
+  echo "fake_website container already running"
+fi
+
+echo "Test site available at http://localhost:8081"
+echo "Proxy via AI Scraping Defense at http://localhost:8080"

--- a/quick_deploy.zsh
+++ b/quick_deploy.zsh
@@ -1,0 +1,19 @@
+#!/bin/zsh
+# Quick deployment for Kubernetes
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== AI Scraping Defense: Quick Deploy ==="
+
+# Ensure .env exists for docker build context or other scripts
+if [ ! -f .env ]; then
+  cp sample.env .env
+  echo "Created .env from sample.env"
+fi
+
+# Deploy to Kubernetes
+bash ./deploy.sh
+
+echo "Deployment complete. Monitor pods with: kubectl get pods -n ai-defense"

--- a/quick_proxy.zsh
+++ b/quick_proxy.zsh
@@ -1,0 +1,31 @@
+#!/bin/zsh
+# Quick setup for Apache or Nginx reverse proxy deployment
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== AI Scraping Defense: Proxy Quick Start ==="
+
+if [ ! -f .env ]; then
+  cp sample.env .env
+  echo "Created .env from sample.env"
+fi
+
+PROXY=${1:-nginx}
+
+case "$PROXY" in
+  apache)
+    echo "Launching stack with Apache reverse proxy..."
+    docker compose up -d apache_proxy
+    ;;
+  nginx)
+    echo "Launching stack with Nginx reverse proxy..."
+    docker compose up -d nginx_proxy
+    ;;
+  *)
+    echo "Usage: $0 [apache|nginx]"
+    exit 1
+    ;;
+ esac
+
+echo "Stack started with $PROXY reverse proxy."

--- a/quick_takeover.zsh
+++ b/quick_takeover.zsh
@@ -1,0 +1,53 @@
+#!/bin/zsh
+# Quick script to stop host web server and run stack on port 80
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== AI Scraping Defense: Server Takeover ==="
+
+# Ensure .env exists
+if [ ! -f .env ]; then
+  cp sample.env .env
+  echo "Created .env from sample.env"
+fi
+
+PROXY=${1:-nginx}
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  for svc in apachectl nginx; do
+    if command -v $svc >/dev/null 2>&1; then
+      echo "Stopping $svc service..."
+      sudo $svc stop
+    fi
+  done
+elif command -v systemctl >/dev/null 2>&1; then
+  for svc in apache2 nginx; do
+    if systemctl is-active --quiet "$svc"; then
+      echo "Stopping $svc service..."
+      if [ "$(id -u)" -eq 0 ]; then
+        systemctl stop "$svc"
+      else
+        sudo systemctl stop "$svc"
+      fi
+    fi
+  done
+fi
+
+case "$PROXY" in
+  apache)
+    echo "Launching stack with Apache on port 80..."
+    APACHE_HTTP_PORT=80 docker compose up -d apache_proxy
+    ;;
+  nginx)
+    echo "Launching stack with Nginx on port 80..."
+    docker compose up -d nginx_proxy
+    ;;
+  *)
+    echo "Usage: $0 [apache|nginx]"
+    exit 1
+    ;;
+esac
+
+echo "Stack is now serving on port 80 via $PROXY."

--- a/quickstart_dev.zsh
+++ b/quickstart_dev.zsh
@@ -1,0 +1,23 @@
+#!/bin/zsh
+# Quick setup script for local development on macOS
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== AI Scraping Defense: Development Quickstart ==="
+
+if [ ! -f .env ]; then
+  cp sample.env .env
+  echo "Created .env from sample.env"
+fi
+
+./setup_local_dirs.zsh
+./generate_secrets.zsh
+./reset_venv.zsh
+./.venv/bin/pip install -r requirements.txt -c constraints.txt
+./.venv/bin/python scripts/validate_env.py
+./.venv/bin/python test/run_all_tests.py
+docker-compose up --build -d
+
+echo "Development environment is up and running!"

--- a/reset_venv.zsh
+++ b/reset_venv.zsh
@@ -1,0 +1,32 @@
+#!/bin/zsh
+# Completely resets the Python virtual environment for macOS users.
+# Mirrors reset_venv.sh but installs dependencies with Homebrew.
+
+set -e
+
+echo "--- Step 1: Installing required system dependencies ---"
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found. Visit https://brew.sh to install." >&2
+  exit 1
+fi
+brew update
+brew install libxml2 libxslt
+
+echo -e "\n--- Step 2: Deactivating and removing old virtual environment ---"
+if typeset -f deactivate >/dev/null; then
+  deactivate
+fi
+rm -rf .venv
+
+echo -e "\n--- Step 3: Creating new virtual environment ---"
+python3 -m venv .venv
+
+echo -e "\n--- Step 4: Upgrading core packaging tools ---"
+./.venv/bin/python -m pip install --upgrade pip setuptools wheel
+
+echo -e "\n--- Step 5: Installing project dependencies from requirements.txt ---"
+./.venv/bin/python -m pip install -r requirements.txt
+
+echo -e "\n---"
+echo "Virtual environment reset successfully!"
+echo "To activate it, run: source .venv/bin/activate"

--- a/security_scan.zsh
+++ b/security_scan.zsh
@@ -102,7 +102,25 @@ fi
 echo "=== 11. Gobuster Directory Scan ==="
 if command -v gobuster >/dev/null 2>&1; then
     gobuster dir -u "$WEB_URL" -w /usr/share/wordlists/dirbuster/directory-list-2.3-medium.txt \
-        -o "reports/gobuster_$(echo $WEB_URL | tr '/:' '_').txt"
+    # Try default Linux path
+    DEFAULT_WORDLIST="/usr/share/wordlists/dirbuster/directory-list-2.3-medium.txt"
+    MAC_WORDLIST="/usr/local/share/wordlists/dirbuster/directory-list-2.3-medium.txt"
+    if [[ -n "$GOBUSTER_WORDLIST" && -f "$GOBUSTER_WORDLIST" ]]; then
+        WORDLIST="$GOBUSTER_WORDLIST"
+    elif [[ -f "$DEFAULT_WORDLIST" ]]; then
+        WORDLIST="$DEFAULT_WORDLIST"
+    elif [[ -f "$MAC_WORDLIST" ]]; then
+        WORDLIST="$MAC_WORDLIST"
+    else
+        echo "No suitable gobuster wordlist found. Please specify a valid wordlist as argument 6."
+        WORDLIST=""
+    fi
+    if [[ -n "$WORDLIST" ]]; then
+        gobuster dir -u "$WEB_URL" -w "$WORDLIST" \
+            -o "reports/gobuster_$(echo $WEB_URL | tr '/:' '_').txt"
+    else
+        echo "Skipping gobuster directory scan due to missing wordlist."
+    fi
 else
     echo "gobuster not installed. Skipping directory scan."
 fi

--- a/security_scan.zsh
+++ b/security_scan.zsh
@@ -1,0 +1,218 @@
+#!/bin/zsh
+# security_scan.zsh - Advanced security testing helper
+#
+
+# Usage: sudo ./security_scan.zsh <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url]
+# - target_host_or_ip: IP or hostname for network scans
+# - web_url_for_nikto: full URL to scan with Nikto and ZAP (defaults to http://<target>)
+# - docker_image: optional container image to scan with Trivy
+# - code_dir: optional path to source code for Bandit static analysis
+# - sqlmap_url: optional parameterized URL for automated SQLMap testing
+
+set -e
+
+TARGET="$1"
+WEB_URL="${2:-http://$1}"
+IMAGE="$3"
+CODE_DIR="${4:-.}"
+
+SQLMAP_URL="$5"
+PORTS="22,80,443,5432,6379"
+
+if [[ -z "$TARGET" ]]; then
+    echo "Usage: sudo $0 <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url]"
+    exit 1
+fi
+
+mkdir -p reports
+
+echo "=== 1. Nmap Scan (version, OS, common vulns) ==="
+if command -v nmap >/dev/null 2>&1; then
+    nmap -A -p "$PORTS" --script=vuln -oN "reports/nmap_${TARGET}.txt" "$TARGET"
+else
+    echo "nmap not installed. Skipping nmap scan."
+fi
+
+echo "=== 2. Nikto Web Scan ==="
+if command -v nikto >/dev/null 2>&1; then
+    nikto -host "$WEB_URL" -output "reports/nikto_$(echo $WEB_URL | tr '/:' '_').txt"
+else
+    echo "nikto not installed. Skipping Nikto scan."
+fi
+
+echo "=== 3. OWASP ZAP Baseline Scan ==="
+if command -v zap-baseline.py >/dev/null 2>&1; then
+    zap-baseline.py -t "$WEB_URL" -w "reports/zap_$(echo $WEB_URL | tr '/:' '_').html" -r "zap_${TARGET}.md"
+else
+    echo "zap-baseline.py not installed. Skipping ZAP scan."
+fi
+
+echo "=== 4. SQLMap (optional automated scan) ==="
+if [[ -n "$SQLMAP_URL" ]]; then
+    if command -v sqlmap >/dev/null 2>&1; then
+        sqlmap -u "$SQLMAP_URL" --batch -oN "reports/sqlmap_$(echo $TARGET | tr '/:' '_').txt"
+    else
+        echo "sqlmap not installed. Skipping SQL injection test."
+    fi
+else
+    echo "  Provide a parameterized URL as sqlmap_url to run SQLMap automatically."
+    echo "  Example: sqlmap -u 'http://$TARGET/vuln.php?id=1' --batch -oN reports/sqlmap_${TARGET}.txt"
+fi
+
+if [[ -n "$IMAGE" ]]; then
+    echo "=== 5. Trivy Container Scan ==="
+    if command -v trivy >/dev/null 2>&1; then
+        trivy image -o "reports/trivy_$(echo $IMAGE | tr '/:' '_').txt" "$IMAGE"
+    else
+        echo "trivy not installed. Skipping image scan."
+    fi
+fi
+
+if [[ -d "$CODE_DIR" ]]; then
+    echo "=== 6. Bandit Static Code Analysis ==="
+    if command -v bandit >/dev/null 2>&1; then
+        bandit -r "$CODE_DIR" -f txt -o "reports/bandit_$(basename $CODE_DIR).txt"
+    else
+        echo "bandit not installed. Skipping static analysis."
+    fi
+fi
+
+echo "=== 7. OpenVAS (Greenbone) ==="
+echo "  Ensure OpenVAS is initialized and running. Example gvm-cli command:" 
+echo "      gvm-cli socket -- gmp start_task <task-id>"
+
+echo "=== 8. Lynis System Audit ==="
+if command -v lynis >/dev/null 2>&1; then
+    lynis audit system --quiet --logfile reports/lynis.log --report-file reports/lynis-report.txt
+else
+    echo "lynis not installed. Skipping system audit."
+fi
+
+echo "=== 9. Optional Hydra Password Test ==="
+echo "  hydra -L users.txt -P passwords.txt ssh://$TARGET -o reports/hydra_${TARGET}.txt"
+
+echo "=== 10. Masscan Quick Sweep ==="
+if command -v masscan >/dev/null 2>&1; then
+    echo "  Running a fast port sweep (rate 1000) on $TARGET"
+    masscan -p"$PORTS" "$TARGET" --rate=1000 -oL "reports/masscan_${TARGET}.txt"
+else
+    echo "masscan not installed. Skipping quick sweep."
+fi
+
+echo "=== 11. Gobuster Directory Scan ==="
+if command -v gobuster >/dev/null 2>&1; then
+    gobuster dir -u "$WEB_URL" -w /usr/share/wordlists/dirbuster/directory-list-2.3-medium.txt \
+        -o "reports/gobuster_$(echo $WEB_URL | tr '/:' '_').txt"
+else
+    echo "gobuster not installed. Skipping directory scan."
+fi
+
+echo "=== 12. Enum4linux SMB Enumeration ==="
+if command -v enum4linux >/dev/null 2>&1; then
+    enum4linux -a "$TARGET" | tee "reports/enum4linux_${TARGET}.txt"
+else
+    echo "enum4linux not installed. Skipping SMB enumeration."
+fi
+
+echo "=== 13. WPScan (WordPress) ==="
+if command -v wpscan >/dev/null 2>&1; then
+    wpscan --url "$WEB_URL" --no-update -o "reports/wpscan_$(echo $WEB_URL | tr '/:' '_').txt"
+else
+    echo "wpscan not installed. Skipping WordPress scan."
+fi
+
+echo "=== 14. SSLyze TLS Scan ==="
+if command -v sslyze >/dev/null 2>&1; then
+    sslyze --regular "$TARGET" > "reports/sslyze_${TARGET}.txt"
+else
+    echo "sslyze not installed. Skipping TLS scan."
+fi
+
+echo "=== 15. ffuf Web Fuzzing ==="
+if command -v ffuf >/dev/null 2>&1; then
+    WORDLIST="/usr/share/seclists/Discovery/Web-Content/common.txt"
+    if [[ -f "$WORDLIST" ]]; then
+        ffuf -w "$WORDLIST" -u "${WEB_URL}/FUZZ" -of csv -o "reports/ffuf_$(echo $WEB_URL | tr '/:' '_').csv"
+    else
+        echo "Wordlist $WORDLIST not found. Skipping ffuf fuzzing."
+    fi
+else
+    echo "ffuf not installed. Skipping web fuzzing."
+fi
+
+echo "=== 16. Wfuzz Parameter Fuzzing ==="
+if command -v wfuzz >/dev/null 2>&1; then
+    PARAM_LIST="/usr/share/seclists/Discovery/Web-Content/burp-parameter-names.txt"
+    if [[ -f "$PARAM_LIST" ]]; then
+        wfuzz -c -z file,"$PARAM_LIST" -d "FUZZ=test" "$WEB_URL" | tee "reports/wfuzz_$(echo $WEB_URL | tr '/:' '_').txt"
+    else
+        echo "Parameter wordlist $PARAM_LIST not found. Skipping wfuzz."
+    fi
+else
+    echo "wfuzz not installed. Skipping parameter fuzzing."
+fi
+
+echo "=== 17. testssl TLS Scan ==="
+if command -v testssl.sh >/dev/null 2>&1; then
+    testssl.sh "$WEB_URL" > "reports/testssl_$(echo $WEB_URL | tr '/:' '_').txt"
+else
+    echo "testssl.sh not installed. Skipping TLS scan."
+fi
+
+echo "=== 18. WhatWeb Fingerprinting ==="
+if command -v whatweb >/dev/null 2>&1; then
+    whatweb "$WEB_URL" > "reports/whatweb_$(echo $WEB_URL | tr '/:' '_').txt"
+else
+    echo "whatweb not installed. Skipping fingerprinting."
+fi
+
+echo "=== 19. Gitleaks Secret Scan ==="
+if command -v gitleaks >/dev/null 2>&1; then
+    gitleaks detect -s "$CODE_DIR" -v --report-path "reports/gitleaks_$(basename $CODE_DIR).txt" || true
+else
+    echo "gitleaks not installed. Skipping secrets scan."
+fi
+
+echo "=== 20. Grype Container Scan ==="
+if [[ -n "$IMAGE" ]] && command -v grype >/dev/null 2>&1; then
+    grype "$IMAGE" -o table > "reports/grype_$(echo $IMAGE | tr '/:' '_').txt"
+else
+    echo "grype not installed or no image specified. Skipping grype scan."
+fi
+
+echo "=== 21. ClamAV Malware Scan ==="
+if command -v clamscan >/dev/null 2>&1; then
+    clamscan -r "$CODE_DIR" > "reports/clamscan_$(basename $CODE_DIR).txt"
+else
+    echo "clamscan not installed. Skipping malware scan."
+fi
+
+echo "=== 22. Rkhunter Rootkit Check ==="
+if command -v rkhunter >/dev/null 2>&1; then
+    rkhunter --check --sk --rwo > "reports/rkhunter_${TARGET}.txt" || true
+else
+    echo "rkhunter not installed. Skipping rootkit check."
+fi
+
+echo "=== 23. Chkrootkit Rootkit Check ==="
+if command -v chkrootkit >/dev/null 2>&1; then
+    chkrootkit > "reports/chkrootkit_${TARGET}.txt"
+else
+    echo "chkrootkit not installed. Skipping rootkit check."
+fi
+
+echo "=== 24. Sublist3r Subdomain Enumeration ==="
+if command -v sublist3r >/dev/null 2>&1; then
+    sublist3r -d "$TARGET" -o "reports/sublist3r_${TARGET}.txt"
+else
+    echo "sublist3r not installed. Skipping subdomain enumeration."
+fi
+
+echo "=== 25. pip-audit Dependency Scan ==="
+if command -v pip-audit >/dev/null 2>&1; then
+    pip-audit -r requirements.txt -f plain > "reports/pip_audit.txt" || true
+else
+    echo "pip-audit not installed. Skipping Python dependency audit."
+fi
+
+echo "Reports saved in the 'reports' directory. Review them for potential issues." 

--- a/security_setup.zsh
+++ b/security_setup.zsh
@@ -27,7 +27,7 @@ curl -fsSL -o "$TMP_DIR/$TRIVY_TAR" \
 curl -fsSL -o "$TMP_DIR/trivy_checksums.txt" \
   "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
 (cd "$TMP_DIR" && grep "$TRIVY_TAR" trivy_checksums.txt | shasum -a 256 -c -)
-tar -xz -C /usr/local/bin -f "$TMP_DIR/$TRIVY_TAR" trivy
+tar -xz -C "$INSTALL_DIR" -f "$TMP_DIR/$TRIVY_TAR" trivy
 rm "$TMP_DIR/$TRIVY_TAR" "$TMP_DIR/trivy_checksums.txt"
 
 # Gitleaks

--- a/security_setup.zsh
+++ b/security_setup.zsh
@@ -39,7 +39,7 @@ curl -fsSL -o "$TMP_DIR/$GITLEAKS_TAR" \
 curl -fsSL -o "$TMP_DIR/gitleaks_checksums.txt" \
   "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
 (cd "$TMP_DIR" && grep "$GITLEAKS_TAR" gitleaks_checksums.txt | shasum -a 256 -c -)
-tar -xz -C /usr/local/bin -f "$TMP_DIR/$GITLEAKS_TAR" gitleaks
+tar -xz -C "$BIN_DIR" -f "$TMP_DIR/$GITLEAKS_TAR" gitleaks
 rm "$TMP_DIR/$GITLEAKS_TAR" "$TMP_DIR/gitleaks_checksums.txt"
 
 # Grype

--- a/security_setup.zsh
+++ b/security_setup.zsh
@@ -51,7 +51,7 @@ curl -fsSL -o "$TMP_DIR/$GRYPE_TAR" \
 curl -fsSL -o "$TMP_DIR/grype_checksums.txt" \
   "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
 (cd "$TMP_DIR" && grep "$GRYPE_TAR" grype_checksums.txt | shasum -a 256 -c -)
-tar -xz -C /usr/local/bin -f "$TMP_DIR/$GRYPE_TAR" grype
+tar -xz -C "$HOME/.local/bin" -f "$TMP_DIR/$GRYPE_TAR" grype
 rm "$TMP_DIR/$GRYPE_TAR" "$TMP_DIR/grype_checksums.txt"
 
 pip install bandit sslyze sublist3r pip-audit

--- a/security_setup.zsh
+++ b/security_setup.zsh
@@ -1,0 +1,58 @@
+#!/bin/zsh
+set -euo pipefail
+
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found. Install it from https://brew.sh" >&2
+  exit 1
+fi
+
+# Install tools used by security_scan.sh
+brew update
+brew install nmap nikto zaproxy sqlmap lynis hydra masscan gobuster enum4linux \
+    wpscan ffuf wfuzz testssl whatweb gvm rkhunter chkrootkit clamav jq
+
+# Additional tools from GitHub with checksum verification
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Trivy
+TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest \
+  | jq -r '.tag_name' | sed 's/^v//')
+TRIVY_TAR="trivy_${TRIVY_VERSION}_macOS-64bit.tar.gz"
+curl -fsSL -o "$TMP_DIR/$TRIVY_TAR" \
+  "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/$TRIVY_TAR"
+curl -fsSL -o "$TMP_DIR/trivy_checksums.txt" \
+  "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
+(cd "$TMP_DIR" && grep "$TRIVY_TAR" trivy_checksums.txt | shasum -a 256 -c -)
+tar -xz -C /usr/local/bin -f "$TMP_DIR/$TRIVY_TAR" trivy
+rm "$TMP_DIR/$TRIVY_TAR" "$TMP_DIR/trivy_checksums.txt"
+
+# Gitleaks
+GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+  | jq -r '.tag_name' | sed 's/^v//')
+GITLEAKS_TAR="gitleaks_${GITLEAKS_VERSION}_macos_x64.tar.gz"
+curl -fsSL -o "$TMP_DIR/$GITLEAKS_TAR" \
+  "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/$GITLEAKS_TAR"
+curl -fsSL -o "$TMP_DIR/gitleaks_checksums.txt" \
+  "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+(cd "$TMP_DIR" && grep "$GITLEAKS_TAR" gitleaks_checksums.txt | shasum -a 256 -c -)
+tar -xz -C /usr/local/bin -f "$TMP_DIR/$GITLEAKS_TAR" gitleaks
+rm "$TMP_DIR/$GITLEAKS_TAR" "$TMP_DIR/gitleaks_checksums.txt"
+
+# Grype
+GRYPE_VERSION=$(curl -s https://api.github.com/repos/anchore/grype/releases/latest \
+  | jq -r '.tag_name' | sed 's/^v//')
+GRYPE_TAR="grype_${GRYPE_VERSION}_darwin_amd64.tar.gz"
+curl -fsSL -o "$TMP_DIR/$GRYPE_TAR" \
+  "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/$GRYPE_TAR"
+curl -fsSL -o "$TMP_DIR/grype_checksums.txt" \
+  "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
+(cd "$TMP_DIR" && grep "$GRYPE_TAR" grype_checksums.txt | shasum -a 256 -c -)
+tar -xz -C /usr/local/bin -f "$TMP_DIR/$GRYPE_TAR" grype
+rm "$TMP_DIR/$GRYPE_TAR" "$TMP_DIR/grype_checksums.txt"
+
+pip install bandit sslyze sublist3r pip-audit
+brew cleanup

--- a/setup_fake_website.zsh
+++ b/setup_fake_website.zsh
@@ -1,0 +1,71 @@
+#!/bin/zsh
+# =============================================================================
+#  setup_fake_website.zsh - launch a simple test web server
+#
+#  This helper creates a small Nginx container serving a fake website and
+#  connects it to the AI Scraping Defense stack by setting REAL_BACKEND_HOST.
+#
+#  DISCLAIMER: This script is meant for local testing only. Use it at your own
+#  risk and do not expose the stack to production traffic without review.
+#
+#  Recommended resources for running the full stack and test site on one machine:
+#    * 4 CPU cores
+#    * 8 GB RAM
+#    * 10+ GB of free disk space
+# =============================================================================
+set -e
+
+# Ensure .env exists
+if [ ! -f .env ]; then
+  cp sample.env .env
+  echo "Created .env from sample.env"
+fi
+
+# Add or update REAL_BACKEND_HOST in .env
+if grep -q '^REAL_BACKEND_HOST=' .env; then
+  sed -i.bak 's|^REAL_BACKEND_HOST=.*|REAL_BACKEND_HOST=http://fake_website:80|' .env && rm -f .env.bak
+else
+  echo 'REAL_BACKEND_HOST=http://fake_website:80' >> .env
+fi
+
+# Create a minimal website if not already present
+mkdir -p fake_site
+if [ ! -f fake_site/index.html ]; then
+cat > fake_site/index.html <<'HTML'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Fake Website</title>
+</head>
+<body>
+  <h1>Hello from the Fake Website!</h1>
+  <p>If you see this page through the proxy, the stack is working.</p>
+</body>
+</html>
+HTML
+fi
+
+# Start the AI Scraping Defense stack
+docker-compose up --build -d
+
+# Determine the Docker network created by docker-compose
+NETWORK_NAME=$(docker network ls --filter name=defense_network -q | head -n 1)
+if [ -z "$NETWORK_NAME" ]; then
+  echo "Could not locate the defense_network. Is the stack running?"
+  exit 1
+fi
+
+# Launch the fake website container
+if [ ! "$(docker ps -q -f name=fake_website)" ]; then
+  docker run -d --name fake_website \
+    --network $NETWORK_NAME \
+    -p 8081:80 \
+    -v $(pwd)/fake_site:/usr/share/nginx/html:ro \
+    nginx:alpine
+else
+  echo "fake_website container already running"
+fi
+
+echo "Fake site available at http://localhost:8081"
+echo "Proxy via AI Scraping Defense at http://localhost:8080"

--- a/setup_local_dirs.zsh
+++ b/setup_local_dirs.zsh
@@ -1,0 +1,37 @@
+#!/bin/zsh
+
+echo "Creating necessary local directories for AI Scraping Defense Stack..."
+
+mkdir -p config
+mkdir -p data
+mkdir -p db
+mkdir -p logs
+mkdir -p logs/nginx
+mkdir -p models
+mkdir -p archives
+mkdir -p secrets
+mkdir -p nginx/errors
+# TLS certificate directory matching TLS_CERT_PATH and TLS_KEY_PATH in .env
+mkdir -p nginx/certs
+# The kubernetes directory should already exist if you cloned the repo.
+
+echo "Creating placeholder secret files in ./secrets/ (REMEMBER TO FILL THESE WITH ACTUAL VALUES):"
+touch ./secrets/pg_password.txt
+touch ./secrets/redis_password.txt # Optional, if you use Redis auth
+touch ./secrets/smtp_password.txt
+touch ./secrets/external_api_key.txt
+touch ./secrets/ip_reputation_api_key.txt
+touch ./secrets/community_blocklist_api_key.txt
+# For Kubernetes, SYSTEM_SEED is directly in secrets.yaml data, not a file.
+# For Docker Compose, you might set SYSTEM_SEED in .env or a secrets file if you adapt it.
+
+echo "---------------------------------------------------------------------"
+echo "IMPORTANT REMINDERS:"
+echo "1. Place your actual 'robots.txt' into the './config/' directory."
+echo "2. Place your 'init_markov.sql' (PostgreSQL schema) into the './db/' directory."
+echo "3. Populate all files in './secrets/' with your actual secret values."
+echo "4. For Kubernetes: Ensure you have created 'kubernetes/postgres-init-script-cm.yaml'."
+echo "5. For Kubernetes: Ensure you have updated 'kubernetes/secrets.yaml' with your base64 encoded secrets (including SYSTEM_SEED)."
+echo "6. Build your Docker images, push them to a registry, and update ALL 'image:' fields in your Kubernetes YAML files."
+echo "---------------------------------------------------------------------"
+echo "Directory structure setup complete."


### PR DESCRIPTION
## Summary
- add macOS setup guide outlining usage of new zsh helper scripts
- link macOS guide from README and MkDocs navigation
- provide macOS-friendly zsh versions of quickstart, deployment, proxy, and support scripts

## Testing
- `pre-commit run --files docs/macos_setup.md README.md docs/getting_started.md quick_deploy.zsh quick_proxy.zsh quick_takeover.zsh quickstart_dev.zsh setup_local_dirs.zsh generate_secrets.zsh setup_fake_website.zsh post_takeover_test_site.zsh`


------
https://chatgpt.com/codex/tasks/task_e_68a509239460832199cf5b7a4383b870