### PR TITLE
Validate IP addresses in flagger

### DIFF
--- a/src/tarpit/ip_flagger.py
+++ b/src/tarpit/ip_flagger.py
@@ -4,6 +4,7 @@ in a dedicated Redis database. It uses a centralized Redis connection
 utility from the 'shared' module.
 """
 
+import ipaddress
 import logging
 import os
 
@@ -33,6 +34,12 @@ def flag_suspicious_ip(ip_address: str, reason: str = "Suspicious activity"):
     Connects to the dedicated database for flagged IPs.
     (Formerly flag_ip)
     """
+    try:
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        logger.error(f"Invalid IP address: {ip_address}")
+        return False
+
     r = get_redis_connection(db_number=REDIS_DB_FLAGGED_IPS)
     if not r:
         logger.error("Redis unavailable. Cannot flag IP.")
@@ -64,6 +71,12 @@ def is_ip_flagged(ip_address: str) -> bool:
     """
     Checks if an IP address is flagged by checking for the key's existence.
     """
+    try:
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        logger.error(f"Invalid IP address: {ip_address}")
+        return False
+
     r = get_redis_connection(db_number=REDIS_DB_FLAGGED_IPS)
     if r:
         try:

--- a/test/tarpit/test_tarpit_api.py
+++ b/test/tarpit/test_tarpit_api.py
@@ -32,6 +32,7 @@ class TestTarpitAPIComprehensive(unittest.IsolatedAsyncioTestCase):
             "shared_get_redis_connection": patch(
                 "src.shared.redis_client.get_redis_connection"
             ),
+            "is_ip_flagged": patch("src.tarpit.tarpit_api.is_ip_flagged"),
             "trigger_ip_block": patch("src.tarpit.tarpit_api.trigger_ip_block"),
             "httpx.AsyncClient": patch("src.tarpit.tarpit_api.httpx.AsyncClient"),
             "ENABLE_TARPIT_CATCH_ALL": patch(
@@ -39,6 +40,7 @@ class TestTarpitAPIComprehensive(unittest.IsolatedAsyncioTestCase):
             ),
         }
         self.mocks = {name: p.start() for name, p in self.patches.items()}
+        self.mocks["is_ip_flagged"].return_value = False
 
         # Configure mock Redis clients
         self.mock_redis_hops = MagicMock()
@@ -102,6 +104,7 @@ class TestTarpitAPIComprehensive(unittest.IsolatedAsyncioTestCase):
         ]  # Hop count exceeds default of 250
 
         self.mock_redis_hops.exists.return_value = 1
+        self.mocks["is_ip_flagged"].return_value = True
         with patch("src.tarpit.tarpit_api.TAR_PIT_MAX_HOPS", 250), patch(
             "src.tarpit.tarpit_api.HOP_LIMIT_ENABLED", True
         ):


### PR DESCRIPTION
## Summary
- validate IP inputs in `flag_suspicious_ip` and `is_ip_flagged`
- test invalid IP rejection and patch tarpit API tests

## Testing
- `pre-commit run --files src/tarpit/ip_flagger.py test/tarpit/test_ip_flagger.py test/tarpit/test_tarpit_api.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8f624cbac8321a4bfbdd1b336a407