### PR TITLE
Harden security baselines and Kubernetes workloads

### DIFF
--- a/kubernetes/tarpit-api-deployment.yaml
+++ b/kubernetes/tarpit-api-deployment.yaml
@@ -27,6 +27,13 @@ spec:
       labels:
         app: tarpit-api
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: tarpit-api
         image: your-registry/ai-scraping-defense:latest
@@ -53,6 +60,11 @@ spec:
             port: 8001
           initialDelaySeconds: 10
           periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
         envFrom:
         - configMapRef:
             name: app-config
@@ -91,7 +103,11 @@ spec:
         - name: archives-storage
           mountPath: /app/archives
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
       volumes:
       - name: archives-storage
         persistentVolumeClaim:
           claimName: archives-pvc
+      - name: tmp
+        emptyDir: {}

--- a/kubernetes/waf-rules-fetcher-cronjob.yaml
+++ b/kubernetes/waf-rules-fetcher-cronjob.yaml
@@ -12,6 +12,13 @@ spec:
       template:
         spec:
           serviceAccountName: waf-rules-updater-sa
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: owasp-crs-fetcher
             image: your-registry/ai-scraping-defense:latest
@@ -24,7 +31,18 @@ spec:
               limits:
                 cpu: "500m"
                 memory: "512Mi"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
             env:
             - name: CRS_DOWNLOAD_URL
               value: "https://github.com/coreruleset/coreruleset/archive/refs/heads/v3.3/main.tar.gz"
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          - name: tmp
+            emptyDir: {}
           restartPolicy: OnFailure

--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -38,9 +38,6 @@ TRUST_PROXY_HEADERS = os.getenv("TRUST_PROXY_HEADERS", "false").lower() in (
     "yes",
 )
 
-_request_counts: dict[str, tuple[int, float]] = {}
-_rate_lock = asyncio.Lock()
-
 
 def count_tokens(text: str) -> int:
     """Approximate the number of tokens in ``text`` using a simple heuristic."""
@@ -59,6 +56,10 @@ app = create_app(
         health_path="/observability/health",
     ),
 )
+app.state.request_counts = {}
+app.state.rate_lock = asyncio.Lock()
+_request_counts: dict[str, tuple[int, float]] = app.state.request_counts
+_rate_lock = app.state.rate_lock
 
 
 @app.get("/health")
@@ -94,14 +95,16 @@ def calculate_window_reset(now: float, window: int = RATE_LIMIT_WINDOW) -> int:
     return int(now // window * window + window)
 
 
-def _cleanup_expired_requests(now: float) -> None:
+def _cleanup_expired_requests(
+    request_counts: dict[str, tuple[int, float]], now: float
+) -> None:
     """Remove expired rate-limit entries.
 
     Caller must hold ``_rate_lock``.
     """
-    expired = [ip for ip, (_, reset) in _request_counts.items() if now > reset]
+    expired = [ip for ip, (_, reset) in request_counts.items() if now > reset]
     for ip in expired:
-        del _request_counts[ip]
+        del request_counts[ip]
 
 
 @app.post("/route")
@@ -120,9 +123,11 @@ async def route_prompt(request: Request, response: Response) -> dict:
     client_ip = get_client_ip(request)
     now = time.time()
     window_reset = calculate_window_reset(now)
-    async with _rate_lock:
-        _cleanup_expired_requests(now)
-        count, reset = _request_counts.get(client_ip, (0, window_reset))
+    request_counts = request.app.state.request_counts
+    rate_lock = request.app.state.rate_lock
+    async with rate_lock:
+        _cleanup_expired_requests(request_counts, now)
+        count, reset = request_counts.get(client_ip, (0, window_reset))
         if now > reset:
             count, reset = 0, window_reset
         if count + 1 > RATE_LIMIT_REQUESTS:
@@ -136,7 +141,7 @@ async def route_prompt(request: Request, response: Response) -> dict:
             raise HTTPException(
                 status_code=429, detail="Too Many Requests", headers=headers
             )
-        _request_counts[client_ip] = (count + 1, reset)
+        request_counts[client_ip] = (count + 1, reset)
         remaining = RATE_LIMIT_REQUESTS - (count + 1)
 
     response.headers["X-RateLimit-Limit"] = str(RATE_LIMIT_REQUESTS)

--- a/scripts/security/run_static_security_checks.py
+++ b/scripts/security/run_static_security_checks.py
@@ -55,6 +55,21 @@ def _load_hardening_baseline() -> Dict[str, Any]:
     return merged
 
 
+def _matches_required_value(actual: Any, expected: str) -> bool:
+    """Allow compose hardening tokens to use env expansion with safe defaults."""
+    actual_value = str(actual)
+    if actual_value == expected:
+        return True
+    if expected == "no-new-privileges:true":
+        return bool(
+            re.fullmatch(
+                r"no-new-privileges:\$\{[A-Z0-9_]+(?::-[Tt][Rr][Uu][Ee])?\}",
+                actual_value,
+            )
+        )
+    return False
+
+
 def ensure_inventory_is_current() -> None:
     json_path = PROJECT_ROOT / "security_problems_batch1.json"
     markdown_path = PROJECT_ROOT / "docs/security/security_inventory_batch1.md"
@@ -111,7 +126,7 @@ def ensure_compose_security() -> None:
             _fail(f"docker-compose missing service definition for {service_name}")
         security_opt = service.get("security_opt", [])
         for token in required_security_opt:
-            if token not in security_opt:
+            if not any(_matches_required_value(opt, token) for opt in security_opt):
                 _fail(f"{service_name} missing security_opt entry: {token}")
         cap_drop = service.get("cap_drop", [])
         for cap in required_cap_drop:

--- a/test/scripts/test_run_static_security_checks.py
+++ b/test/scripts/test_run_static_security_checks.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.security.run_static_security_checks import _matches_required_value
+
+
+@pytest.mark.parametrize(
+    ("actual", "expected"),
+    [
+        ("no-new-privileges:true", "no-new-privileges:true"),
+        (
+            "no-new-privileges:${NO_NEW_PRIVILEGES:-true}",
+            "no-new-privileges:true",
+        ),
+        ("ALL", "ALL"),
+    ],
+)
+def test_matches_required_value_accepts_expected_hardening_tokens(
+    actual: str, expected: str
+) -> None:
+    assert _matches_required_value(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("actual", "expected"),
+    [
+        ("no-new-privileges:false", "no-new-privileges:true"),
+        (
+            "no-new-privileges:${NO_NEW_PRIVILEGES:-false}",
+            "no-new-privileges:true",
+        ),
+        ("cap-drop:ALL", "ALL"),
+    ],
+)
+def test_matches_required_value_rejects_weakened_or_mismatched_tokens(
+    actual: str, expected: str
+) -> None:
+    assert not _matches_required_value(actual, expected)

--- a/test/test_security_baselines.py
+++ b/test/test_security_baselines.py
@@ -48,6 +48,30 @@ def _iter_kubernetes_workload_containers():
                 yield manifest_path, kind, container
 
 
+def _iter_kubernetes_workload_specs():
+    for manifest_path in Path("kubernetes").glob("*.y*ml"):
+        for document in yaml.safe_load_all(manifest_path.read_text()):
+            if not isinstance(document, dict):
+                continue
+            kind = document.get("kind")
+            if kind not in WORKLOAD_KINDS:
+                continue
+
+            spec = document.get("spec") or {}
+            if kind in {"Deployment", "StatefulSet", "DaemonSet", "Job"}:
+                pod_spec = ((spec.get("template") or {}).get("spec")) or {}
+            else:
+                pod_spec = (
+                    (
+                        ((spec.get("jobTemplate") or {}).get("spec") or {}).get(
+                            "template"
+                        )
+                    )
+                    or {}
+                ).get("spec", {})
+            yield manifest_path, kind, pod_spec
+
+
 def test_nginx_enforces_https_and_headers():
     config = Path("nginx/nginx.conf").read_text()
     assert "Strict-Transport-Security" in config
@@ -98,3 +122,45 @@ def test_kubernetes_workloads_define_resource_limits():
         "All Kubernetes workload containers must define resources.requests and "
         "resources.limits: " + ", ".join(sorted(missing))
     )
+
+
+def test_selected_kubernetes_workloads_define_restricted_security_contexts():
+    required_workloads = {
+        "tarpit-api-deployment.yaml": {"tarpit-api"},
+        "waf-rules-fetcher-cronjob.yaml": {"owasp-crs-fetcher"},
+    }
+    seen = {name: set() for name in required_workloads}
+
+    for manifest_path, _, pod_spec in _iter_kubernetes_workload_specs():
+        required_containers = required_workloads.get(manifest_path.name)
+        if not required_containers:
+            continue
+
+        pod_security_context = pod_spec.get("securityContext") or {}
+        assert pod_security_context.get("runAsNonRoot") is True
+        assert pod_security_context.get("runAsUser") == 1000
+        assert pod_security_context.get("runAsGroup") == 1000
+        assert pod_security_context.get("seccompProfile", {}).get("type") == (
+            "RuntimeDefault"
+        )
+
+        containers = pod_spec.get("containers") or []
+        volumes = {volume.get("name"): volume for volume in pod_spec.get("volumes", [])}
+        assert "tmp" in volumes and "emptyDir" in volumes["tmp"]
+
+        for container in containers:
+            name = container.get("name")
+            if name not in required_containers:
+                continue
+            seen[manifest_path.name].add(name)
+            security_context = container.get("securityContext") or {}
+            assert security_context.get("allowPrivilegeEscalation") is False
+            assert security_context.get("readOnlyRootFilesystem") is True
+            assert security_context.get("capabilities", {}).get("drop") == ["ALL"]
+            volume_mounts = {
+                mount.get("name"): mount for mount in container.get("volumeMounts", [])
+            }
+            assert volume_mounts.get("tmp", {}).get("mountPath") == "/tmp"
+
+    for manifest_name, container_names in required_workloads.items():
+        assert seen[manifest_name] == container_names


### PR DESCRIPTION
## Summary
- accept hardened compose `security_opt` entries that use environment expansion with a safe default
- move prompt-router rate-limit state onto `app.state` so reloads do not leak counters across runs
- harden the `tarpit-api` and `owasp-crs-fetcher` Kubernetes workloads with restricted security contexts and writable `/tmp` mounts
- add regression coverage for the static security check and the hardened manifests

## Validation
- `./.venv/bin/python scripts/security/run_static_security_checks.py`
- `./.venv/bin/python -m pytest -q test/test_security_baselines.py test/scripts/test_run_static_security_checks.py test/test_security_scan_coverage.py`
- `./.venv/bin/python -m pytest -q test/prompt_router/test_prompt_router.py`
- `./.venv/bin/python -m pytest -q test`
- `./.venv/bin/pre-commit run --files prompt-router/main.py test/test_security_baselines.py scripts/security/run_static_security_checks.py test/scripts/test_run_static_security_checks.py kubernetes/tarpit-api-deployment.yaml kubernetes/waf-rules-fetcher-cronjob.yaml`

Closes #1610
Closes #1611