### PR TITLE
Add Vault secret support and secure cleanup

### DIFF
--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -5,14 +5,49 @@ import os
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_vault_secret(secret_path: str) -> Optional[str]:
+    """Retrieve a secret from HashiCorp Vault via HTTP."""
+    vault_addr = os.getenv("VAULT_ADDR")
+    token = os.getenv("VAULT_TOKEN")
+    if not (vault_addr and token):
+        return None
+    url = f"{vault_addr.rstrip('/')}/v1/{secret_path.lstrip('/')}"
+    try:
+        with requests.get(url, headers={"X-Vault-Token": token}, timeout=5) as resp:
+            if resp.ok:
+                data = resp.json().get("data", {}).get("data", {})
+                secret = data.get("value")
+            else:
+                secret = None
+    except requests.RequestException as exc:
+        logger.warning("Could not read secret from Vault at %s: %s", secret_path, exc)
+        return None
+    result = secret
+    secret = None
+    return result
+
 
 def get_secret(file_variable_name: str) -> Optional[str]:
-    """Read a secret from the file path specified in an environment variable."""
+    """Read a secret from a file or Vault and clear variables after use."""
+    vault_path = os.environ.get(f"{file_variable_name}_VAULT_PATH")
+    if vault_path:
+        secret = _fetch_vault_secret(vault_path)
+        if secret is not None:
+            return secret
+
     file_path = os.environ.get(file_variable_name)
     if file_path and os.path.exists(file_path):
         try:
             with open(file_path, "r") as f:
-                return f.read().strip()
+                secret = f.read().strip()
+            result = secret
+            secret = None
+            return result
         except IOError as exc:
             logger.warning("Could not read secret file at %s: %s", file_path, exc)
     return None

--- a/src/shared/redis_client.py
+++ b/src/shared/redis_client.py
@@ -41,19 +41,19 @@ def get_redis_connection(db_number: int = 0, fail_fast: bool = False):
     """
     redis_host = os.environ.get("REDIS_HOST", "localhost")
     password = get_secret("REDIS_PASSWORD_FILE")
+    redis_port = int(os.environ.get("REDIS_PORT", 6379))
 
     if password is None and os.environ.get("REDIS_PASSWORD_FILE"):
         msg = f"Redis password file not found at {os.environ['REDIS_PASSWORD_FILE']}"
         logging.error(msg)
         if fail_fast:
+            del password
             raise RedisConnectionError(msg)
+        del password
         return None
-
-    redis_port = int(os.environ.get("REDIS_PORT", 6379))
 
     try:
         r = _create_client(redis_host, redis_port, password, db_number)
-        password = None
         logging.info(
             f"Successfully connected to Redis at {redis_host} on DB {db_number}"
         )
@@ -79,3 +79,5 @@ def get_redis_connection(db_number: int = 0, fail_fast: bool = False):
         if fail_fast:
             raise RedisConnectionError(msg)
         return None
+    finally:
+        del password

--- a/test/shared/test_audit.py
+++ b/test/shared/test_audit.py
@@ -7,14 +7,6 @@ from unittest.mock import patch
 
 
 class TestAuditLogging(unittest.TestCase):
-    def test_log_event_writes_expected_format(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            log_file = os.path.join(tmpdir, "audit.log")
-            with patch.dict(os.environ, {"AUDIT_LOG_FILE": log_file}):
-                from src.shared import audit
-
-                for h in list(audit.logger.handlers):
-                    audit.logger.removeHandler(h)
     def tearDown(self):
         # Clean up logger handlers if audit module was imported
         if hasattr(self, "audit"):
@@ -27,7 +19,10 @@ class TestAuditLogging(unittest.TestCase):
             log_file = os.path.join(tmpdir, "audit.log")
             with patch.dict(os.environ, {"AUDIT_LOG_FILE": log_file}):
                 from src.shared import audit
+
                 self.audit = audit
+                for h in list(audit.logger.handlers):
+                    audit.logger.removeHandler(h)
                 importlib.reload(audit)
                 audit.log_event("user", "action", {"foo": "bar"})
             with open(log_file) as f:


### PR DESCRIPTION
## Summary
- read secrets using context managers and clear variables after use
- add optional HashiCorp Vault lookup to `get_secret`
- update Redis client and tests for secure secret handling

## Testing
- `pre-commit run --files src/shared/config.py src/shared/redis_client.py test/shared/test_config_redis_client.py test/shared/test_audit.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6c370af608321afeb205ecdabc84b