### PR TITLE
Add MFA backup codes for admin UI

### DIFF
--- a/src/admin_ui/mfa.py
+++ b/src/admin_ui/mfa.py
@@ -1,0 +1,108 @@
+import json
+import logging
+import secrets
+import time
+from typing import Any
+
+import bcrypt
+from redis.exceptions import RedisError
+
+from src.shared.config import tenant_key
+from src.shared.redis_client import get_redis_connection
+
+logger = logging.getLogger(__name__)
+
+BACKUP_CODE_LENGTH = 8
+BACKUP_CODE_COUNT = 10
+BACKUP_CODE_TTL = 90 * 24 * 3600
+
+
+def _backup_codes_key(user: str) -> str:
+    return tenant_key(f"admin_ui:mfa:backup_codes:{user}")
+
+
+def generate_backup_codes(count: int = BACKUP_CODE_COUNT) -> list[str]:
+    codes: list[str] = []
+    for _ in range(count):
+        code = "".join(str(secrets.randbelow(10)) for _ in range(BACKUP_CODE_LENGTH))
+        codes.append(code)
+    return codes
+
+
+def _hash_backup_code(code: str) -> str:
+    return bcrypt.hashpw(code.encode(), bcrypt.gensalt()).decode()
+
+
+def store_backup_codes(user: str, codes: list[str]) -> bool:
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        logger.error("Redis unavailable, cannot store backup codes")
+        return False
+    try:
+        payload = {
+            "codes": [_hash_backup_code(code) for code in codes],
+            "used": [False for _ in codes],
+            "created_at": time.time(),
+        }
+        redis_conn.set(_backup_codes_key(user), json.dumps(payload), ex=BACKUP_CODE_TTL)
+        return True
+    except RedisError as exc:
+        logger.error("Failed to store backup codes: %s", exc)
+        return False
+
+
+def _load_backup_payload(redis_conn: Any, user: str) -> dict | None:
+    raw = redis_conn.get(_backup_codes_key(user))
+    if not raw:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def verify_backup_code(user: str, code: str) -> bool:
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        logger.error("Redis unavailable, cannot verify backup codes")
+        return False
+    try:
+        data = _load_backup_payload(redis_conn, user)
+        if not data:
+            return False
+        codes = data.get("codes") or []
+        used = data.get("used") or [False for _ in codes]
+        for index, hashed in enumerate(codes):
+            if index >= len(used) or used[index]:
+                continue
+            if bcrypt.checkpw(code.encode(), hashed.encode()):
+                used[index] = True
+                data["used"] = used
+                ttl = redis_conn.ttl(_backup_codes_key(user))
+                if ttl is None or ttl <= 0:
+                    ttl = BACKUP_CODE_TTL
+                redis_conn.set(_backup_codes_key(user), json.dumps(data), ex=int(ttl))
+                return True
+        return False
+    except RedisError as exc:
+        logger.error("Failed to verify backup code: %s", exc)
+        return False
+
+
+def get_remaining_backup_codes_count(user: str) -> int:
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        return 0
+    try:
+        data = _load_backup_payload(redis_conn, user)
+        if not data:
+            return 0
+        used = data.get("used") or []
+        return sum(1 for status in used if not status)
+    except RedisError:
+        return 0

--- a/test/admin_ui/test_mfa_backup_codes.py
+++ b/test/admin_ui/test_mfa_backup_codes.py
@@ -1,0 +1,93 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import bcrypt
+import pyotp
+from fastapi.testclient import TestClient
+
+from src.admin_ui import admin_ui, auth, mfa
+
+
+class MockRedis:
+    def __init__(self):
+        self.store = {}
+        self.expiry = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        if ex is not None:
+            self.expiry[key] = ex
+        return True
+
+    def ttl(self, key):
+        return self.expiry.get(key, -1)
+
+    def incr(self, key):
+        current = int(self.store.get(key, 0))
+        current += 1
+        self.store[key] = current
+        return current
+
+    def expire(self, key, ttl):
+        self.expiry[key] = ttl
+        return True
+
+
+class TestAdminUIMfaBackupCodes(unittest.TestCase):
+    def setUp(self):
+        os.environ["ADMIN_UI_USERNAME"] = "admin"
+        os.environ["ADMIN_UI_PASSWORD_HASH"] = bcrypt.hashpw(
+            b"testpass", bcrypt.gensalt()
+        ).decode()
+        os.environ["ADMIN_UI_ROLE"] = "admin"
+        os.environ["ADMIN_UI_2FA_SECRET"] = "JBSWY3DPEHPK3PXP"
+        auth.ADMIN_UI_ROLE = "admin"
+        self.client = TestClient(admin_ui.app)
+        self.auth = ("admin", "testpass")
+
+    def _totp_headers(self) -> dict:
+        secret = os.environ["ADMIN_UI_2FA_SECRET"]
+        return {"X-2FA-Code": pyotp.TOTP(secret).now()}
+
+    def test_backup_code_allows_auth(self):
+        mock_redis = MockRedis()
+        with patch("src.admin_ui.auth.get_redis_connection", return_value=mock_redis):
+            with patch(
+                "src.admin_ui.mfa.get_redis_connection", return_value=mock_redis
+            ):
+                codes = mfa.generate_backup_codes(count=1)
+                self.assertTrue(mfa.store_backup_codes("admin", codes))
+                headers = {"X-2FA-Backup-Code": codes[0]}
+                response = self.client.get("/", auth=self.auth, headers=headers)
+                self.assertEqual(response.status_code, 200)
+
+    def test_backup_code_rejected_when_invalid(self):
+        mock_redis = MockRedis()
+        with patch("src.admin_ui.auth.get_redis_connection", return_value=mock_redis):
+            with patch(
+                "src.admin_ui.mfa.get_redis_connection", return_value=mock_redis
+            ):
+                codes = mfa.generate_backup_codes(count=1)
+                self.assertTrue(mfa.store_backup_codes("admin", codes))
+                headers = {"X-2FA-Backup-Code": "00000000"}
+                response = self.client.get("/", auth=self.auth, headers=headers)
+                self.assertEqual(response.status_code, 401)
+
+    def test_generate_backup_codes_endpoint(self):
+        mock_redis = MockRedis()
+        with patch("src.admin_ui.auth.get_redis_connection", return_value=mock_redis):
+            with patch(
+                "src.admin_ui.mfa.get_redis_connection", return_value=mock_redis
+            ):
+                response = self.client.post(
+                    "/mfa/backup-codes",
+                    auth=self.auth,
+                    headers=self._totp_headers(),
+                )
+                self.assertEqual(response.status_code, 200)
+                payload = response.json()
+                self.assertTrue(payload["backup_codes"])


### PR DESCRIPTION
## Summary\n- add backup code generation/storage helpers for admin UI MFA\n- accept X-2FA-Backup-Code as a fallback when TOTP is enabled\n- expose admin-only endpoints to generate and check remaining codes\n\n## Testing\n- .venv/bin/pre-commit run --files src/admin_ui/mfa.py src/admin_ui/auth.py test/admin_ui/test_mfa_backup_codes.py\n\nCloses: #1296 (replaces WIP)