### PR TITLE
Gracefully handle missing Prometheus client

### DIFF
--- a/src/shared/metrics.py
+++ b/src/shared/metrics.py
@@ -9,14 +9,6 @@ functions is implemented.
 import time
 from collections import defaultdict
 
-from prometheus_client import (
-    CollectorRegistry,
-    Counter,
-    Gauge,
-    Histogram,
-    generate_latest,
-)
-
 
 class InMemoryCounter:
     """Simple in-memory counter supporting optional labels."""
@@ -47,6 +39,81 @@ class _InMemoryCounterChild:
 
     def inc(self) -> None:
         self._parent._label_counts[self._key] += 1
+
+
+try:  # pragma: no cover - exercised in fallback test
+    from prometheus_client import (
+        CollectorRegistry,
+        Counter,
+        Gauge,
+        Histogram,
+        generate_latest,
+    )
+except ImportError:  # pragma: no cover
+
+    class CollectorRegistry:
+        """Minimal registry storing counters for fallback metrics."""
+
+        def __init__(self) -> None:
+            self._metrics: dict[str, InMemoryCounter] = {}
+
+        def register(self, metric: "InMemoryCounter") -> None:
+            self._metrics[metric._name] = metric
+
+    class Counter(InMemoryCounter):
+        def __init__(self, name, documentation, labelnames=None, registry=None):
+            super().__init__(name)
+            self._documentation = documentation
+            if registry is not None:
+                registry.register(self)
+
+    class Gauge:
+        def __init__(self, name, documentation, labelnames=None, registry=None):
+            self._name = name
+            self._value = 0
+
+        def labels(self, **labels):
+            return self
+
+        def set(self, value):
+            self._value = value
+
+        def inc(self):
+            self._value += 1
+
+        def dec(self):
+            self._value -= 1
+
+    class Histogram:
+        def __init__(
+            self, name, documentation, labelnames=None, registry=None, buckets=None
+        ):
+            self._name = name
+
+        def labels(self, **labels):
+            return self
+
+        def observe(self, value):
+            pass
+
+        def time(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    def generate_latest(registry):
+        lines = []
+        for metric in getattr(registry, "_metrics", {}).values():
+            lines.append(
+                f"# HELP {metric._name} {getattr(metric, '_documentation', '')}"
+            )
+            lines.append(f"# TYPE {metric._name} counter")
+            lines.append(f"{metric._name}_total {metric.get()}")
+            for labels, value in metric._label_counts.items():
+                label_str = ",".join(f'{k}="{v}"' for k, v in labels)
+                lines.append(f"{metric._name}_total{{{label_str}}} {value}")
+        return "\n".join(lines).encode()
 
 
 # 0. Global Registry

--- a/src/shared/metrics.py
+++ b/src/shared/metrics.py
@@ -112,7 +112,9 @@ except ImportError:  # pragma: no cover
             lines.append(f"{metric._name}_total {metric.get()}")
             for labels, value in metric._label_counts.items():
                 label_str = ",".join(f'{k}="{v}"' for k, v in labels)
-                lines.append(f"{metric._name}_total{{{label_str}}} {value}")
+                lines.append(
+                    f"{metric._name}_total{{{label_str}}} {value}"  # include labeled metrics
+                )
         return "\n".join(lines).encode()
 
 

--- a/test/shared/test_metrics.py
+++ b/test/shared/test_metrics.py
@@ -1,13 +1,18 @@
 # test/shared/metrics.test.py
 import importlib
+import sys
 import unittest
 from unittest.mock import patch
 
-from prometheus_client import CollectorRegistry, generate_latest
+try:  # pragma: no cover
+    from prometheus_client import CollectorRegistry
+except ImportError:  # pragma: no cover
+    CollectorRegistry = None  # type: ignore[assignment]
 
 from src.shared import metrics
 
 
+@unittest.skipIf(CollectorRegistry is None, "prometheus_client not installed")
 class TestMetricsComprehensive(unittest.TestCase):
 
     def setUp(self):
@@ -125,6 +130,18 @@ class TestMetricsComprehensive(unittest.TestCase):
             metrics.observe_histogram_metric(gauge, 0.5)  # Can't observe a gauge
         with self.assertRaises(TypeError):
             metrics.increment_counter_metric(histo)  # Can't increment a histogram
+
+
+class TestMetricsFallback(unittest.TestCase):
+    def test_in_memory_metrics_when_prometheus_missing(self):
+        with patch.dict(sys.modules, {"prometheus_client": None}):
+            importlib.reload(metrics)
+            counter = metrics.REQUEST_COUNT
+            metrics.increment_counter_metric(counter)
+            self.assertEqual(counter.get(), 1)
+            output = metrics.get_metrics().decode("utf-8")
+            self.assertIn("http_requests_total", output)
+        importlib.reload(metrics)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use in-memory metrics when `prometheus_client` is unavailable
- exercise fallback path with new unit test

## Testing
- `pre-commit run --files src/shared/metrics.py test/shared/test_metrics.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe53112408321abf5f5f8fdc631f5