### PR TITLE
Remove stale websocket watchers

### DIFF
--- a/test/cloud_dashboard/test_cloud_dashboard_api.py
+++ b/test/cloud_dashboard/test_cloud_dashboard_api.py
@@ -62,6 +62,12 @@ class TestCloudDashboardAPI(unittest.TestCase):
             data = ws.receive_json()
             self.assertEqual(data, {"m": 1})
 
+    def test_watchers_entry_removed_when_empty(self):
+        self.client.post("/register", json={"installation_id": "ws2"})
+        with self.client.websocket_connect("/ws/ws2"):
+            self.assertIn("ws2", cd.WATCHERS)
+        self.assertNotIn("ws2", cd.WATCHERS)
+
     def test_api_key_enforced_when_configured(self):
         with patch.dict(os.environ, {"CLOUD_DASHBOARD_API_KEY": "sek"}):
             importlib.reload(cd)


### PR DESCRIPTION
## Summary
- remove watcher map entries when websockets disconnect
- periodically clean up stale websocket watchers

## Testing
- `pre-commit run --files src/cloud_dashboard/cloud_dashboard_api.py test/cloud_dashboard/test_cloud_dashboard_api.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7a8b1c5748321b5c44120aa2f6098