### PR TITLE
Handle decision DB directory creation errors

### DIFF
--- a/src/shared/decision_db.py
+++ b/src/shared/decision_db.py
@@ -4,9 +4,11 @@ This module wraps a simple SQLite database used to persist blocklist
 decisions and related metadata for analysis and debugging.
 """
 
+import logging
 import os
 import sqlite3
 from contextlib import contextmanager
+
 from src.shared.config import CONFIG
 
 DEFAULT_DB_DIR = "/app/data"
@@ -16,7 +18,11 @@ DB_PATH = os.getenv(
 )
 
 # Ensure the directory for the database exists so connecting does not fail
-os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+try:
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+except OSError as e:
+    logging.error("Failed to create directory for decision DB: %s", e)
+    raise RuntimeError(f"Failed to create directory for decision DB: {e}") from e
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS decisions (


### PR DESCRIPTION
## Summary
- log and raise an error if the decision DB directory cannot be created
- test directory creation failure

## Testing
- `pre-commit run --files src/shared/decision_db.py test/shared/test_decision_db.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7b30451e883218d0b12b093b5ae40