### PR TITLE
Parameterize Kubernetes deploy scripts

### DIFF
--- a/scripts/linux/deploy.sh
+++ b/scripts/linux/deploy.sh
@@ -17,7 +17,7 @@ if [ "$(uname -s)" != "Linux" ]; then
 fi
 
 # Define the namespace for easy reference
-NAMESPACE="ai-defense"
+NAMESPACE="${KUBE_NAMESPACE:-ai-defense}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 K8S_DIR="$ROOT_DIR/kubernetes"

--- a/scripts/linux/gke_deploy.sh
+++ b/scripts/linux/gke_deploy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Deploy the AI Scraping Defense stack to Google Kubernetes Engine
+# Optional env overrides:
+#   KUBE_CONTEXT   - kubectl context to use instead of gcloud credentials
+#   KUBE_NAMESPACE - namespace to deploy into (default: ai-defense)
 set -euo pipefail
 
 # OS guard: Linux only
@@ -12,6 +15,8 @@ fi
 PROJECT_ID="${PROJECT_ID:-${GOOGLE_PROJECT_ID:-your-gcp-project}}"
 CLUSTER_NAME="${CLUSTER_NAME:-ai-defense-cluster}"
 GKE_ZONE="${GKE_ZONE:-us-central1-a}"
+KUBE_CONTEXT="${KUBE_CONTEXT:-}"
+KUBE_NAMESPACE="${KUBE_NAMESPACE:-ai-defense}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 IMAGE="gcr.io/$PROJECT_ID/ai-scraping-defense:$IMAGE_TAG"
 
@@ -34,10 +39,20 @@ if ! gcloud container clusters describe "$CLUSTER_NAME" --zone "$GKE_ZONE" >/dev
 fi
 
 # Configure kubectl
- gcloud container clusters get-credentials "$CLUSTER_NAME" --zone "$GKE_ZONE"
+if [[ -n "$KUBE_CONTEXT" ]]; then
+  echo "Using KUBE_CONTEXT=$KUBE_CONTEXT for kubectl context override."
+  kubectl config use-context "$KUBE_CONTEXT"
+else
+  gcloud container clusters get-credentials "$CLUSTER_NAME" --zone "$GKE_ZONE"
+fi
 
 # Update image references in manifests
 find kubernetes -name '*.yaml' -print0 | xargs -0 sed -i "s|your-registry/ai-scraping-defense:latest|$IMAGE|g"
+if [[ "$KUBE_NAMESPACE" != "ai-defense" ]]; then
+  echo "Updating namespace references to $KUBE_NAMESPACE"
+  find kubernetes -name '*.yaml' -print0 | xargs -0 \
+    sed -i "s/namespace: ai-defense/namespace: $KUBE_NAMESPACE/g"
+fi
 
 # Generate secrets if missing
 if [ ! -f kubernetes/secrets.yaml ]; then
@@ -46,6 +61,6 @@ if [ ! -f kubernetes/secrets.yaml ]; then
 fi
 
 # Deploy the manifests
-bash "$SCRIPT_DIR/deploy.sh"
+KUBE_NAMESPACE="$KUBE_NAMESPACE" bash "$SCRIPT_DIR/deploy.sh"
 
-echo "Deployment complete. View pods with: kubectl get pods -n ai-defense"
+echo "Deployment complete. View pods with: kubectl get pods -n $KUBE_NAMESPACE"

--- a/scripts/windows/deploy.ps1
+++ b/scripts/windows/deploy.ps1
@@ -13,7 +13,8 @@ if (-not $adminCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administr
 
 # --- Script Configuration ---
 $ErrorActionPreference = "Stop"
-$Namespace = "ai-defense"
+$Namespace = $env:KUBE_NAMESPACE
+if (-not $Namespace) { $Namespace = "ai-defense" }
 $RootDir = Split-Path -Parent $PSScriptRoot
 Set-Location -Path $RootDir
 $K8sDir = Join-Path $RootDir "kubernetes"

--- a/scripts/windows/gke_deploy.ps1
+++ b/scripts/windows/gke_deploy.ps1
@@ -1,13 +1,19 @@
+# Optional env overrides:
+# - KUBE_CONTEXT: kubectl context to use instead of gcloud credentials
+# - KUBE_NAMESPACE: namespace to deploy into (default: ai-defense)
 param(
     [string]$ProjectId = $env:GOOGLE_PROJECT_ID,
     [string]$ClusterName = $env:CLUSTER_NAME,
     [string]$Zone = $env:GKE_ZONE,
-    [string]$ImageTag = 'latest'
+    [string]$ImageTag = 'latest',
+    [string]$KubeContext = $env:KUBE_CONTEXT,
+    [string]$KubeNamespace = $env:KUBE_NAMESPACE
 )
 
 if (-not $ProjectId) { $ProjectId = Read-Host 'GCP Project ID' }
 if (-not $ClusterName) { $ClusterName = 'ai-defense-cluster' }
 if (-not $Zone) { $Zone = 'us-central1-a' }
+if (-not $KubeNamespace) { $KubeNamespace = 'ai-defense' }
 
 $Image = "gcr.io/$ProjectId/ai-scraping-defense:$ImageTag"
 
@@ -25,11 +31,22 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Configure kubectl
- gcloud container clusters get-credentials $ClusterName --zone $Zone
+if ($KubeContext) {
+    Write-Host "Using KUBE_CONTEXT=$KubeContext for kubectl context override."
+    kubectl config use-context $KubeContext
+} else {
+    gcloud container clusters get-credentials $ClusterName --zone $Zone
+}
 
 # Update image references in manifests
 Get-ChildItem -Path kubernetes -Filter '*.yaml' -Recurse | ForEach-Object {
     (Get-Content $_.FullName) -replace 'your-registry/ai-scraping-defense:latest', $Image | Set-Content $_.FullName
+}
+if ($KubeNamespace -ne 'ai-defense') {
+    Write-Host "Updating namespace references to $KubeNamespace"
+    Get-ChildItem -Path kubernetes -Filter '*.yaml' -Recurse | ForEach-Object {
+        (Get-Content $_.FullName) -replace 'namespace: ai-defense', \"namespace: $KubeNamespace\" | Set-Content $_.FullName
+    }
 }
 
 # Generate secrets if needed
@@ -39,6 +56,7 @@ if (-not (Test-Path 'kubernetes/secrets.yaml')) {
 }
 
 # Deploy manifests
+$env:KUBE_NAMESPACE = $KubeNamespace
 ./deploy.ps1
 
-Write-Host 'Deployment complete. View pods with: kubectl get pods -n ai-defense'
+Write-Host \"Deployment complete. View pods with: kubectl get pods -n $KubeNamespace\"


### PR DESCRIPTION
## Summary
- Allow KUBE_CONTEXT and KUBE_NAMESPACE overrides in GKE deploy scripts.
- Propagate namespace into deploy scripts for consistent output.
- Update manifests in-place when a custom namespace is used.

## Issues Closed
- Closes #1500

## Testing
- `.venv/bin/pre-commit run --files scripts/linux/gke_deploy.sh scripts/windows/gke_deploy.ps1 scripts/linux/deploy.sh scripts/windows/deploy.ps1`
