### PR TITLE
Clarify HTTP alert docstring

### DIFF
--- a/src/shared/http_alert.py
+++ b/src/shared/http_alert.py
@@ -1,4 +1,5 @@
-"""Generic HTTP-based alert sender for webhook and API-based alerts.
+"""
+Generic HTTP-based alert sender for webhook and API-based alerts.
 
 This module provides a generic abstraction for sending alerts via HTTP webhooks
 and APIs. It handles alert formatting, error handling, retry logic, and logging


### PR DESCRIPTION
## Summary
- format module docstring in `http_alert` for clearer documentation

## Testing
- `pre-commit run --files src/shared/http_alert.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb91c72cb8832192f098f4a0629b2f