### PR TITLE
Add in-memory counter fallback for metrics

### DIFF
--- a/test/shared/test_metrics.py
+++ b/test/shared/test_metrics.py
@@ -1,9 +1,11 @@
 # test/shared/metrics.test.py
+import importlib
 import unittest
 from unittest.mock import patch
+
 from prometheus_client import CollectorRegistry, generate_latest
+
 from src.shared import metrics
-import importlib
 
 
 class TestMetricsComprehensive(unittest.TestCase):
@@ -42,6 +44,17 @@ class TestMetricsComprehensive(unittest.TestCase):
             ),
             1.0,
         )
+
+    def test_increment_counter_metric_in_memory(self):
+        """Ensure increment_counter_metric works with the in-memory counter."""
+        counter = metrics.InMemoryCounter("test")
+        metrics.increment_counter_metric(counter)
+        metrics.increment_counter_metric(counter)
+        self.assertEqual(counter.get(), 2)
+
+        labels = {"foo": "bar"}
+        metrics.increment_counter_metric(counter, labels=labels)
+        self.assertEqual(counter.get(**labels), 1)
 
     def test_set_gauge_metric(self):
         """Test the gauge set helper function with and without labels."""


### PR DESCRIPTION
## Summary
- add a lightweight `InMemoryCounter` to track metrics without Prometheus
- allow `increment_counter_metric` to operate on either Prometheus or in-memory counters
- test `increment_counter_metric` with the new counter

## Testing
- `pre-commit run --files src/shared/metrics.py test/shared/test_metrics.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6556849748321bb18959c5492d95e