### PR TITLE
Expire sessions after logging

### DIFF
--- a/src/behavioral/honeypot.py
+++ b/src/behavioral/honeypot.py
@@ -21,11 +21,14 @@ class SessionTracker:
         self,
         redis_db: int = 3,
         *,
+        session_ttl: int = 60 * 60 * 24,
         max_fallback_entries: int = 1000,
         cleanup_interval: float = 60.0,
     ) -> None:
         self.redis = get_redis_connection(db_number=redis_db)
+        self.session_ttl = session_ttl
         self.fallback: "OrderedDict[str, List[str]]" = OrderedDict()
+        self.fallback_expiry: Dict[str, datetime.datetime] = {}
         self.max_fallback_entries = max_fallback_entries
         self.cleanup_interval = cleanup_interval
         self._last_cleanup = datetime.datetime.now(datetime.UTC)
@@ -36,18 +39,25 @@ class SessionTracker:
         timestamp = timestamp or datetime.datetime.now(datetime.UTC).timestamp()
         entry = f"{timestamp}:{path}"
         if self.redis:
-            self.redis.rpush(f"session:{ip}", entry)
+            key = f"session:{ip}"
+            self.redis.rpush(key, entry)
+            self.redis.expire(key, self.session_ttl)
         else:
+            now = datetime.datetime.now(datetime.UTC)
+            self._cleanup_expired(now)
             if ip in self.fallback:
                 self.fallback[ip].append(entry)
             else:
                 self.fallback[ip] = [entry]
+            self.fallback_expiry[ip] = now + datetime.timedelta(
+                seconds=self.session_ttl
+            )
             self.fallback.move_to_end(ip)
             self._fallback_counter += 1
             if self._fallback_counter >= self._cleanup_every:
-                now = datetime.datetime.now(datetime.UTC)
                 if (now - self._last_cleanup).total_seconds() >= self.cleanup_interval:
                     self._evict_excess()
+                    self._cleanup_expired(now)
                     self._last_cleanup = now
                 self._fallback_counter = 0
 
@@ -55,6 +65,7 @@ class SessionTracker:
         if self.redis:
             entries = self.redis.lrange(f"session:{ip}", 0, -1)
         else:
+            self._cleanup_expired()
             entries = self.fallback.get(ip, [])
             if ip in self.fallback:
                 self.fallback.move_to_end(ip)
@@ -65,7 +76,17 @@ class SessionTracker:
 
     def _evict_excess(self) -> None:
         while len(self.fallback) > self.max_fallback_entries:
-            self.fallback.popitem(last=False)
+            ip, _ = self.fallback.popitem(last=False)
+            self.fallback_expiry.pop(ip, None)
+
+    def _cleanup_expired(
+        self, now: datetime.datetime | None = None
+    ) -> None:  # pragma: no cover - simple cleanup
+        now = now or datetime.datetime.now(datetime.UTC)
+        expired = [ip for ip, exp in self.fallback_expiry.items() if exp <= now]
+        for ip in expired:
+            self.fallback.pop(ip, None)
+            self.fallback_expiry.pop(ip, None)
 
 
 def _seq_features(seq: List[str]) -> List[float]:

--- a/test/behavioral/test_honeypot.py
+++ b/test/behavioral/test_honeypot.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 
 from src.behavioral import SessionTracker, train_behavior_model
@@ -6,6 +7,7 @@ from src.behavioral import SessionTracker, train_behavior_model
 class DummyRedis:
     def __init__(self) -> None:
         self.store = {}
+        self.expirations = {}
 
     def rpush(self, key: str, value: str) -> None:
         # Mimic Redis by storing the pre-formatted entry as bytes
@@ -13,6 +15,9 @@ class DummyRedis:
 
     def lrange(self, key: str, start: int, end: int):
         return self.store.get(key, [])[start : end + 1 if end != -1 else None]
+
+    def expire(self, key: str, ttl: int) -> None:
+        self.expirations[key] = ttl
 
 
 class TestBehavioralHoneypot(unittest.TestCase):
@@ -35,6 +40,15 @@ class TestBehavioralHoneypot(unittest.TestCase):
         seq = tracker.get_sequence("1.1.1.1")
         self.assertEqual(seq, ["/a", "/b"])
 
+    def test_redis_expire(self):
+        tracker = SessionTracker(redis_db=99, session_ttl=10)
+        tracker.redis = DummyRedis()
+        tracker.log_request("1.1.1.1", "/a")
+        self.assertEqual(
+            tracker.redis.expirations["session:1.1.1.1"],
+            10,
+        )
+
     def test_fallback_eviction(self):
         tracker = SessionTracker(
             redis_db=99, max_fallback_entries=2, cleanup_interval=0
@@ -49,6 +63,15 @@ class TestBehavioralHoneypot(unittest.TestCase):
         self.assertNotIn("3.3.3.3", tracker.fallback)
         self.assertIn("2.2.2.2", tracker.fallback)
         self.assertIn("4.4.4.4", tracker.fallback)
+
+    def test_fallback_expiry(self):
+        tracker = SessionTracker(redis_db=99, session_ttl=1, cleanup_interval=0)
+        tracker.log_request("1.1.1.1", "/a")
+        tracker.fallback_expiry["1.1.1.1"] = datetime.datetime.now(
+            datetime.UTC
+        ) - datetime.timedelta(seconds=1)
+        tracker.log_request("2.2.2.2", "/b")
+        self.assertNotIn("1.1.1.1", tracker.fallback)
 
     def test_batched_cleanup(self):
         tracker = SessionTracker(redis_db=99, cleanup_interval=0)


### PR DESCRIPTION
## Summary
- add configurable session TTL and Redis expire for logged sessions
- enforce same TTL cleanup for in-memory session fallback
- test TTL behavior for Redis and fallback storage

## Testing
- `pre-commit run --files src/behavioral/honeypot.py test/behavioral/test_honeypot.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b903a16d3083218569b72f6b30892e