### PR TITLE
Stream training logs with mmap

### DIFF
--- a/src/util/mmap_reader.py
+++ b/src/util/mmap_reader.py
@@ -1,0 +1,36 @@
+"""Utilities for reading large files efficiently."""
+
+from __future__ import annotations
+
+import mmap
+import os
+from pathlib import Path
+from typing import Iterator
+
+
+def iter_text_lines(
+    path: str | Path,
+    *,
+    encoding: str = "utf-8",
+    errors: str = "ignore",
+    min_size_bytes: int = 1024 * 1024,
+) -> Iterator[str]:
+    """Yield lines from a file, using mmap for large files when possible."""
+    file_path = Path(path)
+    with file_path.open("r", encoding=encoding, errors=errors) as handle:
+        try:
+            size = os.fstat(handle.fileno()).st_size
+        except OSError:
+            size = 0
+
+        if size < min_size_bytes:
+            for line in handle:
+                yield line.rstrip("\n")
+            return
+
+        with mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+            while True:
+                raw = mm.readline()
+                if not raw:
+                    break
+                yield raw.decode(encoding, errors).rstrip("\n")

--- a/test/util/test_mmap_reader.py
+++ b/test/util/test_mmap_reader.py
@@ -1,0 +1,16 @@
+import os
+import tempfile
+
+from src.util.mmap_reader import iter_text_lines
+
+
+def test_iter_text_lines_with_mmap():
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False) as tmp:
+        tmp.write("alpha\nbeta\n")
+        path = tmp.name
+
+    try:
+        lines = list(iter_text_lines(path, min_size_bytes=0))
+        assert lines == ["alpha", "beta"]
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
## Summary\n- add a mmap-backed line reader for large files\n- stream honeypot and CAPTCHA logs in training instead of reading entire files\n- add unit coverage for the mmap reader\n\n## Testing\n- .venv/bin/pre-commit run --files src/util/mmap_reader.py src/rag/training.py test/util/test_mmap_reader.py\n\nCloses: #1336 (partial, replaces WIP with safe mmap integration)