### PR TITLE
Validate peer blocklist IPs

### DIFF
--- a/src/util/peer_blocklist_sync.py
+++ b/src/util/peer_blocklist_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import json
 import logging
 import os
@@ -44,6 +45,11 @@ def update_redis_blocklist(ips: List[str], redis_conn) -> int:
         return 0
     added = 0
     for ip in ips:
+        try:
+            ipaddress.ip_address(ip)
+        except ValueError:
+            logger.warning("Skipping invalid IP address: %s", ip)
+            continue
         key = tenant_key(f"blocklist:ip:{ip}")
         try:
             redis_conn.setex(key, PEER_BLOCKLIST_TTL_SECONDS, "peer")


### PR DESCRIPTION
## Summary
- add missing imports to peer blocklist sync
- validate peer IP addresses before writing to Redis

## Testing
- `pre-commit run --files src/util/peer_blocklist_sync.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7fc53d1b08321b0f72af3dd8eb8c8