### PR TITLE
Add optional Docker Compose hardening overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,13 @@ For a full walkthrough of bringing the stack live, review [docs/test_to_producti
     docker-compose up --build -d
     ```
 
+    For an optional hardened profile (drops Linux capabilities and enforces
+    `no-new-privileges` on core services), layer in the security override file:
+
+    ```bash
+    docker compose -f docker-compose.yaml -f docker-compose.security.yml up -d
+    ```
+
     If you'd like to try the proxy in front of a WordPress site, run `./setup_wordpress_website.sh` (or `./setup_wordpress_website.ps1` on Windows) instead. It launches WordPress and MariaDB containers and sets `REAL_BACKEND_HOST` automatically. For a smaller test, `./setup_fake_website.sh` creates a simple nginx site and updates the variable in the same way.
 
 7. **Access the Services:**

--- a/docker-compose.security.yml
+++ b/docker-compose.security.yml
@@ -1,0 +1,57 @@
+# Optional security hardening overrides for Docker Compose.
+# Use with: docker compose -f docker-compose.yaml -f docker-compose.security.yml up -d
+
+services:
+  ai_service:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  escalation_engine:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  tarpit_api:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  admin_ui:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  captcha_service:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  cloud_dashboard:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  config_recommender:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  cloud_proxy:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  prompt_router:
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL


### PR DESCRIPTION
## Summary\n- add an opt-in docker-compose security override that drops Linux capabilities and enforces no-new-privileges\n- document the hardened compose profile in README\n\n## Testing\n- .venv/bin/pre-commit run --files docker-compose.security.yml README.md\n\nCloses: #1340 (replaces WIP)