### PR TITLE
Avoid robots.txt redirects

### DIFF
--- a/src/util/robots_fetcher.py
+++ b/src/util/robots_fetcher.py
@@ -83,8 +83,16 @@ def fetch_robots_txt(
     logger.info(f"Attempting to fetch robots.txt from: {robots_url}")
     try:
         response = requests.get(
-            robots_url, headers={"User-Agent": FETCHER_USER_AGENT}, timeout=10
+            robots_url,
+            headers={"User-Agent": FETCHER_USER_AGENT},
+            timeout=10,
+            allow_redirects=False,
         )
+        if 300 <= response.status_code < 400:
+            logger.warning(
+                f"Redirect detected while fetching robots.txt from {robots_url}. Returning default."
+            )
+            return get_default_robots_txt()
         response.raise_for_status()
         logger.info("Successfully fetched robots.txt.")
         return response.text


### PR DESCRIPTION
## Summary
- skip following redirects when fetching robots.txt and fall back to default
- cover redirect handling in robots.txt fetcher tests

## Testing
- `pre-commit run --files src/util/robots_fetcher.py test/util/test_robots_fetcher.py`
- `python -m pytest test/util/test_robots_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68b78f59b7788321918cbec180935d3f