### PR TITLE
Stream proxy request body

### DIFF
--- a/src/pay_per_crawl/proxy.py
+++ b/src/pay_per_crawl/proxy.py
@@ -80,13 +80,12 @@ async def proxy(full_path: str, request: Request):
     ):
         raise HTTPException(status_code=400, detail="Invalid upstream URL")
     headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
-    body = await request.body()
     async with httpx.AsyncClient(timeout=HTTPX_TIMEOUT) as client:
         resp = await client.request(
             request.method,
             upstream,
             params=request.query_params,
-            content=body,
+            content=request.stream(),
             headers=headers,
             timeout=HTTPX_TIMEOUT,
         )


### PR DESCRIPTION
## Summary
- stream client request body directly to upstream server

## Testing
- `pre-commit run --files src/pay_per_crawl/proxy.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a80a2cbf2c8321b36ee857e6cfc4d4