### PR TITLE
Guard audit log file permissions

### DIFF
--- a/src/shared/audit.py
+++ b/src/shared/audit.py
@@ -14,9 +14,11 @@ except OSError as e:
 logger = logging.getLogger("audit")
 if not logger.handlers:
     try:
-        handler = RotatingFileHandler(LOG_PATH, maxBytes=1_000_000, backupCount=3)
         Path(LOG_PATH).touch(exist_ok=True)
-        os.chmod(LOG_PATH, 0o600)
+        try:
+            os.chmod(LOG_PATH, 0o600)
+        except OSError as e:
+            logging.warning("Cannot set audit log file permissions: %s", e)
         handler = RotatingFileHandler(LOG_PATH, maxBytes=1_000_000, backupCount=3)
         formatter = logging.Formatter("%(asctime)s %(message)s")
         handler.setFormatter(formatter)

--- a/src/shared/audit.py
+++ b/src/shared/audit.py
@@ -18,7 +18,7 @@ if not logger.handlers:
         try:
             os.chmod(LOG_PATH, 0o600)
         except OSError as e:
-            logging.warning("Cannot set audit log file permissions: %s", e)
+            logger.warning("Cannot set audit log file permissions: %s", e)
         handler = RotatingFileHandler(LOG_PATH, maxBytes=1_000_000, backupCount=3)
         formatter = logging.Formatter("%(asctime)s %(message)s")
         handler.setFormatter(formatter)


### PR DESCRIPTION
## Summary
- remove duplicate RotatingFileHandler initialization
- ignore chmod failures and warn when audit log permissions cannot be set

## Testing
- `pre-commit run --files src/shared/audit.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a67a26b99883218ca9c84a03e9363e