### PR TITLE
Fix k8s smoke test import

### DIFF
--- a/.github/workflows/k8s-smoke.yml
+++ b/.github/workflows/k8s-smoke.yml
@@ -49,10 +49,19 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           python - <<'PY'
+          import importlib.util
           import os
+          import pathlib
 
           from kubernetes import config
-          from src.util.rules_fetcher.kubernetes import get_kubernetes_api
+          module_path = pathlib.Path("src/util/rules_fetcher/kubernetes.py").resolve()
+          spec = importlib.util.spec_from_file_location(
+            "rules_fetcher_kubernetes",
+            module_path,
+          )
+          module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(module)
+          get_kubernetes_api = module.get_kubernetes_api
 
           kubeconfig = os.environ.get("KUBECONFIG")
           if kubeconfig:


### PR DESCRIPTION
- Summary:
  - Load the Kubernetes helper module directly by path in the k8s smoke workflow to avoid importing src.util/__init__ and its optional deps.

- Testing:
  - pre-commit run --files .github/workflows/k8s-smoke.yml
