### PR TITLE
Add scheduled container image scans

### DIFF
--- a/.github/workflows/container-image-scan.yml
+++ b/.github/workflows/container-image-scan.yml
@@ -1,0 +1,66 @@
+name: container-image-scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: ai-scraping-defense-core
+            context: .
+            dockerfile: Dockerfile
+          - name: ai-scraping-defense-proxy
+            context: proxy
+            dockerfile: proxy/Dockerfile
+          - name: ai-scraping-defense-cloud-proxy
+            context: cloud-proxy
+            dockerfile: cloud-proxy/Dockerfile
+          - name: ai-scraping-defense-prompt-router
+            context: prompt-router
+            dockerfile: prompt-router/Dockerfile
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image for scanning
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          tags: ${{ matrix.image.name }}:scan
+          load: true
+      - name: Scan image with Trivy (SARIF)
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ matrix.image.name }}:scan
+          format: sarif
+          output: trivy-${{ matrix.image.name }}.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@528ca598d956c91826bd742262cdfc5d02b77710
+        if: always()
+        with:
+          sarif_file: trivy-${{ matrix.image.name }}.sarif
+          category: trivy-${{ matrix.image.name }}
+      - name: Scan image with Trivy (table)
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ matrix.image.name }}:scan
+          format: table
+          severity: CRITICAL,HIGH,MEDIUM
+          ignore-unfixed: true
+          exit-code: "0"


### PR DESCRIPTION
## Summary\n- add a scheduled/manual workflow to build and scan container images with Trivy\n- upload SARIF results to the security tab without blocking CI\n\n## Testing\n- .venv/bin/pre-commit run --files .github/workflows/container-image-scan.yml\n\nCloses: #1290 (replaces WIP)