### PR TITLE
Handle pricing load errors

### DIFF
--- a/src/pay_per_crawl/pricing.py
+++ b/src/pay_per_crawl/pricing.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import logging
 from typing import Dict
 
 import yaml
 
 
 def load_pricing(path: str) -> Dict[str, float]:
-    with open(path, "r", encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logging.warning("Failed to load pricing from %s: %s", path, exc)
+        return {}
     return {str(k): float(v) for k, v in data.items()}
 
 


### PR DESCRIPTION
## Summary
- wrap pricing config file loading in try/except and log a warning on failure

## Testing
- `pre-commit run --files src/pay_per_crawl/pricing.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a80fb3b5b083219b360cd2a898f7f8