### PR TITLE
Enforce HTTPS and validate security headers

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 user  nginx;
-# env ENABLE_HTTPS;
+env ENABLE_HTTPS;
 worker_processes  auto;
 
 error_log  /var/log/nginx/error.log warn;
@@ -41,10 +41,13 @@ http {
         listen 80 default_server;
         server_name _; # Underscore is a catch-all server name
 
-        # HTTPS enforcement when enabled
-        if ($https_redirect) {
-            return 301 https://$host$request_uri;
-        }
+    # HTTPS enforcement when enabled
+    if ($https_redirect) {
+        return 301 https://$host$request_uri;
+    }
+    if ($https_env) {
+        return 301 https://$host$request_uri;
+    }
 
         # The root is set to the directory where our UI pages are mounted.
         root /usr/share/nginx/html/docs_ui;
@@ -59,8 +62,12 @@ http {
     }
 
     # Optional HTTPS server; assumes certs provided via TLS_CERT_PATH/TLS_KEY_PATH
-    # Redirect map based on optional X-Enable-Https header
+    # Redirect map based on optional X-Enable-Https header or ENABLE_HTTPS env
     map $http_x_enable_https $https_redirect {
+        default 0;
+        ~*^(true|1)$ 1;
+    }
+    map $ENABLE_HTTPS $https_env {
         default 0;
         ~*^(true|1)$ 1;
     }

--- a/scripts/security/run_static_security_checks.py
+++ b/scripts/security/run_static_security_checks.py
@@ -71,6 +71,8 @@ def ensure_nginx_headers_and_limits() -> None:
         "limit_req_zone",
         "limit_req zone=global_limit",
         "add_header X-Frame-Options",
+        "add_header X-Content-Type-Options",
+        "add_header Content-Security-Policy",
     ]
     for token in required_tokens:
         if token not in config:


### PR DESCRIPTION
## Summary
- Add ENABLE_HTTPS-based redirect enforcement in nginx.
- Extend static security checks to validate key security headers.

## Issues Closed
- Closes #1111
- Closes #1114
- Closes #1163
- Closes #1173
- Closes #1165

## Testing
- `.venv/bin/pre-commit run --files scripts/security/run_static_security_checks.py nginx/nginx.conf`
- `.venv/bin/python -m pytest test/test_security_scan_coverage.py`
