### PR TITLE
Move preview cleanup to PR close workflow

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,29 @@
+name: Cleanup Preview Environment
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/get-gke-credentials@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT }}
+          cluster_name: ${{ secrets.GKE_CLUSTER }}
+          location: ${{ secrets.GCP_REGION }}
+      - name: Delete preview namespace
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          kubectl delete ns "pr-${PR}" --wait=false || true

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,7 +1,7 @@
 name: Cleanup Preview Environment
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
 

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -75,21 +75,3 @@ jobs:
           script: |
             const url = `https://${{ steps.host.outputs.host }}/`;
             github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: ${{ inputs.pr_number }}, body: `🔎 Preview ready: ${url}` });
-  cleanup-preview:
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/get-gke-credentials@v2
-        with:
-          project_id: ${{ secrets.GCP_PROJECT }}
-          cluster_name: ${{ secrets.GKE_CLUSTER }}
-          location: ${{ secrets.GCP_REGION }}
-      - name: Delete preview namespace
-        run: PR=${{ inputs.pr_number }}; kubectl delete ns "pr-${PR}" --wait=false || true


### PR DESCRIPTION
## Summary
- remove the cleanup job from the preview deployment workflow so it no longer deletes the namespace immediately
- add a dedicated cleanup workflow that triggers when a pull request is closed and tears down the preview namespace

## Testing
- pre-commit run --files .github/workflows/preview-pr.yml .github/workflows/cleanup-preview.yml

------
https://chatgpt.com/codex/tasks/task_e_68c927f31e908321b93bec423a0ff9bf