### PR TITLE
Add module docstring for decision database

### DIFF
--- a/src/shared/decision_db.py
+++ b/src/shared/decision_db.py
@@ -1,8 +1,5 @@
-"""SQLite storage for request decisions.
-
-This module wraps a simple SQLite database used to persist blocklist
-decisions and related metadata for analysis and debugging.
-"""
+"""This module wraps a simple SQLite database used to persist blocklist decisions
+and related metadata for analysis and debugging."""
 
 import logging
 import os


### PR DESCRIPTION
## Summary
- replace leading text with a concise module docstring in `decision_db`

## Testing
- `pre-commit run --files src/shared/decision_db.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb8f69e0ec8321a5ffe27debb6f04d