### PR TITLE
Document imports in prompt router

### DIFF
--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -1,9 +1,11 @@
+# Built-in modules
 import asyncio
 import hmac
 import os
 import re
 import time
 
+# Third-party modules
 import httpx
 from fastapi import HTTPException, Request, Response
 


### PR DESCRIPTION
## Summary
- group built-in and third-party imports in prompt-router main

## Testing
- `pre-commit run --files prompt-router/main.py`
- `python -m py_compile prompt-router/main.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a14cec88832191fd94342739e387