### PR TITLE
Import ipaddress and datetime in blocklist

### DIFF
--- a/src/admin_ui/blocklist.py
+++ b/src/admin_ui/blocklist.py
@@ -37,18 +37,24 @@ def _load_recent_block_events(limit: int = 5) -> list[dict]:
             try:
                 data = json.loads(line)
                 ts = data.get("timestamp")
-                if ts:
-                    try:
-                        _ = datetime.datetime.fromisoformat(ts)
-                    except ValueError:
-                        logger.debug("Invalid timestamp in block event: %s", ts)
+                if not ts:
+                    logger.debug("Missing timestamp in block event: %s", line)
+                    continue
+                try:
+                    _ = datetime.datetime.fromisoformat(ts)
+                except ValueError:
+                    logger.debug("Invalid timestamp in block event: %s", ts)
+                    continue
+
                 ip_val = data.get("ip_address")
                 try:
                     normalized_ip = (
                         str(ipaddress.ip_address(ip_val)) if ip_val else None
                     )
                 except ValueError:
-                    normalized_ip = ip_val
+                    logger.warning("Invalid IP address in block event: %s", ip_val)
+                    continue
+
                 events.append(
                     {
                         "timestamp": ts,

--- a/src/admin_ui/blocklist.py
+++ b/src/admin_ui/blocklist.py
@@ -1,9 +1,10 @@
 import asyncio
+import datetime
+import ipaddress
 import json
 import logging
 import os
 from collections import deque
-from ipaddress import ip_address
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
@@ -35,10 +36,23 @@ def _load_recent_block_events(limit: int = 5) -> list[dict]:
         for line in lines:
             try:
                 data = json.loads(line)
+                ts = data.get("timestamp")
+                if ts:
+                    try:
+                        _ = datetime.datetime.fromisoformat(ts)
+                    except ValueError:
+                        logger.debug("Invalid timestamp in block event: %s", ts)
+                ip_val = data.get("ip_address")
+                try:
+                    normalized_ip = (
+                        str(ipaddress.ip_address(ip_val)) if ip_val else None
+                    )
+                except ValueError:
+                    normalized_ip = ip_val
                 events.append(
                     {
-                        "timestamp": data.get("timestamp"),
-                        "ip": data.get("ip_address"),
+                        "timestamp": ts,
+                        "ip": normalized_ip,
                         "reason": data.get("reason"),
                     }
                 )
@@ -143,7 +157,7 @@ async def block_ip(request: Request, user: str = Depends(require_admin)):
     if not ip:
         return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
     try:
-        normalized_ip = str(ip_address(ip))
+        normalized_ip = str(ipaddress.ip_address(ip))
     except ValueError:
         return JSONResponse({"error": "Invalid ip"}, status_code=400)
 
@@ -174,7 +188,7 @@ async def unblock_ip(request: Request, user: str = Depends(require_admin)):
     if not ip:
         return JSONResponse({"error": "Invalid request, missing ip"}, status_code=400)
     try:
-        normalized_ip = str(ip_address(ip))
+        normalized_ip = str(ipaddress.ip_address(ip))
     except ValueError:
         return JSONResponse({"error": "Invalid ip"}, status_code=400)
 

--- a/test/admin_ui/test_admin_ui.py
+++ b/test/admin_ui/test_admin_ui.py
@@ -90,7 +90,7 @@ class TestAdminUIComprehensive(unittest.TestCase):
                 tmp.write(
                     json.dumps(
                         {
-                            "timestamp": f"t{i}",
+                            "timestamp": f"2024-01-01T00:00:0{i}",
                             "ip_address": f"1.1.1.{i}",
                             "reason": "r",
                         }


### PR DESCRIPTION
## Summary
- validate block log timestamps with `datetime`
- normalize logged IPs with `ipaddress`
- use `ipaddress.ip_address` in block/unblock endpoints

## Testing
- `pre-commit run --files src/admin_ui/blocklist.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec8f089ec832199afd6b21bd395b2