### PR TITLE
Use logging in get_secret

### DIFF
--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -14,7 +14,7 @@ def get_secret(file_variable_name: str) -> Optional[str]:
             with open(file_path, "r") as f:
                 return f.read().strip()
         except IOError as exc:
-            logging.warning("Could not read secret file at %s: %s", file_path, exc)
+            logger.warning("Could not read secret file at %s: %s", file_path, exc)
     return None
 
 


### PR DESCRIPTION
## Summary
- switch get_secret to use logging.warning for file read errors

## Testing
- `pre-commit run --files src/shared/config.py`
- `python -m pytest test/shared/test_config_redis_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68ff70d608321836ebf063ace1397