### PR TITLE
Handle Nginx reload failures

### DIFF
--- a/src/util/rules_fetcher/fetcher.py
+++ b/src/util/rules_fetcher/fetcher.py
@@ -47,25 +47,26 @@ def fetch_rules(url: str, allowed_domains: Optional[list[str]] = None) -> str:
         return ""
 
 
-def _run_as_script() -> None:
+def _run_as_script() -> bool:
     """Helper to execute the module's main block."""
     logger.info("WAF rules fetcher script started.")
 
     if CRS_DOWNLOAD_URL:
         logger.info("Fetching OWASP CRS from %s", CRS_DOWNLOAD_URL)
         success = download_and_extract_crs(CRS_DOWNLOAD_URL, MODSEC_DIR)
-        if success:
-            try:
-                subprocess.run(NGINX_RELOAD_CMD, check=True)
-            except subprocess.CalledProcessError as exc:
-                logger.error("Failed to reload Nginx after CRS install: %s", exc)
-                return False
+        if not success:
+            return False
+        try:
+            subprocess.run(NGINX_RELOAD_CMD, check=True)
+        except subprocess.CalledProcessError as exc:
+            logger.error("Failed to reload Nginx after CRS install: %s", exc)
+            return False
     else:
         rules_content = fetch_rules(RULES_URL)
 
         if not rules_content:
             logger.warning("No rules content retrieved. Exiting.")
-            return
+            return False
 
         if KUBE_AVAILABLE and os.environ.get("KUBERNETES_SERVICE_HOST"):
             logger.info("Running inside Kubernetes. Attempting to update ConfigMap.")
@@ -79,3 +80,4 @@ def _run_as_script() -> None:
             reload_waf_rules(rules_content.splitlines())
 
     logger.info("WAF rules fetcher script finished.")
+    return True

--- a/test/util/test_rules_fetcher.py
+++ b/test/util/test_rules_fetcher.py
@@ -91,8 +91,24 @@ class TestRulesFetcher(unittest.TestCase):
             patch("src.util.rules_fetcher.fetcher.CRS_DOWNLOAD_URL", ""),
         ):
             self.mock_get.return_value = MockResponse("SecRule ...", 200)
-            rules_fetcher._run_as_script()
+            result = rules_fetcher._run_as_script()
+            self.assertTrue(result)
             mock_reload.assert_called_once()
+
+    def test_main_flow_no_rules_returns_false(self):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("src.util.rules_fetcher.fetcher.reload_waf_rules") as mock_reload,
+            patch(
+                "src.util.rules_fetcher.fetcher.RULES_URL", "https://example.com/rules"
+            ),
+            patch("src.util.rules_fetcher.fetcher.ALLOWED_RULES_DOMAINS", []),
+            patch("src.util.rules_fetcher.fetcher.CRS_DOWNLOAD_URL", ""),
+        ):
+            self.mock_get.return_value = MockResponse("", 200)
+            result = rules_fetcher._run_as_script()
+            self.assertFalse(result)
+            mock_reload.assert_not_called()
 
     def test_reload_failure_returns_false(self):
         with (


### PR DESCRIPTION
## Summary
- check for errors when reloading nginx after installing CRS rules
- test failing reload scenario

## Testing
- `pre-commit run --files src/util/rules_fetcher/fetcher.py test/util/test_rules_fetcher.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b107faaf1c8321a0472aefa6b3f514