### PR TITLE
Update pyasn1 to 0.6.2

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -244,7 +244,7 @@ psycopg2==2.9.10 ; platform_system != "Darwin"
     # via -r requirements.txt
 pyarrow==21.0.0
     # via datasets
-pyasn1==0.6.1
+pyasn1==0.6.2
     # via
     #   pyasn1-modules
     #   rsa


### PR DESCRIPTION
## Summary\n- bump pyasn1 to 0.6.2 in requirements.lock to address CVE-2026-23490\n\n## Testing\n- .venv/bin/pre-commit run --files requirements.lock\n\nCloses: https://github.com/rhamenator/ai-scraping-defense/security/dependabot/34