### PR TITLE
Add LRU eviction to session tracker

### DIFF
--- a/src/behavioral/honeypot.py
+++ b/src/behavioral/honeypot.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from collections import defaultdict
+from collections import OrderedDict
 from typing import Dict, List
 
 try:
@@ -17,9 +17,18 @@ from src.shared.redis_client import get_redis_connection
 class SessionTracker:
     """Log request sequences for behavioral analysis."""
 
-    def __init__(self, redis_db: int = 3) -> None:
+    def __init__(
+        self,
+        redis_db: int = 3,
+        *,
+        max_fallback_entries: int = 1000,
+        cleanup_interval: float = 60.0,
+    ) -> None:
         self.redis = get_redis_connection(db_number=redis_db)
-        self.fallback: Dict[str, List[str]] = defaultdict(list)
+        self.fallback: "OrderedDict[str, List[str]]" = OrderedDict()
+        self.max_fallback_entries = max_fallback_entries
+        self.cleanup_interval = cleanup_interval
+        self._last_cleanup = datetime.datetime.now(datetime.UTC)
 
     def log_request(self, ip: str, path: str, timestamp: float | None = None) -> None:
         timestamp = timestamp or datetime.datetime.now(datetime.UTC).timestamp()
@@ -27,17 +36,28 @@ class SessionTracker:
         if self.redis:
             self.redis.rpush(f"session:{ip}", entry)
         else:
-            self.fallback[ip].append(entry)
+            self.fallback.setdefault(ip, []).append(entry)
+            self.fallback.move_to_end(ip)
+            now = datetime.datetime.now(datetime.UTC)
+            if (now - self._last_cleanup).total_seconds() >= self.cleanup_interval:
+                self._evict_excess()
+                self._last_cleanup = now
 
     def get_sequence(self, ip: str) -> List[str]:
         if self.redis:
             entries = self.redis.lrange(f"session:{ip}", 0, -1)
         else:
-            entries = self.fallback[ip]
+            entries = self.fallback.get(ip, [])
+            if ip in self.fallback:
+                self.fallback.move_to_end(ip)
         return [
             (e.decode() if isinstance(e, bytes) else e).split(":", 1)[1]
             for e in entries
         ]
+
+    def _evict_excess(self) -> None:
+        while len(self.fallback) > self.max_fallback_entries:
+            self.fallback.popitem(last=False)
 
 
 def _seq_features(seq: List[str]) -> List[float]:

--- a/test/behavioral/test_honeypot.py
+++ b/test/behavioral/test_honeypot.py
@@ -35,6 +35,20 @@ class TestBehavioralHoneypot(unittest.TestCase):
         seq = tracker.get_sequence("1.1.1.1")
         self.assertEqual(seq, ["/a", "/b"])
 
+    def test_fallback_eviction(self):
+        tracker = SessionTracker(
+            redis_db=99, max_fallback_entries=2, cleanup_interval=0
+        )
+        tracker.log_request("1.1.1.1", "/a")
+        tracker.log_request("2.2.2.2", "/b")
+        tracker.log_request("3.3.3.3", "/c")
+        self.assertNotIn("1.1.1.1", tracker.fallback)
+        tracker.log_request("2.2.2.2", "/d")
+        tracker.log_request("4.4.4.4", "/e")
+        self.assertNotIn("3.3.3.3", tracker.fallback)
+        self.assertIn("2.2.2.2", tracker.fallback)
+        self.assertIn("4.4.4.4", tracker.fallback)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- cap in-memory session tracker with LRU eviction
- test fallback eviction logic

## Testing
- `pre-commit run --files src/behavioral/honeypot.py test/behavioral/test_honeypot.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e3d0404883219ea814a4539fe5ba