### PR TITLE
Handle Redis errors gracefully

### DIFF
--- a/src/admin_ui/blocklist.py
+++ b/src/admin_ui/blocklist.py
@@ -7,6 +7,7 @@ from ipaddress import ip_address
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
+from redis.exceptions import RedisError
 
 from src.shared.audit import log_event
 from src.shared.config import tenant_key
@@ -84,6 +85,9 @@ async def block_stats(user: str = Depends(require_auth)):
                 temp_block_count += len(keys)
                 if cursor == 0:
                     break
+        except RedisError as exc:
+            logger.error("Error loading blocklist from redis", exc_info=exc)
+            return JSONResponse({"error": f"Redis error: {exc}"}, status_code=503)
         except Exception as exc:
             logger.error("Error loading blocklist from redis", exc_info=exc)
 
@@ -105,9 +109,13 @@ async def get_blocklist(user: str = Depends(require_auth)):
     if not redis_conn:
         return JSONResponse({"error": "Redis service unavailable"}, status_code=503)
 
-    blocklist_set = redis_conn.smembers(tenant_key("blocklist"))
-    if asyncio.iscoroutine(blocklist_set):
-        blocklist_set = await blocklist_set
+    try:
+        blocklist_set = redis_conn.smembers(tenant_key("blocklist"))
+        if asyncio.iscoroutine(blocklist_set):
+            blocklist_set = await blocklist_set
+    except RedisError as exc:
+        return JSONResponse({"error": f"Redis error: {exc}"}, status_code=503)
+
     if isinstance(blocklist_set, (set, list)):
         return JSONResponse(list(blocklist_set))
 
@@ -138,7 +146,10 @@ async def block_ip(request: Request, user: str = Depends(require_admin)):
     if not redis_conn:
         return JSONResponse({"error": "Redis service unavailable"}, status_code=503)
 
-    redis_conn.sadd(tenant_key("blocklist"), normalized_ip)
+    try:
+        redis_conn.sadd(tenant_key("blocklist"), normalized_ip)
+    except RedisError as exc:
+        return JSONResponse({"error": f"Redis error: {exc}"}, status_code=503)
     log_event(user, "block_ip", {"ip": normalized_ip})
     return JSONResponse({"status": "success", "ip": normalized_ip})
 
@@ -163,6 +174,9 @@ async def unblock_ip(request: Request, user: str = Depends(require_admin)):
     if not redis_conn:
         return JSONResponse({"error": "Redis service unavailable"}, status_code=503)
 
-    redis_conn.srem(tenant_key("blocklist"), normalized_ip)
+    try:
+        redis_conn.srem(tenant_key("blocklist"), normalized_ip)
+    except RedisError as exc:
+        return JSONResponse({"error": f"Redis error: {exc}"}, status_code=503)
     log_event(user, "unblock_ip", {"ip": normalized_ip})
     return JSONResponse({"status": "success", "ip": normalized_ip})

--- a/src/ai_service/main.py
+++ b/src/ai_service/main.py
@@ -169,7 +169,7 @@ async def webhook_receiver(request: Request, response: Response):
         raise
     except RedisError as e:
         logger.error("Redis error during action %s: %s", action, e)
-        raise HTTPException(status_code=503, detail=f"Redis error: {e}")
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
     except Exception as e:
         logger.error("Failed to execute action: %s", e)
         raise HTTPException(status_code=500, detail="Failed to execute action")

--- a/src/shared/request_utils.py
+++ b/src/shared/request_utils.py
@@ -16,9 +16,9 @@ async def read_json_body(
     """Read JSON body from request with a maximum size limit."""
     body = io.BytesIO()
     async for chunk in request.stream():
-        body.write(chunk)
-        if body.tell() > max_bytes:
+        if body.tell() + len(chunk) > max_bytes:
             raise HTTPException(status_code=413, detail="Payload too large")
+        body.write(chunk)
     try:
         return json.loads(body.getvalue().decode())
     except json.JSONDecodeError as exc:

--- a/src/shared/request_utils.py
+++ b/src/shared/request_utils.py
@@ -1,23 +1,19 @@
+import io
 import json
 import os
 
 from fastapi import HTTPException, Request
 
-MAX_JSON_PAYLOAD_SIZE = int(os.getenv("MAX_JSON_PAYLOAD_SIZE", "1048576"))
-
-# 1MB default limit for JSON payloads
 DEFAULT_MAX_PAYLOAD_BYTES = 1048576  # 1MB default limit
-MAX_JSON_PAYLOAD_SIZE = int(os.getenv("MAX_JSON_PAYLOAD_SIZE", str(DEFAULT_MAX_PAYLOAD_BYTES)))
+MAX_JSON_PAYLOAD_SIZE = int(
+    os.getenv("MAX_JSON_PAYLOAD_SIZE", str(DEFAULT_MAX_PAYLOAD_BYTES))
+)
+
+
 async def read_json_body(
     request: Request, max_bytes: int = MAX_JSON_PAYLOAD_SIZE
 ) -> dict:
     """Read JSON body from request with a maximum size limit."""
-    body = bytearray()
-    async for chunk in request.stream():
-        body.extend(chunk)
-        if len(body) > max_bytes:
-            raise HTTPException(status_code=413, detail="Payload too large")
-    try:
     body = io.BytesIO()
     async for chunk in request.stream():
         body.write(chunk)


### PR DESCRIPTION
## Summary
- catch Redis errors in Cloud Dashboard API endpoints and websocket to return 503 JSON
- return 503 on Redis errors in webhook actions
- add Redis error handling for admin blocklist endpoints
- fix request utils indentation and consolidate JSON body reading

## Testing
- `pre-commit run --files src/shared/request_utils.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66356cb848321acd5aa1535f7011e