### PR TITLE
Reuse SQLite connection for crawler registry

### DIFF
--- a/src/pay_per_crawl/db.py
+++ b/src/pay_per_crawl/db.py
@@ -4,72 +4,80 @@ from typing import Dict, Optional
 
 DB_PATH = os.environ.get("CRAWLER_DB_PATH", "crawler_registry.db")
 
+_CONNECTION: sqlite3.Connection | None = None
+_DB_PATH = DB_PATH
 
-def init_db(db_path: str = DB_PATH) -> None:
-    conn = sqlite3.connect(db_path)
+
+def init_db(db_path: str = DB_PATH) -> sqlite3.Connection:
+    """Initialize the crawler database if it hasn't been already."""
+    global _CONNECTION, _DB_PATH
+    if _CONNECTION is not None and db_path != _DB_PATH:
+        _CONNECTION.close()
+        _CONNECTION = None
+    if _CONNECTION is None:
+        _CONNECTION = sqlite3.connect(db_path)
+        _CONNECTION.execute(
+            "CREATE TABLE IF NOT EXISTS crawlers (token TEXT PRIMARY KEY, name TEXT, purpose TEXT, balance REAL DEFAULT 0)"
+        )
+        _CONNECTION.commit()
+        _DB_PATH = db_path
+    return _CONNECTION
+
+
+def _get_conn() -> sqlite3.Connection:
+    if _CONNECTION is None:
+        raise RuntimeError("Database not initialized. Call init_db first.")
+    return _CONNECTION
+
+
+def register_crawler(name: str, token: str, purpose: str) -> None:
+    conn = _get_conn()
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS crawlers (token TEXT PRIMARY KEY, name TEXT, purpose TEXT, balance REAL DEFAULT 0)"
+        (
+            "INSERT OR REPLACE INTO crawlers(token, name, purpose, balance) "
+            "VALUES(?,?,?, COALESCE((SELECT balance FROM crawlers WHERE token=?),0))"
+        ),
+        (token, name, purpose, token),
     )
     conn.commit()
-    conn.close()
 
 
-def register_crawler(
-    name: str, token: str, purpose: str, db_path: str = DB_PATH
-) -> None:
-    init_db(db_path)
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            (
-                "INSERT OR REPLACE INTO crawlers(token, name, purpose, balance) "
-                "VALUES(?,?,?, COALESCE((SELECT balance FROM crawlers WHERE token=?),0))"
-            ),
-            (token, name, purpose, token),
-        )
-        conn.commit()
-
-
-def get_crawler(token: str, db_path: str = DB_PATH) -> Optional[Dict[str, str]]:
-    init_db(db_path)
-    with sqlite3.connect(db_path) as conn:
-        cur = conn.execute(
-            "SELECT token, name, purpose, balance FROM crawlers WHERE token=?",
-            (token,),
-        )
-        row = cur.fetchone()
-        if row:
-            return {
-                "token": row[0],
-                "name": row[1],
-                "purpose": row[2],
-                "balance": row[3],
-            }
+def get_crawler(token: str) -> Optional[Dict[str, str]]:
+    conn = _get_conn()
+    cur = conn.execute(
+        "SELECT token, name, purpose, balance FROM crawlers WHERE token=?",
+        (token,),
+    )
+    row = cur.fetchone()
+    if row:
+        return {
+            "token": row[0],
+            "name": row[1],
+            "purpose": row[2],
+            "balance": row[3],
+        }
     return None
 
 
-def add_credit(token: str, amount: float, db_path: str = DB_PATH) -> None:
-    init_db(db_path)
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            "UPDATE crawlers SET balance=COALESCE(balance,0)+? WHERE token=?",
-            (amount, token),
-        )
-        conn.commit()
+def add_credit(token: str, amount: float) -> None:
+    conn = _get_conn()
+    conn.execute(
+        "UPDATE crawlers SET balance=COALESCE(balance,0)+? WHERE token=?",
+        (amount, token),
+    )
+    conn.commit()
 
 
-def charge(token: str, amount: float, db_path: str = DB_PATH) -> bool:
-    init_db(db_path)
-    with sqlite3.connect(db_path) as conn:
-        cur = conn.execute("SELECT balance FROM crawlers WHERE token=?", (token,))
-        row = cur.fetchone()
-        if not row:
-            return False
-        balance = row[0] or 0.0
-        if balance < amount:
-            return False
-        new_balance = balance - amount
-        conn.execute(
-            "UPDATE crawlers SET balance=? WHERE token=?", (new_balance, token)
-        )
-        conn.commit()
-        return True
+def charge(token: str, amount: float) -> bool:
+    conn = _get_conn()
+    cur = conn.execute("SELECT balance FROM crawlers WHERE token=?", (token,))
+    row = cur.fetchone()
+    if not row:
+        return False
+    balance = row[0] or 0.0
+    if balance < amount:
+        return False
+    new_balance = balance - amount
+    conn.execute("UPDATE crawlers SET balance=? WHERE token=?", (new_balance, token))
+    conn.commit()
+    return True

--- a/test/pay_per_crawl/test_db.py
+++ b/test/pay_per_crawl/test_db.py
@@ -25,22 +25,22 @@ class TestCrawlerDB(unittest.TestCase):
             return row[0] if row else None
 
     def test_register_and_get(self) -> None:
-        db.register_crawler("bot", "tok", "crawl", self.db_path)
-        info: Optional[Dict[str, str]] = db.get_crawler("tok", self.db_path)
+        db.register_crawler("bot", "tok", "crawl")
+        info: Optional[Dict[str, str]] = db.get_crawler("tok")
         self.assertIsNotNone(info)
         self.assertEqual(info["name"], "bot")
         self.assertEqual(info["purpose"], "crawl")
         self.assertEqual(self._balance("tok"), 0)
 
     def test_add_credit_and_charge(self) -> None:
-        db.register_crawler("bot", "tok", "crawl", self.db_path)
-        db.add_credit("tok", 2.0, self.db_path)
-        self.assertTrue(db.charge("tok", 1.5, self.db_path))
+        db.register_crawler("bot", "tok", "crawl")
+        db.add_credit("tok", 2.0)
+        self.assertTrue(db.charge("tok", 1.5))
         self.assertEqual(self._balance("tok"), 0.5)
-        self.assertFalse(db.charge("tok", 1.0, self.db_path))
+        self.assertFalse(db.charge("tok", 1.0))
 
     def test_get_crawler_missing(self) -> None:
-        info: Optional[Dict[str, str]] = db.get_crawler("nope", self.db_path)
+        info: Optional[Dict[str, str]] = db.get_crawler("nope")
         self.assertIsNone(info)
 
 

--- a/test/pay_per_crawl/test_service.py
+++ b/test/pay_per_crawl/test_service.py
@@ -17,12 +17,12 @@ class TestPayPerCrawlDB(unittest.TestCase):
         os.environ.pop("CRAWLER_DB_PATH", None)
 
     def test_register_and_charge(self):
-        db.register_crawler("bot", "token", "training", self.db_path)
-        db.add_credit("token", 1.0, self.db_path)
-        info = db.get_crawler("token", self.db_path)
+        db.register_crawler("bot", "token", "training")
+        db.add_credit("token", 1.0)
+        info = db.get_crawler("token")
         self.assertAlmostEqual(info["balance"], 1.0)
-        self.assertTrue(db.charge("token", 0.5, self.db_path))
-        info = db.get_crawler("token", self.db_path)
+        self.assertTrue(db.charge("token", 0.5))
+        info = db.get_crawler("token")
         self.assertAlmostEqual(info["balance"], 0.5)
 
 


### PR DESCRIPTION
## Summary
- maintain a shared SQLite connection and initialize the crawler DB once
- drop redundant `init_db` calls from CRUD helpers and update tests

## Testing
- `pre-commit run --files src/pay_per_crawl/db.py test/pay_per_crawl/test_db.py test/pay_per_crawl/test_service.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8eaef3c488321ab5ab2e8400877fe