### PR TITLE
Make auth token TTL configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,19 @@ See `src/security/secret_rotation.py` for rotation service implementation.
 | `CONFIG_RECOMMENDER_PORT` | `8010` | Config Recommender |
 | `PROMPT_ROUTER_PORT` | `8009` | Prompt Router |
 
+## Admin UI Authentication
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ADMIN_UI_USERNAME` | `admin` | Basic auth username |
+| `ADMIN_UI_PASSWORD_HASH` | *(none)* | bcrypt hash for admin password |
+| `ADMIN_UI_2FA_SECRET` | *(none)* | TOTP secret for MFA |
+| `WEBAUTHN_RP_ID` | `localhost` | WebAuthn relying party ID |
+| `WEBAUTHN_ORIGIN` | `http://localhost` | WebAuthn origin |
+| `WEBAUTHN_TOKEN_TTL` | `300` | WebAuthn token TTL in seconds |
+| `PASSKEY_TOKEN_TTL` | `300` | Passkey token TTL in seconds |
+| `WEBAUTHN_AUTHENTICATOR_ATTACHMENT` | `none` | `none`, `platform`, or `cross-platform` |
+
 ## Redis Configuration
 
 | Variable | Default | Description |

--- a/src/admin_ui/passkeys.py
+++ b/src/admin_ui/passkeys.py
@@ -26,7 +26,7 @@ from webauthn.helpers.structs import (
 from src.shared.config import tenant_key
 from src.shared.redis_client import get_redis_connection
 
-PASSKEY_TOKEN_TTL = 300
+PASSKEY_TOKEN_TTL = int(os.getenv("PASSKEY_TOKEN_TTL", "300"))
 
 RP_ID = os.getenv("WEBAUTHN_RP_ID", "localhost")
 ORIGIN = os.getenv("WEBAUTHN_ORIGIN", "http://localhost")

--- a/src/admin_ui/webauthn.py
+++ b/src/admin_ui/webauthn.py
@@ -29,7 +29,7 @@ from .auth import require_auth
 
 router = APIRouter()
 
-WEBAUTHN_TOKEN_TTL = 300
+WEBAUTHN_TOKEN_TTL = int(os.getenv("WEBAUTHN_TOKEN_TTL", "300"))
 
 RP_ID = os.getenv("WEBAUTHN_RP_ID", "localhost")
 ORIGIN = os.getenv("WEBAUTHN_ORIGIN", "http://localhost")


### PR DESCRIPTION
## Summary
- Make WebAuthn/passkey token TTLs configurable via env vars.
- Document the new settings in `docs/configuration.md`.

## Issues Closed
- Closes #1164

## Testing
- `.venv/bin/pre-commit run --files src/admin_ui/webauthn.py src/admin_ui/passkeys.py docs/configuration.md`
- `.venv/bin/python -m pytest test/admin_ui/test_webauthn.py test/admin_ui/test_passkeys.py`
