### PR TITLE
Add tests for plugin discovery and shared utilities

### DIFF
--- a/test/admin_ui/test_plugin_discovery.py
+++ b/test/admin_ui/test_plugin_discovery.py
@@ -1,0 +1,22 @@
+# test/admin_ui/test_plugin_discovery.py
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from src.admin_ui.admin_ui import _discover_plugins
+
+
+class TestPluginDiscovery(unittest.TestCase):
+    def test_discovers_sorted_python_modules(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            open(os.path.join(tmpdir, "a.py"), "w").close()
+            open(os.path.join(tmpdir, "b.py"), "w").close()
+            open(os.path.join(tmpdir, "_c.py"), "w").close()
+            open(os.path.join(tmpdir, "d.txt"), "w").close()
+            with patch.dict(os.environ, {"PLUGIN_DIR": tmpdir}):
+                self.assertEqual(_discover_plugins(), ["a", "b"])
+
+    def test_missing_directory_returns_empty_list(self):
+        with patch.dict(os.environ, {"PLUGIN_DIR": "/no/such/dir"}):
+            self.assertEqual(_discover_plugins(), [])

--- a/test/admin_ui/test_webauthn.py
+++ b/test/admin_ui/test_webauthn.py
@@ -1,0 +1,53 @@
+# test/admin_ui/test_webauthn.py
+import base64
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.admin_ui import webauthn
+
+
+class TestWebAuthnFlows(unittest.TestCase):
+    def test_store_and_consume_challenge(self):
+        mock_redis = MagicMock()
+        with patch(
+            "src.admin_ui.webauthn.get_redis_connection", return_value=mock_redis
+        ):
+            webauthn._store_webauthn_challenge("user", b"abc")
+            mock_redis.set.assert_called_once()
+        mock_redis.getdel.return_value = base64.b64encode(b"abc")
+        with patch(
+            "src.admin_ui.webauthn.get_redis_connection", return_value=mock_redis
+        ):
+            result = webauthn._consume_webauthn_challenge("user")
+        self.assertEqual(result, b"abc")
+
+    def test_store_and_consume_token(self):
+        mock_redis = MagicMock()
+        future = time.time() + 10
+        with patch(
+            "src.admin_ui.webauthn.get_redis_connection", return_value=mock_redis
+        ):
+            webauthn._store_webauthn_token("tok", "user", exp=future)
+            args, kwargs = mock_redis.set.call_args
+            self.assertEqual(args[0], webauthn._token_key("tok"))
+            self.assertEqual(args[1], "user")
+            self.assertGreater(kwargs["ex"], 0)
+        mock_redis.getdel.return_value = "user"
+        with patch(
+            "src.admin_ui.webauthn.get_redis_connection", return_value=mock_redis
+        ):
+            self.assertEqual(webauthn._consume_webauthn_token("tok"), "user")
+
+    def test_has_webauthn_tokens(self):
+        mock_redis = MagicMock()
+        mock_redis.scan_iter.return_value = iter(["token"])
+        with patch(
+            "src.admin_ui.webauthn.get_redis_connection", return_value=mock_redis
+        ):
+            self.assertTrue(webauthn._has_webauthn_tokens())
+        mock_redis.scan_iter.return_value = iter([])
+        with patch(
+            "src.admin_ui.webauthn.get_redis_connection", return_value=mock_redis
+        ):
+            self.assertFalse(webauthn._has_webauthn_tokens())

--- a/test/shared/test_audit.py
+++ b/test/shared/test_audit.py
@@ -1,0 +1,23 @@
+# test/shared/test_audit.py
+import importlib
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+class TestAuditLogging(unittest.TestCase):
+    def test_log_event_writes_expected_format(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "audit.log")
+            with patch.dict(os.environ, {"AUDIT_LOG_FILE": log_file}):
+                from src.shared import audit
+
+                for h in list(audit.logger.handlers):
+                    audit.logger.removeHandler(h)
+                    h.close()
+                importlib.reload(audit)
+                audit.log_event("user", "action", {"foo": "bar"})
+            with open(log_file) as f:
+                line = f.read().strip()
+        self.assertIn('user\taction\t{"foo": "bar"}', line)

--- a/test/shared/test_audit.py
+++ b/test/shared/test_audit.py
@@ -15,7 +15,19 @@ class TestAuditLogging(unittest.TestCase):
 
                 for h in list(audit.logger.handlers):
                     audit.logger.removeHandler(h)
-                    h.close()
+    def tearDown(self):
+        # Clean up logger handlers if audit module was imported
+        if hasattr(self, "audit"):
+            for h in list(self.audit.logger.handlers):
+                self.audit.logger.removeHandler(h)
+                h.close()
+
+    def test_log_event_writes_expected_format(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "audit.log")
+            with patch.dict(os.environ, {"AUDIT_LOG_FILE": log_file}):
+                from src.shared import audit
+                self.audit = audit
                 importlib.reload(audit)
                 audit.log_event("user", "action", {"foo": "bar"})
             with open(log_file) as f:

--- a/test/shared/test_redis_client_error_handling.py
+++ b/test/shared/test_redis_client_error_handling.py
@@ -1,0 +1,29 @@
+# test/shared/test_redis_client_error_handling.py
+import unittest
+from unittest.mock import patch
+
+from src.shared import redis_client
+
+
+class TestRedisClientErrorHandling(unittest.TestCase):
+    def test_missing_password_file_fail_fast(self):
+        with patch.dict(
+            redis_client.os.environ,
+            {"REDIS_PASSWORD_FILE": "/no/file"},
+        ), patch("builtins.open", side_effect=FileNotFoundError), patch(
+            "logging.error"
+        ) as mock_log:
+            with self.assertRaises(redis_client.RedisConnectionError):
+                redis_client.get_redis_connection(fail_fast=True)
+            mock_log.assert_called_once_with(
+                "Redis password file not found at /no/file"
+            )
+
+    def test_connection_error_without_fail_fast(self):
+        with patch(
+            "src.shared.redis_client._create_client",
+            side_effect=redis_client.redis.ConnectionError(),
+        ), patch("logging.error") as mock_log:
+            conn = redis_client.get_redis_connection()
+            self.assertIsNone(conn)
+            mock_log.assert_called_once()


### PR DESCRIPTION
## Summary
- test plugin discovery returns sorted modules and handles missing directory
- add WebAuthn token and challenge storage tests
- cover Redis client error handling and audit log formatting

## Testing
- `pre-commit run --files test/admin_ui/test_plugin_discovery.py test/admin_ui/test_webauthn.py test/shared/test_redis_client_error_handling.py test/shared/test_audit.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6bde419808321a9d2e308569792ac