### PR TITLE
Harden security scans and outbound redirects

### DIFF
--- a/docs/layered_alerting_architecture.md
+++ b/docs/layered_alerting_architecture.md
@@ -92,8 +92,8 @@ success = await alert_sender.send_alert({
 
 **Usage Example**:
 ```bash
-# Set your Slack webhook URL in the environment (masked here)
-export ALERT_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX"
+# Set your Slack webhook URL in the environment (example placeholder)
+export ALERT_SLACK_WEBHOOK_URL="https://hooks.example.com/services/REDACTED/REDACTED/REDACTED"
 ```
 
 ```python

--- a/docs/security_scan.md
+++ b/docs/security_scan.md
@@ -1,6 +1,6 @@
 # Security Scan Helper
 
-`scripts/linux/security_scan.sh` runs a collection of open-source tools to audit a target for common weaknesses. It invokes scanners such as **Nmap**, **Nikto**, **OWASP ZAP**, and **Trivy** alongside optional checks like **SQLMap** and **Bandit**.
+`scripts/linux/security_scan.sh` runs a collection of open-source tools to audit a target for common weaknesses. It invokes scanners such as **Nmap**, **Nikto**, **OWASP ZAP**, and **Trivy** alongside optional checks like **SQLMap**, **Bandit**, API security tests, and LLM prompt-injection exercises.
 
 ## Prerequisites
 - Linux environment with the required utilities installed (e.g. `nmap`, `nikto`, `zaproxy`, `trivy`, `sqlmap`, `masscan`, `bandit`, etc.)
@@ -21,3 +21,15 @@ The AI Scraping Defense stack includes multiple layers designed to detect or mit
 - **Comprehensive Logging** – All requests are logged and exported to Prometheus/Grafana for monitoring unusual activity.
 
 Both `scripts/linux/security_scan.sh` and the new **`scripts/windows/security_scan.ps1`** script produce reports in the `reports` directory, allowing you to verify that these defenses are functioning as expected.
+
+## Optional Deep-Dive Arguments
+
+The scan script accepts optional parameters to trigger deeper API and LLM checks:
+
+```bash
+sudo ./scripts/linux/security_scan.sh <target> [web_url] [docker_image] [code_dir] [sqlmap_url] \
+  [api_base_url] [openapi_spec_url] [llm_endpoint] [llm_auth_token]
+```
+
+- Use `api_base_url` to run `api_security_test` against the API surface.
+- Use `llm_endpoint` to run the prompt-injection tests against the AI endpoint.

--- a/scripts/linux/security_scan.sh
+++ b/scripts/linux/security_scan.sh
@@ -2,12 +2,16 @@
 # security_scan.sh - Advanced security testing helper
 #
 
-# Usage: sudo ./security_scan.sh <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url]
+# Usage: sudo ./security_scan.sh <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url] [api_base_url] [openapi_spec_url] [llm_endpoint] [llm_auth_token]
 # - target_host_or_ip: IP or hostname for network scans
 # - web_url_for_nikto: full URL to scan with Nikto and ZAP (defaults to http://<target>)
 # - docker_image: optional container image to scan with Trivy
 # - code_dir: optional path to source code for Bandit static analysis
 # - sqlmap_url: optional parameterized URL for automated SQLMap testing
+# - api_base_url: optional base URL for API security testing
+# - openapi_spec_url: optional OpenAPI/Swagger spec URL for API security testing
+# - llm_endpoint: optional AI/LLM endpoint for prompt injection testing
+# - llm_auth_token: optional auth token for LLM prompt injection testing
 
 set -euo pipefail
 
@@ -17,10 +21,14 @@ IMAGE="$3"
 CODE_DIR="${4:-.}"
 
 SQLMAP_URL="$5"
+API_BASE_URL="${6:-}"
+OPENAPI_SPEC_URL="${7:-}"
+LLM_ENDPOINT="${8:-}"
+LLM_AUTH_TOKEN="${9:-}"
 PORTS="22,80,443,5432,6379"
 
 if [[ -z "$TARGET" ]]; then
-    echo "Usage: sudo $0 <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url]"
+    echo "Usage: sudo $0 <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url] [api_base_url] [openapi_spec_url] [llm_endpoint] [llm_auth_token]"
     exit 1
 fi
 
@@ -286,6 +294,38 @@ if command -v syft >/dev/null 2>&1 && [[ -n "$IMAGE" ]]; then
     syft "$IMAGE" -o json > "reports/syft_$(echo $IMAGE | tr '/:' '_').json" || true
 else
     echo "syft not installed or no image specified. Skipping SBOM generation."
+fi
+
+echo "=== 36. Static Security Configuration Checks ==="
+if command -v python3 >/dev/null 2>&1 && [[ -f "scripts/security/run_static_security_checks.py" ]]; then
+    python3 scripts/security/run_static_security_checks.py \
+        > "reports/static_security_checks.txt" 2>&1 || true
+else
+    echo "python3 or static security checks script not found. Skipping."
+fi
+
+echo "=== 37. API Security Test Suite ==="
+if [[ -n "$API_BASE_URL" ]] && [[ -x "scripts/linux/api_security_test.sh" ]]; then
+    ./scripts/linux/api_security_test.sh "$API_BASE_URL" "$OPENAPI_SPEC_URL" || true
+else
+    echo "API base URL or api_security_test.sh missing. Skipping API tests."
+fi
+
+echo "=== 38. LLM Prompt Injection Tests ==="
+if [[ -n "$LLM_ENDPOINT" ]] && [[ -x "scripts/linux/llm_prompt_injection_test.sh" ]]; then
+    ./scripts/linux/llm_prompt_injection_test.sh "$LLM_ENDPOINT" "$LLM_AUTH_TOKEN" || true
+else
+    echo "LLM endpoint or llm_prompt_injection_test.sh missing. Skipping LLM tests."
+fi
+
+echo "=== 39. AI-Driven Scan Correlation ==="
+if command -v python3 >/dev/null 2>&1 && [[ -f "scripts/linux/ai_driven_security_test.py" ]]; then
+    python3 scripts/linux/ai_driven_security_test.py \
+        --reports-dir reports \
+        --provider "${AI_SECURITY_PROVIDER:-local}" \
+        --output reports/ai_analysis.txt || true
+else
+    echo "python3 or ai_driven_security_test.py missing. Skipping AI analysis."
 fi
 
 echo "Reports saved in the 'reports' directory. Review them for potential issues." 

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -56,7 +56,9 @@ def _fetch_vault_secret(secret_path: str, key: str = "value") -> Optional[str]:
         else:
             url = f"{vault_addr.rstrip('/')}/v1/{secret_path.lstrip('/')}"
 
-        with requests.get(url, headers={"X-Vault-Token": token}, timeout=5) as resp:
+        with requests.get(
+            url, headers={"X-Vault-Token": token}, timeout=5, allow_redirects=False
+        ) as resp:
             if resp.ok:
                 data = resp.json().get("data", {}).get("data", {})
                 secret = data.get(key)
@@ -70,7 +72,9 @@ def _fetch_vault_secret(secret_path: str, key: str = "value") -> Optional[str]:
             return None
         url = f"{vault_addr.rstrip('/')}/v1/{secret_path.lstrip('/')}"
         try:
-            with requests.get(url, headers={"X-Vault-Token": token}, timeout=5) as resp:
+            with requests.get(
+                url, headers={"X-Vault-Token": token}, timeout=5, allow_redirects=False
+            ) as resp:
                 if resp.ok:
                     data = resp.json().get("data", {}).get("data", {})
                     secret = data.get(key)

--- a/src/shared/http_alert.py
+++ b/src/shared/http_alert.py
@@ -250,7 +250,7 @@ class MultiChannelAlertSender:
 
     Usage Example:
         sender = MultiChannelAlertSender()
-        sender.add_channel("slack", HttpAlertSender("https://hooks.slack.com/..."))
+        sender.add_channel("slack", HttpAlertSender("https://hooks.example.com/..."))
         sender.add_channel("teams", HttpAlertSender("https://outlook.office.com/..."))
 
         success_count = await sender.send_alert_to_all({

--- a/src/util/rules_fetcher/crs.py
+++ b/src/util/rules_fetcher/crs.py
@@ -18,7 +18,7 @@ def download_and_extract_crs(url: str, dest_dir: str) -> bool:
         return False
 
     try:
-        response = requests.get(url, timeout=30)
+        response = requests.get(url, timeout=30, allow_redirects=False)
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         logger.error("Failed to download CRS archive from %s: %s", url, exc)

--- a/src/util/rules_fetcher/fetcher.py
+++ b/src/util/rules_fetcher/fetcher.py
@@ -42,7 +42,7 @@ def fetch_rules(url: str, allowed_domains: Optional[list[str]] = None) -> str:
         return ""
 
     try:
-        response = requests.get(url, timeout=15)
+        response = requests.get(url, timeout=15, allow_redirects=False)
         response.raise_for_status()
         logger.info("Successfully fetched rules file.")
         return response.text


### PR DESCRIPTION
## Summary
- Remove real Slack webhook examples from docs and alert examples.
- Disable outbound redirects on rules/Vault fetches.
- Extend security_scan scripts to include API, LLM, static checks, and AI correlation.
- Document expanded scan usage.

## Issues Closed
- Closes #1431, #1436, #1439 (redirect mitigations and Slack webhook examples).

## Notes
- Closed as moot/not-codifiable: #1201, #1189, #1193, #1196, #1432, #1433, #1434, #1435, #1437, #1438 (see issue comments).

## Testing
- `pre-commit run --files …` (not run; pre-commit not installed)
- `.venv/bin/python -m pytest` (timed out after ~120s at ~79% progress)
