### PR TITLE
Add security KPI summary

### DIFF
--- a/src/admin_ui/admin_ui.py
+++ b/src/admin_ui/admin_ui.py
@@ -251,6 +251,12 @@ async def settings_page(
     except Exception as e:
         logger.warning(f"Failed to generate GDPR report: {e}")
 
+    security_kpis = {}
+    try:
+        security_kpis = metrics.get_security_kpis()
+    except Exception as e:
+        logger.warning("Failed to load security KPIs: %s", e)
+
     current_settings = {
         "Model URI": os.getenv("MODEL_URI", "Not Set"),
         "LOG_LEVEL": _get_runtime_setting("LOG_LEVEL"),
@@ -269,6 +275,7 @@ async def settings_page(
             "settings": current_settings,
             "csrf_token": csrf_token,
             "gdpr_report": gdpr_report,
+            "security_kpis": security_kpis,
         },
     )
     response.set_cookie(

--- a/src/admin_ui/metrics.py
+++ b/src/admin_ui/metrics.py
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 
 METRICS_TRULY_AVAILABLE = True
 WEBSOCKET_METRICS_INTERVAL = 5
+SECURITY_KPI_PREFIXES = {
+    "security_events_total": "security_events_total",
+    "errors_total": "errors_total",
+    "login_attempts_total": "login_attempts_total",
+    "community_reports_attempted_total": "community_reports_attempted_total",
+}
 
 router = APIRouter()
 
@@ -51,6 +57,19 @@ def _get_metrics_dict() -> dict:
 
 # Exposed for tests so they can patch the behaviour
 _get_metrics_dict_func = _get_metrics_dict
+
+
+def _sum_metrics(metrics_dict: dict, prefix: str) -> float:
+    return sum(value for key, value in metrics_dict.items() if key.startswith(prefix))
+
+
+def get_security_kpis() -> dict[str, float]:
+    """Return a summary of security KPI counters derived from metrics."""
+    metrics_dict = _get_metrics_dict_func()
+    return {
+        label: _sum_metrics(metrics_dict, prefix)
+        for label, prefix in SECURITY_KPI_PREFIXES.items()
+    }
 
 
 @router.get("/metrics")

--- a/src/admin_ui/templates/settings.html
+++ b/src/admin_ui/templates/settings.html
@@ -83,6 +83,33 @@
                 </div>
             </div>
 
+            {% if security_kpis %}
+            <div class="bg-white p-6 rounded-lg shadow-md mt-8">
+                <h2 class="text-2xl font-semibold mb-4">Security KPIs</h2>
+                <p class="text-gray-600 mb-6">
+                    Summary counters derived from the security metrics pipeline.
+                </p>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full bg-white border">
+                        <thead class="bg-gray-200">
+                            <tr>
+                                <th class="py-2 px-4 border-b text-left">Metric</th>
+                                <th class="py-2 px-4 border-b text-left">Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for key, value in security_kpis.items() %}
+                            <tr class="hover:bg-gray-50">
+                                <td class="py-2 px-4 border-b font-mono text-sm text-gray-700">{{ key }}</td>
+                                <td class="py-2 px-4 border-b font-mono text-sm text-blue-800">{{ value }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            {% endif %}
+
             <!-- GDPR Compliance Section -->
             <div class="bg-white p-6 rounded-lg shadow-md mt-8">
                 <h2 class="text-2xl font-semibold mb-4">GDPR Compliance</h2>

--- a/test/admin_ui/test_admin_ui.py
+++ b/test/admin_ui/test_admin_ui.py
@@ -117,6 +117,23 @@ class TestAdminUIComprehensive(unittest.TestCase):
                 os.environ.get("WEBAUTHN_AUTHENTICATOR_ATTACHMENT"), "platform"
             )
 
+    def test_settings_page_shows_security_kpis(self):
+        """Settings page should render security KPI summaries."""
+        fake_redis = self._FakeRedis()
+        with patch(
+            "src.admin_ui.admin_ui.get_redis_connection", return_value=fake_redis
+        ):
+            with patch(
+                "src.admin_ui.admin_ui.metrics.get_security_kpis",
+                return_value={"security_events_total": 5.0},
+            ):
+                response = self.client.get(
+                    "/settings", auth=self.auth, headers=self._totp_headers()
+                )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Security KPIs", response.content)
+        self.assertIn(b"security_events_total", response.content)
+
     def test_index_route_success(self):
         """Test the main dashboard page serves HTML correctly and contains key elements."""
         response = self.client.get("/", auth=self.auth, headers=self._totp_headers())


### PR DESCRIPTION
## Summary
- Add security KPI aggregation to the Admin UI settings page.
- Expose KPI derivation helper in admin UI metrics module.
- Add tests to validate KPI rendering.

## Issues Closed
- Closes #1199

## Testing
- `.venv/bin/pre-commit run --files src/admin_ui/metrics.py src/admin_ui/admin_ui.py src/admin_ui/templates/settings.html test/admin_ui/test_admin_ui.py`
- `.venv/bin/python -m pytest test/admin_ui/test_admin_ui.py`
