### PR TITLE
Add HMAC verification and IP rate limiting to webhook

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,9 @@ This page documents all environment variables consumed by the Python services. D
 | `COMMUNITY_BLOCKLIST_REPORT_URL` | *(none)* | URL to send community reports |
 | `COMMUNITY_BLOCKLIST_API_KEY_FILE` | `/run/secrets/community_blocklist_api_key` | API key file for community reports |
 | `COMMUNITY_BLOCKLIST_REPORT_TIMEOUT` | `10.0` | HTTP timeout for reporting |
-| `WEBHOOK_API_KEY` | *(none)* | Shared key for webhook auth |
+| `WEBHOOK_SHARED_SECRET` | *(none)* | Secret used to verify webhook HMAC signatures |
+| `WEBHOOK_RATE_LIMIT_REQUESTS` | `60` | Requests allowed per IP in each window |
+| `WEBHOOK_RATE_LIMIT_WINDOW` | `60` | Rate limit window size in seconds |
 
 ## Escalation Engine and Classification
 

--- a/sample.env
+++ b/sample.env
@@ -93,7 +93,9 @@ ENABLE_COMMUNITY_REPORTING=true
 COMMUNITY_BLOCKLIST_REPORT_URL=
 COMMUNITY_BLOCKLIST_API_KEY_FILE=/run/secrets/community_blocklist_api_key
 COMMUNITY_BLOCKLIST_REPORT_TIMEOUT=10.0
-WEBHOOK_API_KEY=
+WEBHOOK_SHARED_SECRET=
+WEBHOOK_RATE_LIMIT_REQUESTS=60
+WEBHOOK_RATE_LIMIT_WINDOW=60
 
 # --- Local Secrets (Copy from generate_secrets.sh output or use your own) ---
 # It's recommended to run ./generate_secrets.sh and copy the output here.

--- a/src/ai_service/ai_webhook.py
+++ b/src/ai_service/ai_webhook.py
@@ -10,6 +10,8 @@ notifications through webhooks, Slack or SMTP email.
 
 import asyncio
 import datetime
+import hashlib
+import hmac
 import ipaddress
 import json
 import logging
@@ -17,15 +19,17 @@ import os
 import pprint
 import smtplib
 import ssl
+import time
 from email.mime.text import MIMEText
 from typing import Any, Dict, Optional, Union
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from redis.exceptions import ConnectionError, RedisError
 
+from src.shared.audit import log_event as audit_log_event
 from src.shared.config import CONFIG, tenant_key
 from src.shared.redis_client import get_redis_connection as shared_get_redis_connection
 
@@ -125,7 +129,12 @@ try:
 except OSError as e:
     logger.error("Cannot create log directory %s: %s", LOG_DIR, e)
     raise SystemExit(1)
-WEBHOOK_API_KEY = CONFIG.WEBHOOK_API_KEY
+
+WEBHOOK_SHARED_SECRET = CONFIG.WEBHOOK_SHARED_SECRET
+RATE_LIMIT_REQUESTS = CONFIG.WEBHOOK_RATE_LIMIT_REQUESTS
+RATE_LIMIT_WINDOW = CONFIG.WEBHOOK_RATE_LIMIT_WINDOW
+_request_counts: dict[str, tuple[int, float]] = {}
+_rate_lock = asyncio.Lock()
 
 # --- Load Secrets ---
 ALERT_SMTP_PASSWORD = CONFIG.ALERT_SMTP_PASSWORD
@@ -731,19 +740,68 @@ async def send_alert(event_data: WebhookEvent):
 # --- Simple Webhook Endpoint for tests ---
 
 
+def get_client_ip(request: Request) -> str:
+    return request.client.host if request.client else "unknown"
+
+
+def calculate_window_reset(now: float) -> int:
+    return int(now // RATE_LIMIT_WINDOW * RATE_LIMIT_WINDOW + RATE_LIMIT_WINDOW)
+
+
+def _cleanup_expired_requests(now: float) -> None:
+    expired = [ip for ip, (_, reset) in _request_counts.items() if now > reset]
+    for ip in expired:
+        del _request_counts[ip]
+
+
 @app.post("/webhook")
-async def webhook_receiver(request: Request):
+async def webhook_receiver(request: Request, response: Response):
     """Handle blocklist/flag actions from the escalation engine tests."""
-    api_key = request.headers.get("X-API-Key")
-    if not WEBHOOK_API_KEY or api_key != WEBHOOK_API_KEY:
+    if not WEBHOOK_SHARED_SECRET:
+        raise HTTPException(status_code=500, detail="Shared secret not configured")
+    client_ip = get_client_ip(request)
+    body = await request.body()
+    signature = request.headers.get("X-Signature", "")
+    expected = hmac.new(
+        WEBHOOK_SHARED_SECRET.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        audit_log_event(client_ip, "webhook_auth_failed", {"ip": client_ip})
         raise HTTPException(status_code=401, detail="Unauthorized")
-    payload = (
-        await request.json()
-        if request.headers.get("content-type", "").startswith("application/json")
-        else {}
-    )
+
+    now = time.time()
+    window_reset = calculate_window_reset(now)
+    async with _rate_lock:
+        _cleanup_expired_requests(now)
+        count, reset = _request_counts.get(client_ip, (0, window_reset))
+        if now > reset:
+            count, reset = 0, window_reset
+        if count + 1 > RATE_LIMIT_REQUESTS:
+            retry_after = int(reset - now)
+            headers = {
+                "X-RateLimit-Limit": str(RATE_LIMIT_REQUESTS),
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(int(reset)),
+                "Retry-After": str(retry_after),
+            }
+            audit_log_event(client_ip, "webhook_rate_limited", {"ip": client_ip})
+            raise HTTPException(
+                status_code=429, detail="Too Many Requests", headers=headers
+            )
+        _request_counts[client_ip] = (count + 1, reset)
+        remaining = RATE_LIMIT_REQUESTS - (count + 1)
+
+    response.headers["X-RateLimit-Limit"] = str(RATE_LIMIT_REQUESTS)
+    response.headers["X-RateLimit-Remaining"] = str(remaining)
+    response.headers["X-RateLimit-Reset"] = str(int(reset))
+
+    payload = {}
+    if request.headers.get("content-type", "").startswith("application/json") and body:
+        payload = json.loads(body.decode("utf-8"))
+
     redis_conn = get_redis_connection()
     if not redis_conn:
+        audit_log_event(client_ip, "webhook_redis_unavailable", {"ip": client_ip})
         raise HTTPException(status_code=503, detail="Redis service unavailable")
 
     action = payload.get("action")
@@ -764,16 +822,20 @@ async def webhook_receiver(request: Request):
     try:
         if action == "block_ip":
             redis_conn.sadd(tenant_key("blocklist"), ip)
+            audit_log_event(client_ip, "webhook_block_ip", {"ip": ip})
             return {"status": "success", "message": f"IP {ip} added to blocklist."}
         elif action == "allow_ip":
             redis_conn.srem(tenant_key("blocklist"), ip)
+            audit_log_event(client_ip, "webhook_allow_ip", {"ip": ip})
             return {"status": "success", "message": f"IP {ip} removed from blocklist."}
         elif action == "flag_ip":
             reason = payload.get("reason", "")
             redis_conn.set(tenant_key(f"ip_flag:{ip}"), reason)
+            audit_log_event(client_ip, "webhook_flag_ip", {"ip": ip})
             return {"status": "success", "message": f"IP {ip} flagged."}
         elif action == "unflag_ip":
             redis_conn.delete(tenant_key(f"ip_flag:{ip}"))
+            audit_log_event(client_ip, "webhook_unflag_ip", {"ip": ip})
             return {"status": "success", "message": f"IP {ip} unflagged."}
         else:
             raise HTTPException(status_code=400, detail=f"Invalid action: {action}")

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -195,6 +195,15 @@ class Config:
     WEBHOOK_API_KEY: Optional[str] = field(
         default_factory=lambda: os.getenv("WEBHOOK_API_KEY")
     )
+    WEBHOOK_SHARED_SECRET: Optional[str] = field(
+        default_factory=lambda: os.getenv("WEBHOOK_SHARED_SECRET")
+    )
+    WEBHOOK_RATE_LIMIT_REQUESTS: int = field(
+        default_factory=lambda: int(os.getenv("WEBHOOK_RATE_LIMIT_REQUESTS", "60"))
+    )
+    WEBHOOK_RATE_LIMIT_WINDOW: int = field(
+        default_factory=lambda: int(os.getenv("WEBHOOK_RATE_LIMIT_WINDOW", "60"))
+    )
 
     # Escalation engine configuration
     ESCALATION_THRESHOLD: float = field(

--- a/test/ai_webhook/test_ai_webhook.py
+++ b/test/ai_webhook/test_ai_webhook.py
@@ -1,10 +1,15 @@
 # test/ai_webhook/test_ai_webhook.py
 import asyncio
+import hashlib
+import hmac
+import json
+import os
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+os.environ["WEBHOOK_SHARED_SECRET"] = "test-secret"
 from src.ai_service import ai_webhook
 
 
@@ -13,9 +18,9 @@ class TestAIWebhookComprehensive(unittest.TestCase):
     def setUp(self):
         """Set up the FastAPI test client and patch dependencies."""
         self.client = TestClient(ai_webhook.app)
-        self.api_key = "test-api-key"
-        ai_webhook.WEBHOOK_API_KEY = self.api_key
-        self.headers = {"X-API-Key": self.api_key}
+        self.secret = "test-secret"
+        ai_webhook.WEBHOOK_SHARED_SECRET = self.secret
+        ai_webhook._request_counts.clear()
 
         # The function is imported from shared.redis_client into the ai_webhook module.
         # Therefore, we must patch it where it is used.
@@ -29,7 +34,15 @@ class TestAIWebhookComprehensive(unittest.TestCase):
     def tearDown(self):
         """Stop all patches."""
         patch.stopall()
-        ai_webhook.WEBHOOK_API_KEY = None
+        ai_webhook.WEBHOOK_SHARED_SECRET = None
+
+    def _post(self, payload, headers=None):
+        body = json.dumps(payload).encode("utf-8")
+        sig = hmac.new(self.secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        hdrs = {"X-Signature": sig, "Content-Type": "application/json"}
+        if headers:
+            hdrs.update(headers)
+        return self.client.post("/webhook", data=body, headers=hdrs)
 
     def test_webhook_receiver_block_ip_success(self):
         """Test a successful 'block_ip' action."""
@@ -40,7 +53,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
             "source": "escalation-engine",
         }
         self.mock_redis_client.sadd.return_value = 1
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -55,7 +68,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         """Test a successful 'allow_ip' action."""
         payload = {"action": "allow_ip", "ip": "20.0.0.2"}
         self.mock_redis_client.srem.return_value = 1
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -74,7 +87,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
             "reason": "Suspicious activity",
         }
         self.mock_redis_client.set.return_value = True
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -89,7 +102,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         """Test a successful 'unflag_ip' action."""
         payload = {"action": "unflag_ip", "ip": "40.0.0.4"}
         self.mock_redis_client.delete.return_value = 1
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -112,9 +125,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         for action, redis_mock, extra in actions:
             with self.subTest(action=action):
                 payload = {"action": action, "ip": invalid_ip, **extra}
-                response = self.client.post(
-                    "/webhook", json=payload, headers=self.headers
-                )
+                response = self._post(payload)
                 self.assertEqual(response.status_code, 400)
                 self.assertEqual(
                     response.json()["detail"],
@@ -136,31 +147,43 @@ class TestAIWebhookComprehensive(unittest.TestCase):
     def test_webhook_receiver_invalid_action(self):
         """Test that an unsupported action returns a 400 error."""
         payload = {"action": "reboot_server", "ip": "1.2.3.4"}
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
         self.assertEqual(response.status_code, 400)
         self.assertIn("Invalid action", response.json()["detail"])
 
     def test_webhook_receiver_payload_missing_ip(self):
         """Test that a payload missing the 'ip' field returns a 400 error."""
         payload = {"action": "block_ip", "reason": "No IP here."}
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()["detail"], "Missing 'ip' in payload for action 'block_ip'."
         )
 
-    def test_webhook_receiver_missing_api_key(self):
-        """Request without the API key should be unauthorized."""
+    def test_webhook_receiver_missing_signature(self):
+        """Request without the signature should be unauthorized."""
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
-        response = self.client.post("/webhook", json=payload)
+        body = json.dumps(payload).encode("utf-8")
+        response = self.client.post(
+            "/webhook",
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json()["detail"], "Unauthorized")
 
-    def test_webhook_receiver_invalid_api_key(self):
-        """Request with an incorrect API key should be unauthorized."""
+    def test_webhook_receiver_invalid_signature(self):
+        """Request with an incorrect signature should be unauthorized."""
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
+        body = json.dumps(payload).encode("utf-8")
+        wrong_sig = hmac.new(b"wrong", body, hashlib.sha256).hexdigest()
         response = self.client.post(
-            "/webhook", json=payload, headers={"X-API-Key": "wrong"}
+            "/webhook",
+            data=body,
+            headers={
+                "X-Signature": wrong_sig,
+                "Content-Type": "application/json",
+            },
         )
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.json()["detail"], "Unauthorized")
@@ -169,7 +192,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         """Test that a 503 error is returned if the Redis connection fails."""
         self.mock_get_redis.return_value = None
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()["detail"], "Redis service unavailable")
 
@@ -178,7 +201,7 @@ class TestAIWebhookComprehensive(unittest.TestCase):
         """Test that a 500 error is returned if a Redis command fails."""
         self.mock_redis_client.sadd.side_effect = Exception("Redis command failed")
         payload = {"action": "block_ip", "ip": "1.2.3.4"}
-        response = self.client.post("/webhook", json=payload, headers=self.headers)
+        response = self._post(payload)
 
         self.assertEqual(response.status_code, 500)
         self.assertIn("Failed to execute action", response.json()["detail"])


### PR DESCRIPTION
## Summary
- verify webhook requests with HMAC signatures using a shared secret
- enforce per-IP rate limiting and log requests to audit log
- document new webhook environment variables

## Testing
- `pre-commit run --files src/shared/config.py src/ai_service/ai_webhook.py test/ai_webhook/test_ai_webhook.py docs/configuration.md sample.env`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a57a4e3e4c83218d2d3a0734894c50