### PR TITLE
Atomically update rate limit config

### DIFF
--- a/src/util/adaptive_rate_limit_manager.py
+++ b/src/util/adaptive_rate_limit_manager.py
@@ -37,8 +37,10 @@ def update_rate_limit(new_limit: int) -> bool:
     """Write the limit_req configuration for Nginx."""
     line = f"limit_req_zone $binary_remote_addr zone=req_rate_limit:10m rate={new_limit}r/m;"
     try:
-        with open(NGINX_RATE_LIMIT_CONF, "w", encoding="utf-8") as f:
+        temp_path = f"{NGINX_RATE_LIMIT_CONF}.tmp"
+        with open(temp_path, "w", encoding="utf-8") as f:
             f.write(line + "\n")
+        os.replace(temp_path, NGINX_RATE_LIMIT_CONF)
         logger.info("Wrote new Nginx rate limit: %sr/m", new_limit)
         return True
     except Exception as exc:  # pragma: no cover - file system issues


### PR DESCRIPTION
## Summary
- atomically update Nginx rate limit configuration using temp file and os.replace

## Testing
- `pre-commit run --files src/util/adaptive_rate_limit_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7f0c5998c8321be1f37ea8d6254ac