### PR TITLE
Mask sensitive data in log output

### DIFF
--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -1,1 +1,5 @@
 """Shared utilities for the defense stack."""
+
+from .log_filter import apply_sensitive_data_filter
+
+apply_sensitive_data_filter()

--- a/src/shared/log_filter.py
+++ b/src/shared/log_filter.py
@@ -1,0 +1,61 @@
+import logging
+import re
+from typing import List, Tuple
+
+_REPLACEMENTS: List[Tuple[re.Pattern[str], str]] = [
+    # IPv4 addresses
+    (re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"), "[REDACTED_IP]"),
+    # API keys and tokens
+    (
+        re.compile(r"(?i)(api[_-]?key|token|authorization)[:=]\s*[^\s]+"),
+        r"\1=<redacted>",
+    ),
+    # Passwords
+    (
+        re.compile(r"(?i)(password|passwd|pwd)[:=]\s*[^\s]+"),
+        r"\1=<redacted>",
+    ),
+]
+
+
+def _mask(message: str) -> str:
+    for pattern, repl in _REPLACEMENTS:
+        message = pattern.sub(repl, message)
+    return message
+
+
+class SensitiveDataFilter(logging.Filter):
+    """Mask sensitive data such as IPs, API keys, and passwords."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple
+        message = record.getMessage()
+        masked = _mask(message)
+        record.msg = masked
+        record.args = ()
+        return True
+
+
+_FILTER = SensitiveDataFilter()
+
+
+def apply_sensitive_data_filter() -> None:
+    """Attach the sensitive data filter to all loggers."""
+
+    root_logger = logging.getLogger()
+    if _FILTER not in root_logger.filters:
+        root_logger.addFilter(_FILTER)
+
+    for name in list(logging.root.manager.loggerDict):
+        logger = logging.getLogger(name)
+        if _FILTER not in logger.filters:
+            logger.addFilter(_FILTER)
+
+    _orig_get_logger = logging.getLogger
+
+    def get_logger(name: str | None = None) -> logging.Logger:
+        logger = _orig_get_logger(name)
+        if _FILTER not in logger.filters:
+            logger.addFilter(_FILTER)
+        return logger
+
+    logging.getLogger = get_logger

--- a/src/shared/log_filter.py
+++ b/src/shared/log_filter.py
@@ -4,7 +4,13 @@ from typing import List, Tuple
 
 _REPLACEMENTS: List[Tuple[re.Pattern[str], str]] = [
     # IPv4 addresses
-    (re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"), "[REDACTED_IP]"),
+    (
+        re.compile(
+            r"\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}"
+            r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b"
+        ),
+        "[REDACTED_IP]",
+    ),
     # API keys and tokens
     (
         re.compile(r"(?i)(api[_-]?key|token|authorization)[:=]\s*[^\s]+"),

--- a/test/shared/test_log_filter.py
+++ b/test/shared/test_log_filter.py
@@ -1,0 +1,16 @@
+import logging
+
+from src.shared import log_filter  # ensures filter is applied
+
+
+def test_sensitive_data_filter_masks_data(caplog):
+    logger = logging.getLogger("test_logger")
+    with caplog.at_level(logging.INFO):
+        logger.info("User 192.168.1.1 used api_key=ABC123 and password=secret")
+    message = caplog.messages[0]
+    assert "192.168.1.1" not in message
+    assert "api_key=ABC123" not in message
+    assert "password=secret" not in message
+    assert "[REDACTED_IP]" in message
+    assert "api_key=<redacted>" in message
+    assert "password=<redacted>" in message


### PR DESCRIPTION
## Summary
- add a logging filter to scrub IPs, API keys, and passwords
- ensure the sensitive data filter is applied to every logger on import
- test that log messages redact sensitive values

## Testing
- `pre-commit run --files src/shared/log_filter.py src/shared/__init__.py test/shared/test_log_filter.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f2c04f148321bed23d2f2b8f675c