### PR TITLE
Align Rust release profiles

### DIFF
--- a/docs/rust_optimization.md
+++ b/docs/rust_optimization.md
@@ -1,0 +1,30 @@
+# Rust Release Profile Optimization
+
+This project ships multiple Rust crates that are compiled into shared libraries.
+To keep runtime performance consistent, each crate uses the same release
+profile settings.
+
+## Release Profile
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = true
+panic = "abort"
+```
+
+## Why These Settings?
+
+- `opt-level = 3` enables the most aggressive optimizations.
+- `lto = "thin"` improves cross-crate optimization without the full LTO cost.
+- `codegen-units = 1` helps the compiler optimize across the entire crate.
+- `strip = true` reduces release binary size.
+- `panic = "abort"` removes unwind overhead in release builds.
+
+## How to Build
+
+```bash
+cargo build --release
+```

--- a/frequency-rs/Cargo.toml
+++ b/frequency-rs/Cargo.toml
@@ -12,3 +12,10 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.24.2", features = ["extension-module"] }
 redis = "0.23"
 chrono = "0.4"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = true
+panic = "abort"

--- a/jszip-rs/Cargo.toml
+++ b/jszip-rs/Cargo.toml
@@ -21,3 +21,10 @@ tempfile = "3"
 
 [build-dependencies]
 pyo3-build-config = { version = "0.27.1", features = ["resolve-config"] }
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = true
+panic = "abort"

--- a/markov-train-rs/Cargo.toml
+++ b/markov-train-rs/Cargo.toml
@@ -12,3 +12,10 @@ crate-type = ["cdylib", "rlib"]
 pyo3 = { version = "0.27.2", features = ["extension-module"] }
 postgres = "0.19"
 regex = "1"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = true
+panic = "abort"

--- a/tarpit-rs/Cargo.toml
+++ b/tarpit-rs/Cargo.toml
@@ -13,3 +13,10 @@ pyo3 = { version = "0.24.2", features = ["extension-module"] }
 postgres = "0.19"
 rand = "0.8"
 html-escape = "0.2"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = true
+panic = "abort"


### PR DESCRIPTION
## Summary\n- add consistent release profile settings across Rust crates\n- document the optimization profile\n\n## Testing\n- .venv/bin/pre-commit run --files frequency-rs/Cargo.toml markov-train-rs/Cargo.toml jszip-rs/Cargo.toml tarpit-rs/Cargo.toml docs/rust_optimization.md\n\nCloses: #1374 (replaces WIP)