### PR TITLE
Handle crawler redis errors

### DIFF
--- a/src/bot_control/crawler_auth.py
+++ b/src/bot_control/crawler_auth.py
@@ -22,12 +22,15 @@ def register_crawler(name: str, token: str, purpose: str) -> bool:
     redis_conn = get_redis_connection()
     if not redis_conn:
         return False
+    key = _key(token)
     try:
-        key = _key(token)
         redis_conn.hset(key, mapping={"name": name, "purpose": purpose})
-        redis_conn.expire(key, CRAWLER_TTL_SECONDS)
     except RedisError:
         return False
+    try:
+        redis_conn.expire(key, CRAWLER_TTL_SECONDS)
+    except RedisError:
+        pass
     return True
 
 

--- a/src/bot_control/crawler_auth.py
+++ b/src/bot_control/crawler_auth.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
+from redis.exceptions import RedisError
+
 from src.shared.config import tenant_key
 from src.shared.redis_client import get_redis_connection
 
@@ -12,20 +14,32 @@ def _key(token: str) -> str:
     return tenant_key(f"crawler:token:{token}")
 
 
-def register_crawler(name: str, token: str, purpose: str) -> None:
+CRAWLER_TTL_SECONDS = 24 * 60 * 60
+
+
+def register_crawler(name: str, token: str, purpose: str) -> bool:
     """Register or update a crawler token."""
     redis_conn = get_redis_connection()
     if not redis_conn:
-        raise RuntimeError("Redis unavailable")
-    redis_conn.hset(_key(token), mapping={"name": name, "purpose": purpose})
+        return False
+    try:
+        key = _key(token)
+        redis_conn.hset(key, mapping={"name": name, "purpose": purpose})
+        redis_conn.expire(key, CRAWLER_TTL_SECONDS)
+    except RedisError:
+        return False
+    return True
 
 
 def verify_crawler(token: str, purpose: str | None = None) -> bool:
     """Return True if the token exists and (optionally) matches the given purpose."""
     redis_conn = get_redis_connection()
     if not redis_conn:
-        raise RuntimeError("Redis unavailable")
-    info = redis_conn.hgetall(_key(token))
+        return False
+    try:
+        info = redis_conn.hgetall(_key(token))
+    except RedisError:
+        return False
     if not info:
         return False
     if purpose and info.get("purpose") != purpose:
@@ -37,6 +51,9 @@ def get_crawler_info(token: str) -> Optional[Dict[str, str]]:
     """Return crawler info if registered."""
     redis_conn = get_redis_connection()
     if not redis_conn:
-        raise RuntimeError("Redis unavailable")
-    info = redis_conn.hgetall(_key(token))
+        return None
+    try:
+        info = redis_conn.hgetall(_key(token))
+    except RedisError:
+        return None
     return info or None

--- a/test/bot_control/test_crawler_features.py
+++ b/test/bot_control/test_crawler_features.py
@@ -18,6 +18,7 @@ class TestCrawlerFeatures(unittest.TestCase):
         class MockRedis:
             def __init__(self):
                 self.store = {}
+                self.ttl = {}
 
             def hset(self, name, key=None, value=None, mapping=None):
                 if mapping is not None:
@@ -36,13 +37,16 @@ class TestCrawlerFeatures(unittest.TestCase):
                 self.store.setdefault(name, {})[field] = current
                 return current
 
+            def expire(self, name, ttl):
+                self.ttl[name] = ttl
+
         mock_redis = MockRedis()
         with patch(
             "src.bot_control.crawler_auth.get_redis_connection", return_value=mock_redis
         ), patch(
             "src.bot_control.pricing.get_redis_connection", return_value=mock_redis
         ):
-            register_crawler("testbot", "token123", "training")
+            self.assertTrue(register_crawler("testbot", "token123", "training"))
             self.assertTrue(verify_crawler("token123"))
             self.assertTrue(verify_crawler("token123", "training"))
             info = get_crawler_info("token123")


### PR DESCRIPTION
## Summary
- expire crawler tokens after registration
- return False on Redis errors in crawler auth helpers
- test registration expiry handling

## Testing
- `pre-commit run --files src/bot_control/crawler_auth.py test/bot_control/test_crawler_features.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a802b102888321b0e095f5e10d80f9