### PR TITLE
Defer logging config to runtime entrypoints

### DIFF
--- a/scripts/adaptive_rate_limit_daemon.py
+++ b/scripts/adaptive_rate_limit_daemon.py
@@ -1,15 +1,12 @@
 import asyncio
-import os
 import logging
+import os
 
 from src.util.adaptive_rate_limit_manager import compute_and_update
 
 SYNC_INTERVAL_SECONDS = int(os.getenv("ADAPTIVE_RATE_LIMIT_INTERVAL", "60"))
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 async def run_loop(stop_event: asyncio.Event | None = None) -> None:
@@ -27,6 +24,9 @@ async def run_loop(stop_event: asyncio.Event | None = None) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     try:
         asyncio.run(run_loop())
     except KeyboardInterrupt:

--- a/scripts/blocklist_sync_daemon.py
+++ b/scripts/blocklist_sync_daemon.py
@@ -1,14 +1,12 @@
 import asyncio
-import os
 import logging
+import os
+
 from src.util import community_blocklist_sync
 
 SYNC_INTERVAL_SECONDS = int(os.getenv("COMMUNITY_BLOCKLIST_SYNC_INTERVAL", "3600"))
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 async def run_sync_loop(stop_event: asyncio.Event | None = None) -> None:
@@ -27,6 +25,9 @@ async def run_sync_loop(stop_event: asyncio.Event | None = None) -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     try:
         asyncio.run(run_sync_loop())
     except KeyboardInterrupt:

--- a/scripts/peer_blocklist_sync_daemon.py
+++ b/scripts/peer_blocklist_sync_daemon.py
@@ -1,15 +1,12 @@
 import asyncio
-import os
 import logging
+import os
 
 from src.util import peer_blocklist_sync
 
 SYNC_INTERVAL_SECONDS = int(os.getenv("PEER_BLOCKLIST_SYNC_INTERVAL", "3600"))
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 async def run_sync_loop(stop_event: asyncio.Event | None = None) -> None:
@@ -28,6 +25,9 @@ async def run_sync_loop(stop_event: asyncio.Event | None = None) -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     try:
         asyncio.run(run_sync_loop())
     except KeyboardInterrupt:

--- a/src/captcha/custom_captcha_service.py
+++ b/src/captcha/custom_captcha_service.py
@@ -18,9 +18,6 @@ CAPTCHA_SECRET = get_secret("CAPTCHA_SECRET_FILE") or os.getenv("CAPTCHA_SECRET"
 CAPTCHA_SUCCESS_LOG = os.getenv("CAPTCHA_SUCCESS_LOG", "/app/logs/captcha_success.log")
 TOKEN_EXPIRY = int(os.getenv("CAPTCHA_TOKEN_EXPIRY_SECONDS", 300))
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 
@@ -172,3 +169,9 @@ async def verify(token: str, ip: str):
     ):
         return {"success": False}
     return {"success": True}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )

--- a/src/captcha/recaptcha_service.py
+++ b/src/captcha/recaptcha_service.py
@@ -1,8 +1,10 @@
-from fastapi import FastAPI, HTTPException
-import httpx
-import os
 import datetime
 import logging
+import os
+
+import httpx
+from fastapi import FastAPI, HTTPException
+
 from src.shared.config import get_secret
 
 app = FastAPI()
@@ -13,9 +15,6 @@ CAPTCHA_VERIFICATION_URL = os.getenv(
 CAPTCHA_SECRET = get_secret("CAPTCHA_SECRET_FILE") or os.getenv("CAPTCHA_SECRET")
 CAPTCHA_SUCCESS_LOG = os.getenv("CAPTCHA_SUCCESS_LOG", "/app/logs/captcha_success.log")
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 
@@ -48,3 +47,9 @@ async def verify_captcha(token: str, ip: str):
         except Exception as e:
             logger.error(f"Failed to log CAPTCHA success: {e}")
     return {"success": success}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )

--- a/src/escalation/escalation_engine.py
+++ b/src/escalation/escalation_engine.py
@@ -36,9 +36,6 @@ from src.shared.model_provider import get_model_adapter
 from src.shared.redis_client import get_redis_connection
 
 # --- Setup Logging ---
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 try:
@@ -1229,6 +1226,9 @@ async def admin_reload_plugins(request: Request):
 
 # --- Main (Preserved) ---
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     import uvicorn
 
     port = CONFIG.ESCALATION_ENGINE_PORT

--- a/src/iis_gateway/main.py
+++ b/src/iis_gateway/main.py
@@ -39,7 +39,6 @@ BAD_BOTS = [
     "wget",
 ]
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("iis_gateway")
 
 app = FastAPI()
@@ -138,6 +137,7 @@ async def proxy(path: str, request: Request) -> Response:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     import uvicorn
 
     uvicorn.run(app, host="0.0.0.0", port=9000)

--- a/src/tarpit/ip_flagger.py
+++ b/src/tarpit/ip_flagger.py
@@ -4,16 +4,13 @@ in a dedicated Redis database. It uses a centralized Redis connection
 utility from the 'shared' module.
 """
 
-import sys
 import logging
 import os
-from src.shared.redis_client import get_redis_connection
+
 from src.shared.config import tenant_key
+from src.shared.redis_client import get_redis_connection
 
 # Configure logging for this module
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 # Define the specific Redis database number for flagged IPs.
@@ -99,6 +96,9 @@ def remove_ip_flag(ip_address: str):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     # Example usage for direct testing of this module.
     print("Running IP Flagger example...")
     test_ip = "192.168.1.100"

--- a/src/tarpit/rotating_archive.py
+++ b/src/tarpit/rotating_archive.py
@@ -1,22 +1,19 @@
 # tarpit/rotating_archive.py
 # Periodically generates new fake JS ZIP archives and removes old ones.
 
-import os
 import glob
-import time
-import schedule  # Using 'schedule' library for easy job scheduling
-import sys
 import logging
+import os
+import time
+
+import schedule  # Using 'schedule' library for easy job scheduling
 
 # Configure module-level logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 # --- Import the generator script ---
 try:
-    from .js_zip_generator import create_fake_js_zip, DEFAULT_ARCHIVE_DIR
+    from .js_zip_generator import DEFAULT_ARCHIVE_DIR, create_fake_js_zip
 except ImportError as e:
     # Raise a clearer error so importing modules (like tests) fail gracefully
     raise ImportError(
@@ -75,6 +72,9 @@ def rotate_archives():
 
 # --- Main Execution Logic ---
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     logger.info("--- Rotating Archive Scheduler ---")
     logger.info(f"Watching directory: {ARCHIVE_DIR}")
     logger.info(f"Keeping latest: {MAX_ARCHIVES_TO_KEEP} archives")

--- a/src/tarpit/tarpit_api.py
+++ b/src/tarpit/tarpit_api.py
@@ -23,10 +23,6 @@ from src.shared.redis_client import get_redis_connection
 
 from .bad_api_generator import register_bad_endpoints
 
-logging.basicConfig(
-    level=CONFIG.LOG_LEVEL.upper(),
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 # --- Import Local & Shared Modules (Preserved from your original file) ---
@@ -374,6 +370,10 @@ async def root():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=CONFIG.LOG_LEVEL.upper(),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     import uvicorn
 
     logger.info("--- Tarpit API Starting ---")

--- a/src/util/adaptive_rate_limit_manager.py
+++ b/src/util/adaptive_rate_limit_manager.py
@@ -16,9 +16,6 @@ NGINX_RATE_LIMIT_CONF = os.getenv(
 )
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 def get_recent_counts(redis_conn, window_seconds: int) -> List[int]:
@@ -64,4 +61,7 @@ def compute_and_update(redis_conn: Optional[object] = None) -> int:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     compute_and_update()

--- a/src/util/cdn_manager.py
+++ b/src/util/cdn_manager.py
@@ -12,9 +12,6 @@ CLOUD_CDN_API_TOKEN = os.getenv("CLOUD_CDN_API_TOKEN") or get_secret(
 )
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 async def purge_cache() -> bool:
@@ -37,3 +34,9 @@ async def purge_cache() -> bool:
     except Exception as e:  # pragma: no cover - network/HTTP errors
         logger.error(f"Failed to purge CDN cache: {e}")
         return False
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )

--- a/src/util/community_blocklist_sync.py
+++ b/src/util/community_blocklist_sync.py
@@ -19,9 +19,6 @@ REDIS_DB_BLOCKLIST = int(os.getenv("REDIS_DB_BLOCKLIST", 2))
 BLOCKLIST_TTL_SECONDS = int(os.getenv("COMMUNITY_BLOCKLIST_TTL_SECONDS", 86400))
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 async def fetch_blocklist(url: str) -> List[str]:
@@ -85,4 +82,7 @@ async def sync_blocklist() -> Optional[int]:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     asyncio.run(sync_blocklist())

--- a/src/util/corpus_wikipedia_updater.py
+++ b/src/util/corpus_wikipedia_updater.py
@@ -1,7 +1,6 @@
 # util/corpus_wikipedia_updater.py
 import logging
 import os
-import logging
 import re
 import time
 
@@ -9,9 +8,6 @@ import wikipedia
 from wikipedia.exceptions import DisambiguationError, PageError
 
 # Set up basic logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 # No longer necessary with correct PYTHONPATH
@@ -165,4 +161,7 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     main()

--- a/src/util/ddos_protection.py
+++ b/src/util/ddos_protection.py
@@ -15,9 +15,6 @@ DDOS_PROTECTION_API_KEY = os.getenv("DDOS_PROTECTION_API_KEY") or get_secret(
 DDOS_INTERNAL_ENDPOINT = os.getenv("DDOS_INTERNAL_ENDPOINT", CONFIG.ESCALATION_ENDPOINT)
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 async def report_attack(
@@ -84,3 +81,9 @@ async def report_attack(
     except Exception as e:  # pragma: no cover - network/HTTP errors
         logger.error(f"Failed to submit IP {ip} for internal analysis: {e}")
         return False
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )

--- a/src/util/peer_blocklist_sync.py
+++ b/src/util/peer_blocklist_sync.py
@@ -14,9 +14,6 @@ REDIS_DB_BLOCKLIST = int(os.getenv("REDIS_DB_BLOCKLIST", 2))
 PEER_BLOCKLIST_TTL_SECONDS = int(os.getenv("PEER_BLOCKLIST_TTL_SECONDS", 86400))
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 async def fetch_peer_ips(url: str) -> List[str]:
@@ -87,4 +84,7 @@ async def sync_peer_blocklists() -> Optional[int]:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     asyncio.run(sync_peer_blocklists())

--- a/src/util/robots_fetcher.py
+++ b/src/util/robots_fetcher.py
@@ -30,9 +30,6 @@ except Exception:  # pragma: no cover - kubernetes may not be installed
 
 
 # --- Logging and Configuration ---
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 REAL_BACKEND_HOST = os.getenv("REAL_BACKEND_HOST", "http://example.com")
 CONFIGMAP_NAME = os.getenv("ROBOTS_CONFIGMAP_NAME", "live-robots-txt-config")
@@ -169,4 +166,7 @@ def _run_as_script() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     _run_as_script()

--- a/src/util/rules_fetcher.py
+++ b/src/util/rules_fetcher.py
@@ -35,9 +35,6 @@ except Exception:  # pragma: no cover - kubernetes may not be installed
 
 
 # --- Logging and Configuration ---
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 RULES_URL = os.getenv("RULES_DOWNLOAD_URL", "")
@@ -268,4 +265,7 @@ def _run_as_script() -> None:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     _run_as_script()

--- a/src/util/suricata_manager.py
+++ b/src/util/suricata_manager.py
@@ -11,9 +11,6 @@ ESCALATION_URL = os.getenv(
 )
 EVE_LOG_PATH = os.getenv("SURICATA_EVE_LOG", "/var/log/suricata/eve.json")
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 
@@ -68,4 +65,7 @@ def process_eve_log() -> int:
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     process_eve_log()

--- a/src/util/tls_manager.py
+++ b/src/util/tls_manager.py
@@ -6,9 +6,6 @@ TLS_PROVIDER = os.getenv("TLS_PROVIDER", "certbot")
 TLS_EMAIL = os.getenv("TLS_EMAIL")
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 def ensure_certificate(domain: str) -> bool:
@@ -19,3 +16,9 @@ def ensure_certificate(domain: str) -> bool:
     logger.info(f"Ensuring TLS certificate for {domain} via {TLS_PROVIDER}.")
     # Real certificate management would be implemented here.
     return True
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )

--- a/src/util/waf_manager.py
+++ b/src/util/waf_manager.py
@@ -10,9 +10,6 @@ WAF_RULES_PATH = os.getenv(
 NGINX_RELOAD_CMD = ["nginx", "-s", "reload"]
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 
 
 def load_waf_rules() -> list[str]:
@@ -46,3 +43,9 @@ def reload_waf_rules(rules: list[str]) -> bool:
     except Exception as exc:  # pylint: disable=broad-except
         logger.error("Failed to reload WAF rules: %s", exc)
         return False
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )


### PR DESCRIPTION
## Summary
- move logging.basicConfig into `if __name__ == "__main__"` blocks across scripts and utilities
- avoid configuring logging on import for services

## Testing
- `pre-commit run --files scripts/adaptive_rate_limit_daemon.py scripts/blocklist_sync_daemon.py scripts/peer_blocklist_sync_daemon.py src/captcha/custom_captcha_service.py src/captcha/recaptcha_service.py src/escalation/escalation_engine.py src/iis_gateway/main.py src/tarpit/ip_flagger.py src/tarpit/rotating_archive.py src/tarpit/tarpit_api.py src/util/adaptive_rate_limit_manager.py src/util/cdn_manager.py src/util/community_blocklist_sync.py src/util/corpus_wikipedia_updater.py src/util/ddos_protection.py src/util/peer_blocklist_sync.py src/util/robots_fetcher.py src/util/rules_fetcher.py src/util/suricata_manager.py src/util/tls_manager.py src/util/waf_manager.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a64ec35f2c8321a8cf643ba78bbd96