### PR TITLE
Limit JSON payload size and sanitize logging

### DIFF
--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -7,6 +7,8 @@ import time
 import httpx
 from fastapi import FastAPI, HTTPException, Request, Response
 
+from src.shared.request_utils import read_json_body
+
 LOCAL_LLM_URL = os.getenv("LOCAL_LLM_URL", "http://llama3:11434/api/generate")
 CLOUD_PROXY_URL = os.getenv("CLOUD_PROXY_URL", "http://cloud_proxy:8008/api/chat")
 MAX_LOCAL_TOKENS = int(os.getenv("MAX_LOCAL_TOKENS", "1000"))
@@ -98,7 +100,7 @@ async def route_prompt(request: Request, response: Response) -> dict:
     response.headers["X-RateLimit-Remaining"] = str(remaining)
     response.headers["X-RateLimit-Reset"] = str(int(reset))
 
-    payload = await request.json()
+    payload = await read_json_body(request)
     prompt = payload.get("prompt", "")
     prompt_tokens = count_tokens(prompt)
     target = LOCAL_LLM_URL if prompt_tokens <= MAX_LOCAL_TOKENS else CLOUD_PROXY_URL

--- a/src/admin_ui/blocklist.py
+++ b/src/admin_ui/blocklist.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from src.shared.audit import log_event
 from src.shared.config import tenant_key
 from src.shared.redis_client import get_redis_connection
+from src.shared.request_utils import read_json_body
 
 from . import metrics
 from .auth import require_admin, require_auth
@@ -119,7 +120,7 @@ async def get_blocklist(user: str = Depends(require_auth)):
 
 @router.post("/block")
 async def block_ip(request: Request, user: str = Depends(require_admin)):
-    json_data = await request.json()
+    json_data = await read_json_body(request)
     if not json_data:
         return JSONResponse(
             {"error": "Invalid request, missing JSON body"}, status_code=400
@@ -144,7 +145,7 @@ async def block_ip(request: Request, user: str = Depends(require_admin)):
 
 @router.post("/unblock")
 async def unblock_ip(request: Request, user: str = Depends(require_admin)):
-    json_data = await request.json()
+    json_data = await read_json_body(request)
     if not json_data:
         return JSONResponse(
             {"error": "Invalid request, missing JSON body"}, status_code=400

--- a/src/ai_service/alerts.py
+++ b/src/ai_service/alerts.py
@@ -74,7 +74,6 @@ def _load_smtp_password() -> Optional[str]:
             "Unexpected error loading SMTP password from %s: %s",
             ALERT_SMTP_PASSWORD_FILE,
             e,
-            exc_info=True,
         )
     return None
 

--- a/src/ai_service/community_reporting.py
+++ b/src/ai_service/community_reporting.py
@@ -128,6 +128,6 @@ async def report_ip_to_community(ip: str, reason: str, details: Dict) -> bool:
         increment_counter_metric(COMMUNITY_REPORTS_ERRORS_RESPONSE_DECODE)
         return False
     except Exception as e:  # pragma: no cover - unexpected
-        logger.error("Unexpected error reporting IP %s: %s", ip, e, exc_info=True)
+        logger.error("Unexpected error reporting IP %s: %s", ip, e)
         increment_counter_metric(COMMUNITY_REPORTS_ERRORS_UNEXPECTED)
         return False

--- a/src/ai_service/main.py
+++ b/src/ai_service/main.py
@@ -166,8 +166,8 @@ async def webhook_receiver(request: Request, response: Response):
             raise HTTPException(status_code=400, detail=f"Invalid action: {action}")
     except HTTPException:
         raise
-    except Exception:
-        logger.error("Failed to execute action", exc_info=True)
+    except Exception as e:
+        logger.error("Failed to execute action: %s", e)
         raise HTTPException(status_code=500, detail="Failed to execute action")
 
 

--- a/src/shared/model_provider.py
+++ b/src/shared/model_provider.py
@@ -100,8 +100,7 @@ def get_model_adapter(
             return adapter_class(model_path)
         except Exception as e:
             logging.error(
-                f"Attempt {attempt} failed to instantiate adapter for scheme '{scheme}': {e}",
-                exc_info=True,
+                f"Attempt {attempt} failed to instantiate adapter for scheme '{scheme}': {e}"
             )
             if attempt < retries:
                 backoff = delay * (2 ** (attempt - 1))

--- a/src/shared/slack_alert.py
+++ b/src/shared/slack_alert.py
@@ -15,7 +15,7 @@ Usage Example:
     slack_sender = SlackAlertSender(
         webhook_url="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
     )
-    
+
     await slack_sender.send_slack_alert({
         "reason": "High Combined Score (0.95)",
         "ip": "192.168.1.1",
@@ -27,7 +27,7 @@ Usage Example:
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from .http_alert import AlertDeliveryError, HttpAlertSender
 
@@ -36,18 +36,18 @@ logger = logging.getLogger(__name__)
 
 class SlackAlertSender(HttpAlertSender):
     """Slack-specific alert sender with rich message formatting.
-    
+
     This class extends the generic HttpAlertSender to provide Slack-specific
     formatting including emoji, markdown, colors, and structured attachments.
     It handles the nuances of Slack's webhook API and message format requirements.
-    
+
     Attributes:
         channel (str): Optional Slack channel override (if not set in webhook URL)
         username (str): Username for the bot sending messages
         icon_emoji (str): Emoji icon for the bot
         color_mapping (Dict[str, str]): Mapping of alert severities to Slack colors
     """
-    
+
     def __init__(
         self,
         webhook_url: str,
@@ -55,10 +55,10 @@ class SlackAlertSender(HttpAlertSender):
         channel: Optional[str] = None,
         username: str = "AI Defense Bot",
         icon_emoji: str = ":shield:",
-        verify_ssl: bool = True
+        verify_ssl: bool = True,
     ):
         """Initialize the Slack alert sender.
-        
+
         Args:
             webhook_url: Slack webhook URL for sending messages
             timeout: Timeout in seconds for HTTP requests
@@ -72,23 +72,23 @@ class SlackAlertSender(HttpAlertSender):
             webhook_url=webhook_url,
             timeout=timeout,
             default_headers={"Content-Type": "application/json"},
-            verify_ssl=verify_ssl
+            verify_ssl=verify_ssl,
         )
-        
+
         self.channel = channel
         self.username = username
         self.icon_emoji = icon_emoji
-        
+
         # Color mapping for different alert severities
         self.color_mapping = {
             "critical": "#FF0000",  # Red
-            "high": "#FF6600",      # Orange
-            "medium": "#FFCC00",    # Yellow
-            "low": "#00CC00",       # Green
-            "info": "#0099FF",      # Blue
-            "warning": "#FF9900",   # Orange-yellow
+            "high": "#FF6600",  # Orange
+            "medium": "#FFCC00",  # Yellow
+            "low": "#00CC00",  # Green
+            "info": "#0099FF",  # Blue
+            "warning": "#FF9900",  # Orange-yellow
         }
-        
+
         # Emoji mapping for different alert types and reasons
         self.emoji_mapping = {
             "high_combined": ":rotating_light:",
@@ -100,44 +100,44 @@ class SlackAlertSender(HttpAlertSender):
             "scan": ":mag:",
             "scraping": ":spider:",
             "crawler": ":robot_face:",
-            "default": ":shield:"
+            "default": ":shield:",
         }
-    
+
     def get_alert_emoji(self, reason: str, alert_type: str = "") -> str:
         """Get appropriate emoji for the alert based on reason and type.
-        
+
         Args:
             reason: Alert reason (e.g., "High Combined Score")
             alert_type: Optional alert type for more specific emoji selection
-            
+
         Returns:
             str: Emoji code suitable for Slack messages
         """
         reason_lower = reason.lower()
-        
+
         # Check for specific patterns in the reason
         for key, emoji in self.emoji_mapping.items():
             if key in reason_lower:
                 return emoji
-        
+
         # Default emoji
         return self.emoji_mapping["default"]
-    
+
     def format_slack_message_text(self, alert_data: Dict[str, Any]) -> str:
         """Format the main message text for Slack with rich formatting.
-        
+
         Args:
             alert_data: Alert data including reason, IP, user agent, etc.
-            
+
         Returns:
             str: Formatted Slack message text with markdown
         """
         reason = alert_data.get("reason", "Unknown reason")
-        
+
         # Extract IP and user agent from either top level or details
         ip = alert_data.get("ip", "N/A")
         user_agent = alert_data.get("user_agent", "N/A")
-        
+
         # If not found at top level, check in details
         details = alert_data.get("details", {})
         if isinstance(details, dict):
@@ -145,12 +145,14 @@ class SlackAlertSender(HttpAlertSender):
                 ip = details.get("ip", "N/A")
             if user_agent == "N/A":
                 user_agent = details.get("user_agent", "N/A")
-        
-        timestamp_utc = alert_data.get("timestamp_utc", datetime.now(timezone.utc).isoformat())
-        
+
+        timestamp_utc = alert_data.get(
+            "timestamp_utc", datetime.now(timezone.utc).isoformat()
+        )
+
         # Get appropriate emoji for this alert
         emoji = self.get_alert_emoji(reason)
-        
+
         # Format the main message
         message = (
             f"{emoji} *AI Defense Alert*\n"
@@ -159,7 +161,7 @@ class SlackAlertSender(HttpAlertSender):
             f"> *User Agent:* `{user_agent}`\n"
             f"> *Timestamp (UTC):* {timestamp_utc}"
         )
-        
+
         # Add additional details if available
         details = alert_data.get("details", {})
         if isinstance(details, dict):
@@ -169,21 +171,21 @@ class SlackAlertSender(HttpAlertSender):
                 message += f"\n> *Method:* `{details['method']}`"
             if details.get("score"):
                 message += f"\n> *Score:* `{details['score']}`"
-        
+
         return message
-    
+
     def format_slack_attachment(self, alert_data: Dict[str, Any]) -> Dict[str, Any]:
         """Format a detailed Slack attachment for the alert.
-        
+
         Args:
             alert_data: Alert data to format into an attachment
-            
+
         Returns:
             Dict: Slack attachment object with fields and formatting
         """
         reason = alert_data.get("reason", "Unknown reason")
         details = alert_data.get("details", {})
-        
+
         # Determine color based on alert severity or reason
         color = self.color_mapping.get("medium")  # Default color
         reason_lower = reason.lower()
@@ -193,25 +195,29 @@ class SlackAlertSender(HttpAlertSender):
             color = self.color_mapping.get("high")
         elif "honeypot" in reason_lower:
             color = self.color_mapping.get("warning")
-        
+
         # Build attachment fields
         fields = []
-        
+
         # Add basic alert information
         if alert_data.get("event_type"):
-            fields.append({
-                "title": "Event Type",
-                "value": alert_data["event_type"],
-                "short": True
-            })
-        
+            fields.append(
+                {
+                    "title": "Event Type",
+                    "value": alert_data["event_type"],
+                    "short": True,
+                }
+            )
+
         # Add detail fields from the details dictionary
         if isinstance(details, dict):
             for key, value in details.items():
-                if key not in ["ip", "user_agent"] and value:  # Skip already displayed fields
+                if (
+                    key not in ["ip", "user_agent"] and value
+                ):  # Skip already displayed fields
                     # Format field title (convert snake_case to Title Case)
                     title = key.replace("_", " ").title()
-                    
+
                     # Format value appropriately
                     if isinstance(value, (dict, list)):
                         value_str = str(value)
@@ -219,95 +225,101 @@ class SlackAlertSender(HttpAlertSender):
                             value_str = value_str[:97] + "..."
                     else:
                         value_str = str(value)
-                    
-                    fields.append({
-                        "title": title,
-                        "value": value_str,
-                        "short": len(value_str) < 30
-                    })
-        
+
+                    fields.append(
+                        {
+                            "title": title,
+                            "value": value_str,
+                            "short": len(value_str) < 30,
+                        }
+                    )
+
         attachment = {
             "color": color,
             "fields": fields,
             "footer": "AI Scraping Defense System",
             "footer_icon": "https://github.com/rhamenator/ai-scraping-defense/raw/main/docs/ai-defense-icon.png",
-            "ts": int(datetime.now(timezone.utc).timestamp())
+            "ts": int(datetime.now(timezone.utc).timestamp()),
         }
-        
+
         return attachment
-    
+
     def format_alert_payload(self, alert_data: Dict[str, Any]) -> Dict[str, Any]:
         """Format alert data into Slack webhook payload.
-        
+
         Args:
             alert_data: Alert data from the AI Defense System
-            
+
         Returns:
             Dict: Slack webhook payload with rich formatting
         """
         # Format the main message text
         message_text = self.format_slack_message_text(alert_data)
-        
+
         # Build the base payload
         payload = {
             "text": message_text,
             "username": self.username,
-            "icon_emoji": self.icon_emoji
+            "icon_emoji": self.icon_emoji,
         }
-        
+
         # Add channel if specified
         if self.channel:
             payload["channel"] = self.channel
-        
+
         # Add detailed attachment for rich formatting
         attachment = self.format_slack_attachment(alert_data)
         if attachment["fields"]:  # Only add attachment if it has content
             payload["attachments"] = [attachment]
-        
-        logger.debug(f"Formatted Slack payload with {len(attachment.get('fields', []))} detail fields")
+
+        logger.debug(
+            f"Formatted Slack payload with {len(attachment.get('fields', []))} detail fields"
+        )
         return payload
-    
+
     async def send_slack_alert(self, alert_data: Dict[str, Any]) -> bool:
         """Send a Slack alert with AI Defense System specific formatting.
-        
+
         This method provides a convenient interface for sending alerts with
         the expected data structure from the AI webhook system.
-        
+
         Args:
             alert_data: Dict containing:
                 - reason (str): Alert reason/trigger
                 - details (dict): Request details including ip, user_agent, etc.
                 - timestamp_utc (str): UTC timestamp
                 - event_type (str, optional): Type of event
-                
+
         Returns:
             bool: True if alert was sent successfully
         """
         # Extract IP and user agent from details for top-level access
         details = alert_data.get("details", {})
         formatted_data = alert_data.copy()
-        
+
         if isinstance(details, dict):
             formatted_data["ip"] = details.get("ip", "N/A")
             formatted_data["user_agent"] = details.get("user_agent", "N/A")
-        
+
         logger.info(f"Sending Slack alert for IP: {formatted_data.get('ip', 'N/A')}")
-        
+
         try:
             success = await self.send_alert(formatted_data)
             if success:
-                logger.info(f"Slack alert sent successfully for IP {formatted_data.get('ip', 'N/A')}")
+                logger.info(
+                    f"Slack alert sent successfully for IP {formatted_data.get('ip', 'N/A')}"
+                )
             return success
         except AlertDeliveryError as e:
             logger.error(f"Failed to deliver Slack alert: {e}")
             return False
         except Exception as e:
-            logger.error(f"Unexpected error sending Slack alert: {e}", exc_info=True)
+            logger.error(f"Unexpected error sending Slack alert: {e}")
             return False
-    
+
     async def send_test_slack_alert(self) -> bool:
         """Send a test Slack alert to verify configuration.
-        
+
         Returns:
             bool: True if the test alert was sent successfully
         """
@@ -321,21 +333,21 @@ class SlackAlertSender(HttpAlertSender):
                 "path": "/test",
                 "method": "GET",
                 "test_mode": True,
-                "score": "0.1"
-            }
+                "score": "0.1",
+            },
         }
-        
+
         logger.info("Sending Slack test alert")
         return await self.send_slack_alert(test_alert_data)
 
 
 def create_slack_alert_sender(webhook_url: str, **kwargs) -> SlackAlertSender:
     """Factory function to create a SlackAlertSender instance.
-    
+
     Args:
         webhook_url: Slack webhook URL
         **kwargs: Additional configuration options for SlackAlertSender
-        
+
     Returns:
         SlackAlertSender: Configured Slack alert sender instance
     """

--- a/src/tarpit/bad_api_generator.py
+++ b/src/tarpit/bad_api_generator.py
@@ -74,7 +74,7 @@ def register_bad_endpoints(app: FastAPI, count: int = 5) -> List[str]:
                 try:
                     log_honeypot_hit(details)
                 except Exception as exc:  # pragma: no cover - log unexpected error
-                    logger.error(f"Error logging honeypot hit: {exc}", exc_info=True)
+                    logger.error(f"Error logging honeypot hit: {exc}")
             logger.info(f"BAD API HIT: /api{path} from {client_ip}")
             return JSONResponse({"detail": "Invalid API endpoint"}, status_code=404)
 

--- a/src/tarpit/tarpit_api.py
+++ b/src/tarpit/tarpit_api.py
@@ -179,7 +179,7 @@ def trigger_ip_block(ip: str, reason: str):
         logger.error(f"Redis error while trying to block IP {ip}: {e}")
         return False
     except Exception as e:
-        logger.error(f"Unexpected error while blocking IP {ip}: {e}", exc_info=True)
+        logger.error(f"Unexpected error while blocking IP {ip}: {e}")
         return False
 
 
@@ -237,8 +237,7 @@ async def tarpit_handler(request: Request, path: str = ""):
             logger.error(f"Redis error during hop limit check for IP {client_ip}: {e}")
         except Exception as e:
             logger.error(
-                f"Unexpected error during hop limit check for IP {client_ip}: {e}",
-                exc_info=True,
+                f"Unexpected error during hop limit check for IP {client_ip}: {e}"
             )
 
     logger.info(
@@ -256,13 +255,13 @@ async def tarpit_handler(request: Request, path: str = ""):
         try:
             log_honeypot_hit(honeypot_details)
         except Exception as e:
-            logger.error(f"Error logging honeypot hit: {e}", exc_info=True)
+            logger.error(f"Error logging honeypot hit: {e}")
 
     if FLAGGING_AVAILABLE:
         try:
             flag_suspicious_ip(ip_address=client_ip, reason="Tarpit Hit")
         except Exception as e:
-            logger.error(f"Error flagging IP {client_ip}: {e}", exc_info=True)
+            logger.error(f"Error flagging IP {client_ip}: {e}")
 
     timestamp_iso = (
         datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -295,7 +294,6 @@ async def tarpit_handler(request: Request, path: str = ""):
             client_ip,
             ESCALATION_ENDPOINT,
             e,
-            exc_info=True,
         )
 
     content = "<html><body>Tarpit Error</body></html>"
@@ -309,8 +307,7 @@ async def tarpit_handler(request: Request, path: str = ""):
             )
         except Exception as e:
             logger.error(
-                f"Error generating labyrinth page for path '{requested_path}': {e}",
-                exc_info=True,
+                f"Error generating labyrinth page for path '{requested_path}': {e}"
             )
     elif GENERATOR_AVAILABLE:
         try:
@@ -323,8 +320,7 @@ async def tarpit_handler(request: Request, path: str = ""):
             content = generate_dynamic_tarpit_page(rng)
         except Exception as e:
             logger.error(
-                f"Error generating dynamic page for path '{requested_path}': {e}",
-                exc_info=True,
+                f"Error generating dynamic page for path '{requested_path}': {e}"
             )
             content = "<html><head><title>Error</title></head><body>Service temporarily unavailable.</body></html>"
     else:

--- a/src/util/corpus_wikipedia_updater.py
+++ b/src/util/corpus_wikipedia_updater.py
@@ -109,10 +109,7 @@ def fetch_random_wikipedia_articles(num_articles: int) -> list[str]:
         except PageError:
             logger.warning("Could not find a page for a random title, skipping.")
         except Exception as e:
-            logger.error(
-                f"An unexpected error occurred while fetching an article: {e}",
-                exc_info=True,
-            )
+            logger.error(f"An unexpected error occurred while fetching an article: {e}")
             time.sleep(2)  # Wait a bit longer after an unexpected error
 
     return fetched_articles
@@ -147,9 +144,7 @@ def update_corpus_file(articles: list[str]):
     except IOError as e:
         logger.error(f"Failed to write to corpus file {CORPUS_OUTPUT_FILE}: {e}")
     except Exception as e:
-        logger.error(
-            f"An unexpected error occurred during file update: {e}", exc_info=True
-        )
+        logger.error(f"An unexpected error occurred during file update: {e}")
 
 
 def main():


### PR DESCRIPTION
## Summary
- add shared helper to read JSON bodies with maximum size limit
- use streaming JSON parsing in prompt router, admin blocklist, and escalation endpoints
- replace `exc_info` logging with sanitized error messages across services

## Testing
- `pre-commit run --files prompt-router/main.py src/admin_ui/blocklist.py src/ai_service/alerts.py src/ai_service/community_reporting.py src/ai_service/main.py src/escalation/escalation_engine.py src/shared/http_alert.py src/shared/model_provider.py src/shared/slack_alert.py src/tarpit/bad_api_generator.py src/tarpit/tarpit_api.py src/util/corpus_wikipedia_updater.py src/shared/request_utils.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a65d1a0ae48321bde2c17e875f617f