### PR TITLE
Add rate limiting and request size middleware

### DIFF
--- a/cloud-proxy/main.py
+++ b/cloud-proxy/main.py
@@ -1,13 +1,16 @@
 import os
+import secrets
 
 import httpx
-from fastapi import FastAPI, Header, HTTPException
+from fastapi import Header, HTTPException
+
+from src.shared.middleware import create_app
 
 API_KEY = os.getenv("OPENAI_API_KEY")
 LLM_URL = os.getenv("CLOUD_LLM_API_URL", "https://api.openai.com/v1/chat/completions")
 PROXY_KEY = os.getenv("PROXY_KEY")
 
-app = FastAPI()
+app = create_app()
 
 
 @app.get("/health")

--- a/cloud-proxy/main.py
+++ b/cloud-proxy/main.py
@@ -1,5 +1,5 @@
+import hmac
 import os
-import secrets
 
 import httpx
 from fastapi import Header, HTTPException
@@ -24,7 +24,7 @@ async def proxy_chat(payload: dict, x_proxy_key: str | None = Header(None)) -> d
         raise HTTPException(status_code=500, detail="API key not configured")
     if not PROXY_KEY:
         raise HTTPException(status_code=500, detail="Proxy key not configured")
-    if not secrets.compare_digest(x_proxy_key or "", PROXY_KEY or ""):
+    if not hmac.compare_digest(x_proxy_key or "", PROXY_KEY or ""):
         raise HTTPException(status_code=401, detail="Invalid proxy key")
     headers = {"Authorization": f"Bearer {API_KEY}"}
     try:

--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -5,8 +5,9 @@ import re
 import time
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi import HTTPException, Request, Response
 
+from src.shared.middleware import create_app
 from src.shared.request_utils import read_json_body
 
 LOCAL_LLM_URL = os.getenv("LOCAL_LLM_URL", "http://llama3:11434/api/generate")
@@ -33,7 +34,7 @@ def count_tokens(text: str) -> int:
     return len(TOKEN_PATTERN.findall(text))
 
 
-app = FastAPI()
+app = create_app()
 
 
 @app.get("/health")

--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -9,7 +9,7 @@ import logging
 import os
 import secrets
 
-from fastapi import Cookie, Depends, FastAPI, Request
+from fastapi import Cookie, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -18,6 +18,7 @@ from jinja2 import pass_context
 
 from src.shared.audit import log_event
 from src.shared.config import CONFIG, tenant_key
+from src.shared.middleware import create_app
 from src.shared.redis_client import get_redis_connection
 
 from . import blocklist, metrics, webauthn
@@ -79,7 +80,7 @@ def _get_allowed_origins() -> list[str]:
     return origins
 
 
-app = FastAPI()
+app = create_app()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_get_allowed_origins(),

--- a/src/ai_service/main.py
+++ b/src/ai_service/main.py
@@ -8,13 +8,14 @@ import os
 import time
 from typing import Any, Dict
 
-from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi import Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from redis.exceptions import RedisError
 
 from src.shared.audit import log_event as audit_log_event
 from src.shared.config import CONFIG, Config, tenant_key
+from src.shared.middleware import create_app
 from src.shared.redis_client import get_redis_connection
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ class WebhookEvent(BaseModel):
     )
 
 
-app = FastAPI()
+app = create_app()
 
 
 def get_config() -> Config:

--- a/src/captcha/custom_captcha_service.py
+++ b/src/captcha/custom_captcha_service.py
@@ -7,12 +7,13 @@ import logging
 import os
 import secrets
 
-from fastapi import Cookie, FastAPI, Form, HTTPException, Request
+from fastapi import Cookie, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from src.shared.config import get_secret
+from src.shared.middleware import create_app
 
-app = FastAPI()
+app = create_app()
 
 CAPTCHA_SECRET = get_secret("CAPTCHA_SECRET_FILE") or os.getenv("CAPTCHA_SECRET")
 CAPTCHA_SUCCESS_LOG = os.getenv("CAPTCHA_SUCCESS_LOG", "/app/logs/captcha_success.log")

--- a/src/captcha/recaptcha_service.py
+++ b/src/captcha/recaptcha_service.py
@@ -3,11 +3,12 @@ import logging
 import os
 
 import httpx
-from fastapi import FastAPI, HTTPException
+from fastapi import HTTPException
 
 from src.shared.config import get_secret
+from src.shared.middleware import create_app
 
-app = FastAPI()
+app = create_app()
 
 CAPTCHA_VERIFICATION_URL = os.getenv(
     "CAPTCHA_VERIFICATION_URL", "https://www.google.com/recaptcha/api/siteverify"

--- a/src/cloud_dashboard/cloud_dashboard_api.py
+++ b/src/cloud_dashboard/cloud_dashboard_api.py
@@ -5,14 +5,15 @@ import json
 from json import JSONDecodeError
 from typing import Any, Dict, List
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from redis.exceptions import RedisError
 
 from src.shared.config import tenant_key
+from src.shared.middleware import create_app
 from src.shared.redis_client import get_redis_connection
 
-app = FastAPI()
+app = create_app()
 
 # Redis-backed storage of metrics per installation with TTLs
 METRICS_TTL = 60

--- a/src/config_recommender/recommender_api.py
+++ b/src/config_recommender/recommender_api.py
@@ -2,13 +2,14 @@ import os
 import secrets
 from typing import Dict
 
-from fastapi import FastAPI, Header, HTTPException
+from fastapi import Header, HTTPException
 
 from src.shared.config import CONFIG
+from src.shared.middleware import create_app
 
 from .metrics_config_recommender import get_metrics
 
-app = FastAPI()
+app = create_app()
 
 
 def _parse_prometheus_metrics(text: str) -> Dict[str, float]:

--- a/src/escalation/escalation_engine.py
+++ b/src/escalation/escalation_engine.py
@@ -14,10 +14,11 @@ from urllib.parse import urlparse
 
 import httpx
 import numpy as np
-from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi import HTTPException, Request, Response
 from pydantic import BaseModel, Field, ValidationError
 
 from src.shared.config import tenant_key
+from src.shared.middleware import create_app
 
 # GeoIP
 try:
@@ -627,7 +628,7 @@ class RequestMetadata(BaseModel):
 
 
 # --- FastAPI App ---
-app = FastAPI(
+app = create_app(
     title="Escalation Engine",
     description="Analyzes suspicious requests and escalates if necessary.",
 )

--- a/src/iis_gateway/main.py
+++ b/src/iis_gateway/main.py
@@ -12,8 +12,10 @@ from dataclasses import dataclass
 import httpx
 import redis
 from cachetools import TTLCache
-from fastapi import FastAPI, Request, Response
+from fastapi import Request, Response
 from fastapi.responses import PlainTextResponse
+
+from src.shared.middleware import create_app
 
 
 @dataclass
@@ -41,7 +43,7 @@ BAD_BOTS = [
 
 logger = logging.getLogger("iis_gateway")
 
-app = FastAPI()
+app = create_app()
 redis_client = redis.Redis(
     host=settings.REDIS_HOST,
     port=settings.REDIS_PORT,

--- a/src/pay_per_crawl/proxy.py
+++ b/src/pay_per_crawl/proxy.py
@@ -5,8 +5,10 @@ import secrets
 from urllib.parse import urljoin, urlparse
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi import HTTPException, Request, Response
 from pydantic import BaseModel
+
+from src.shared.middleware import create_app
 
 from .db import add_credit, charge, get_crawler, init_db, register_crawler
 from .pricing import PricingEngine, load_pricing
@@ -19,7 +21,7 @@ HTTPX_TIMEOUT = float(os.getenv("HTTPX_TIMEOUT", "10.0"))
 pricing_engine = PricingEngine(load_pricing(PRICING_PATH), DEFAULT_PRICE)
 init_db()
 
-app = FastAPI()
+app = create_app()
 
 
 class RegisterPayload(BaseModel):

--- a/src/public_blocklist/public_blocklist_api.py
+++ b/src/public_blocklist/public_blocklist_api.py
@@ -3,8 +3,10 @@ import json
 import os
 from typing import List, Optional
 
-from fastapi import FastAPI, Header, HTTPException
+from fastapi import Header, HTTPException
 from pydantic import BaseModel, IPvAnyAddress
+
+from src.shared.middleware import create_app
 
 PUBLIC_BLOCKLIST_FILE = os.getenv(
     "PUBLIC_BLOCKLIST_FILE", "./data/public_blocklist.json"
@@ -13,7 +15,7 @@ PUBLIC_BLOCKLIST_API_KEY = os.getenv("PUBLIC_BLOCKLIST_API_KEY")
 if not PUBLIC_BLOCKLIST_API_KEY:
     raise RuntimeError("PUBLIC_BLOCKLIST_API_KEY environment variable is required")
 
-app = FastAPI()
+app = create_app()
 
 
 def _load_blocklist() -> List[str]:

--- a/src/shared/middleware.py
+++ b/src/shared/middleware.py
@@ -1,0 +1,71 @@
+import asyncio
+import os
+import time
+
+from fastapi import FastAPI, HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+RATE_LIMIT_REQUESTS = int(os.getenv("RATE_LIMIT_REQUESTS", "100"))
+RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))
+MAX_BODY_SIZE = int(os.getenv("MAX_BODY_SIZE", str(1 * 1024 * 1024)))
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Simple in-memory IP-based rate limiter."""
+
+    def __init__(self, app: FastAPI, max_requests: int, window_seconds: int) -> None:
+        super().__init__(app)
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._requests: dict[str, list[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def dispatch(self, request: Request, call_next):
+        if self.max_requests <= 0:
+            return await call_next(request)
+        ip = request.client.host if request.client else "unknown"
+        now = time.time()
+        async with self._lock:
+            bucket = self._requests.setdefault(ip, [])
+            cutoff = now - self.window_seconds
+            while bucket and bucket[0] <= cutoff:
+                bucket.pop(0)
+            if len(bucket) >= self.max_requests:
+                raise HTTPException(status_code=429, detail="Too Many Requests")
+            bucket.append(now)
+        return await call_next(request)
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests with bodies exceeding the configured limit."""
+
+    def __init__(self, app: FastAPI, max_body_size: int) -> None:
+        super().__init__(app)
+        self.max_body_size = max_body_size
+
+    async def dispatch(self, request: Request, call_next):
+        if self.max_body_size <= 0:
+            return await call_next(request)
+        length = request.headers.get("content-length")
+        if length and int(length) > self.max_body_size:
+            raise HTTPException(status_code=413, detail="Request body too large")
+        body = await request.body()
+        if len(body) > self.max_body_size:
+            raise HTTPException(status_code=413, detail="Request body too large")
+        return await call_next(request)
+
+
+def add_security_middleware(app: FastAPI) -> None:
+    app.add_middleware(BodySizeLimitMiddleware, max_body_size=MAX_BODY_SIZE)
+    app.add_middleware(
+        RateLimitMiddleware,
+        max_requests=RATE_LIMIT_REQUESTS,
+        window_seconds=RATE_LIMIT_WINDOW,
+    )
+
+
+def create_app(**kwargs) -> FastAPI:
+    app = FastAPI(**kwargs)
+    add_security_middleware(app)
+    return app

--- a/src/shared/middleware.py
+++ b/src/shared/middleware.py
@@ -1,8 +1,11 @@
 import asyncio
 import os
 import time
+from collections import deque
 
-from fastapi import FastAPI, HTTPException
+from cachetools import TTLCache
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
@@ -18,7 +21,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.max_requests = max_requests
         self.window_seconds = window_seconds
-        self._requests: dict[str, list[float]] = {}
+        self._requests: TTLCache[str, deque[float]] = TTLCache(
+            maxsize=10000, ttl=window_seconds * 2
+        )
         self._lock = asyncio.Lock()
 
     async def dispatch(self, request: Request, call_next):
@@ -27,13 +32,22 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         ip = request.client.host if request.client else "unknown"
         now = time.time()
         async with self._lock:
-            bucket = self._requests.setdefault(ip, [])
-            cutoff = now - self.window_seconds
-            while bucket and bucket[0] <= cutoff:
-                bucket.pop(0)
+            bucket = self._requests.get(ip)
+            if bucket is None:
+                bucket = deque()
+            else:
+                cutoff = now - self.window_seconds
+                while bucket and bucket[0] <= cutoff:
+                    bucket.popleft()
+                if not bucket:
+                    self._requests.pop(ip, None)
+                    bucket = deque()
             if len(bucket) >= self.max_requests:
-                raise HTTPException(status_code=429, detail="Too Many Requests")
+                return JSONResponse(
+                    status_code=429, content={"detail": "Too Many Requests"}
+                )
             bucket.append(now)
+            self._requests[ip] = bucket
         return await call_next(request)
 
 
@@ -49,10 +63,38 @@ class BodySizeLimitMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         length = request.headers.get("content-length")
         if length and int(length) > self.max_body_size:
-            raise HTTPException(status_code=413, detail="Request body too large")
-        body = await request.body()
-        if len(body) > self.max_body_size:
-            raise HTTPException(status_code=413, detail="Request body too large")
+            return JSONResponse(
+                status_code=413, content={"detail": "Request body too large"}
+            )
+
+        size = 0
+        body = bytearray()
+        async for chunk in request.stream():
+            size += len(chunk)
+            if size > self.max_body_size:
+                return JSONResponse(
+                    status_code=413, content={"detail": "Request body too large"}
+                )
+            body.extend(chunk)
+
+        if body:
+            body_bytes = bytes(body)
+            received = False
+
+            async def receive() -> dict:
+                nonlocal received
+                if received:
+                    return {"type": "http.request", "body": b"", "more_body": False}
+                received = True
+                return {
+                    "type": "http.request",
+                    "body": body_bytes,
+                    "more_body": False,
+                }
+
+            request._receive = receive  # type: ignore[attr-defined]
+            request._body = body_bytes  # type: ignore[attr-defined]
+            request._stream_consumed = False  # type: ignore[attr-defined]
         return await call_next(request)
 
 

--- a/src/tarpit/tarpit_api.py
+++ b/src/tarpit/tarpit_api.py
@@ -10,7 +10,7 @@ import sys
 from typing import Dict
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 
 # The direct 'redis' import is no longer needed as the client handles it.
@@ -19,6 +19,7 @@ from redis.exceptions import RedisError
 # --- Setup Logging ---
 # Preserved from your original file.
 from src.shared.config import CONFIG, tenant_key
+from src.shared.middleware import create_app
 from src.shared.redis_client import get_redis_connection
 
 from .bad_api_generator import register_bad_endpoints
@@ -145,7 +146,7 @@ if not redis_hops or not redis_blocklist:
 
 
 # --- FastAPI App ---
-app = FastAPI()
+app = create_app()
 BAD_API_ENDPOINTS = register_bad_endpoints(app)
 
 

--- a/test/shared/test_middleware.py
+++ b/test/shared/test_middleware.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import time
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from src.shared.middleware import BodySizeLimitMiddleware, RateLimitMiddleware
+
+
+def create_app(
+    max_body_size: int = 1024,
+    max_requests: int = 2,
+    window_seconds: int = 60,
+) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_body_size=max_body_size)
+    app.add_middleware(
+        RateLimitMiddleware,
+        max_requests=max_requests,
+        window_seconds=window_seconds,
+    )
+
+    @app.post("/echo")
+    async def echo(request: Request) -> dict[str, int]:
+        data = await request.body()
+        return {"len": len(data)}
+
+    @app.get("/ping")
+    async def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+def get_rate_limiter(app: FastAPI) -> RateLimitMiddleware:
+    stack = app.middleware_stack
+    while True:
+        if isinstance(stack, RateLimitMiddleware):
+            return stack
+        if not hasattr(stack, "app"):
+            break
+        stack = stack.app  # type: ignore[assignment]
+    raise RuntimeError("RateLimitMiddleware not found")
+
+
+def test_content_length_exceeds_limit() -> None:
+    app = create_app(max_body_size=10)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post("/echo", data="x" * 11)
+    assert resp.status_code == 413
+
+
+def test_streaming_body_exceeds_limit() -> None:
+    app = create_app(max_body_size=10)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    def gen():
+        for _ in range(3):
+            yield b"a" * 5
+
+    resp = client.post("/echo", data=gen())
+    assert resp.status_code == 413
+
+
+def test_body_under_limit_and_readable() -> None:
+    app = create_app(max_body_size=10)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post("/echo", data="hello")
+    assert resp.status_code == 200
+    assert resp.json() == {"len": 5}
+
+
+def test_rate_limit_exceeded() -> None:
+    app = create_app(max_requests=2, window_seconds=60)
+    client = TestClient(app, raise_server_exceptions=False)
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 429
+
+
+def test_rate_limiter_prunes_stale_ips() -> None:
+    app = create_app(max_requests=1, window_seconds=1)
+    client = TestClient(app, raise_server_exceptions=False)
+    assert client.get("/ping").status_code == 200
+    rate = get_rate_limiter(app)
+    assert len(rate._requests) == 1
+    time.sleep(2.1)
+    # access cache to trigger expiry
+    assert len(rate._requests) == 0


### PR DESCRIPTION
## Summary
- add shared FastAPI middleware providing IP-based rate limiting and body size caps
- apply new middleware across FastAPI services via `create_app`

## Testing
- `pre-commit run --files cloud-proxy/main.py prompt-router/main.py src/admin_ui/admin_ui.py src/ai_service/main.py src/captcha/custom_captcha_service.py src/captcha/recaptcha_service.py src/cloud_dashboard/cloud_dashboard_api.py src/config_recommender/recommender_api.py src/escalation/escalation_engine.py src/iis_gateway/main.py src/pay_per_crawl/proxy.py src/public_blocklist/public_blocklist_api.py src/tarpit/tarpit_api.py src/shared/middleware.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6e7e7999083218d26303936151f40