### PR TITLE
Use logging in diagnostic scripts

### DIFF
--- a/src/rag/email_entropy_scanner.py
+++ b/src/rag/email_entropy_scanner.py
@@ -1,8 +1,11 @@
 # rag/email_entropy_scanner.py
 
+import logging
 import math
 from collections import Counter
 from typing import List
+
+logger = logging.getLogger(__name__)
 
 
 # Calculate Shannon entropy
@@ -81,6 +84,9 @@ def is_suspicious_email(email: str, disposable_list: List[str]) -> bool:
 
 # Example usage block (only runs if script is executed directly)
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     # Sample disposable domains list (load from file/config in production)
     default_disposable_domains = [
         "mailinator.com",
@@ -113,8 +119,8 @@ if __name__ == "__main__":
         "@test.com",  # SUSPICIOUS (Invalid)
     ]
 
-    print("--- Email Suspicion Test ---")
+    logger.info("--- Email Suspicion Test ---")
     for email in test_emails:
         result = is_suspicious_email(email, default_disposable_domains)
-        print(f"'{email}': {'SUSPICIOUS' if result else 'OK'}")
-    print("----------------------------")
+        logger.info("'%s': %s", email, "SUSPICIOUS" if result else "OK")
+    logger.info("----------------------------")

--- a/src/util/robots_fetcher.py
+++ b/src/util/robots_fetcher.py
@@ -167,8 +167,8 @@ def _run_as_script() -> None:
         )
         with open(ROBOTS_OUTPUT_FILE, "w", encoding="utf-8") as f:
             f.write(robots_content)
-        print("\n--- Fetched Robots.txt Content ---")
-        print(robots_content)
+        logger.info("\n--- Fetched Robots.txt Content ---")
+        logger.info(robots_content)
 
     logger.info("Robots.txt Fetcher script finished.")
 


### PR DESCRIPTION
## Summary
- add module-level logger to email entropy scanner
- log robots.txt fetch results instead of printing

## Testing
- `pre-commit run --files src/util/robots_fetcher.py src/rag/email_entropy_scanner.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8e577b6d08321807ed8c309561667