### PR TITLE
Install gh, jq, and PyYAML in security triage workflow

### DIFF
--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Install jq & gh
-        run: sudo apt-get update && sudo apt-get install -y jq
+        run: sudo apt-get update && sudo apt-get install -y jq gh
+      - name: Install PyYAML
+        run: pip install pyyaml
       - name: Dismiss allowlisted Code Scanning alerts
         run: |
           set -e


### PR DESCRIPTION
## Summary
- install jq and gh in security triage workflow
- add step to install PyYAML for triage script

## Testing
- `pre-commit run --files .github/workflows/security-triage.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7b66adcd483219c8e450547bf9a46