### PR TITLE
Validate IP addresses before storing in Redis

### DIFF
--- a/src/util/community_blocklist_sync.py
+++ b/src/util/community_blocklist_sync.py
@@ -51,16 +51,16 @@ def update_redis_blocklist(ips: List[str], redis_conn) -> int:
     added = 0
     for ip in ips:
         try:
-            ipaddress.ip_address(ip)
+            parsed_ip = ipaddress.ip_address(ip)
         except ValueError:
             logger.warning("Skipping invalid IP address: %s", ip)
             continue
-        key = tenant_key(f"blocklist:ip:{ip}")
+        key = tenant_key(f"blocklist:ip:{parsed_ip}")
         try:
             redis_conn.setex(key, BLOCKLIST_TTL_SECONDS, "community")
             added += 1
         except Exception as e:  # pragma: no cover - unexpected redis error
-            logger.error(f"Failed to set Redis key for IP {ip}: {e}")
+            logger.error(f"Failed to set Redis key for IP {parsed_ip}: {e}")
     return added
 
 

--- a/src/util/community_blocklist_sync.py
+++ b/src/util/community_blocklist_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import json
 import logging
 import os
@@ -49,6 +50,11 @@ def update_redis_blocklist(ips: List[str], redis_conn) -> int:
         return 0
     added = 0
     for ip in ips:
+        try:
+            ipaddress.ip_address(ip)
+        except ValueError:
+            logger.warning("Skipping invalid IP address: %s", ip)
+            continue
         key = tenant_key(f"blocklist:ip:{ip}")
         try:
             redis_conn.setex(key, BLOCKLIST_TTL_SECONDS, "community")


### PR DESCRIPTION
## Summary
- validate IPs prior to writing them to Redis
- ensure blocklist sync imports logging, json, and asyncio

## Testing
- `pre-commit run --files src/util/community_blocklist_sync.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7ff3985408321bd49c8eeb51b822d