### PR TITLE
Align security setup scripts with scan tooling

### DIFF
--- a/docs/security_scan.md
+++ b/docs/security_scan.md
@@ -25,6 +25,10 @@ Both `scripts/linux/security_scan.sh` and the new **`scripts/windows/security_sc
 Static configuration checks validate against `config/security_hardening.yaml` to
 ensure baseline hardening expectations are met in `docker-compose.yaml`.
 
+Some tools require extra prerequisites: Go for ProjectDiscovery utilities
+(`nuclei`, `katana`, `httpx`, `amass`, `dalfox`), Node.js for `snyk`, and
+wordlists such as Seclists/DirBuster for directory and parameter fuzzing.
+
 ## Optional Deep-Dive Arguments
 
 The scan script accepts optional parameters to trigger deeper API and LLM checks:

--- a/scripts/macos/security_setup.zsh
+++ b/scripts/macos/security_setup.zsh
@@ -12,7 +12,7 @@ fi
 # Install tools used by security_scan.sh
 brew update
 brew install nmap nikto zaproxy sqlmap lynis hydra masscan gobuster enum4linux \
-    wpscan ffuf wfuzz testssl whatweb gvm rkhunter chkrootkit clamav jq
+    wpscan ffuf wfuzz testssl whatweb gvm rkhunter chkrootkit clamav jq seclists
 
 # Additional tools from GitHub with checksum verification
 TMP_DIR=$(mktemp -d)
@@ -62,7 +62,7 @@ if command -v go >/dev/null 2>&1; then
     go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
     go install github.com/hahwul/dalfox/v2@latest
     go install -v github.com/owasp-amass/amass/v4/...@master
-    
+
     # Add Go bin to PATH if not already present
     if [[ ":$PATH:" != *":$HOME/go/bin:"* ]]; then
         echo 'export PATH="$PATH:$HOME/go/bin"' >> ~/.zshrc

--- a/scripts/windows/security_setup.ps1
+++ b/scripts/windows/security_setup.ps1
@@ -8,7 +8,8 @@ pip install -r requirements.txt
 
 $tools = @(
     'nmap','nikto','zaproxy','sqlmap','lynis','hydra','masscan','gobuster','enum4linux',
-    'wpscan','ffuf','wfuzz','testssl.sh','whatweb','gvm','rkhunter','chkrootkit','clamav'
+    'wpscan','ffuf','wfuzz','testssl.sh','whatweb','gvm','rkhunter','chkrootkit','clamav',
+    'seclists'
 )
 
 if (Get-Command choco -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
## Summary
- Install wordlists (Seclists/DirBuster) alongside scan tools.
- Gate Go- and Node-based installs with clearer prerequisites.
- Document prerequisites in `docs/security_scan.md`.

## Issues Closed
- Closes #1504

## Testing
- `.venv/bin/pre-commit run --files scripts/linux/security_setup.sh scripts/macos/security_setup.zsh scripts/windows/security_setup.ps1 docs/security_scan.md`
