### PR TITLE
Document operations toolkit subprocess guardrails

### DIFF
--- a/scripts/operations_toolkit.py
+++ b/scripts/operations_toolkit.py
@@ -14,7 +14,10 @@ import json
 import logging
 import os
 import shlex
-import subprocess
+
+# Bandit B404 is acceptable here because this module wraps fixed operator CLIs
+# and passes argv lists directly to subprocess.run without shell=True.
+import subprocess  # nosec B404
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -43,7 +46,7 @@ def run_command(
         LOG.info("[dry-run] %s", shlex.join(args))
         return CommandResult(command=args, returncode=0, stdout="", stderr="")
 
-    proc = subprocess.run(  # nosec B603 - controlled CLI wrapper
+    proc = subprocess.run(  # nosec B603
         args,
         cwd=str(cwd) if cwd else None,
         check=False,

--- a/test/scripts/test_operations_toolkit.py
+++ b/test/scripts/test_operations_toolkit.py
@@ -8,6 +8,40 @@ from scripts import operations_toolkit
 
 
 class TestOperationsToolkit(unittest.TestCase):
+    def test_run_command_dry_run_skips_subprocess(self):
+        with patch("scripts.operations_toolkit.subprocess.run") as mock_run:
+            result = operations_toolkit.run_command(
+                ["kubectl", "get", "pods"], execute=False
+            )
+
+        mock_run.assert_not_called()
+        self.assertEqual(result.command, ["kubectl", "get", "pods"])
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+
+    def test_run_command_executes_without_shell(self):
+        completed = MagicMock(returncode=0, stdout="ok", stderr="")
+
+        with patch(
+            "scripts.operations_toolkit.subprocess.run", return_value=completed
+        ) as mock_run:
+            result = operations_toolkit.run_command(
+                ["kubectl", "get", "pods"], execute=True
+            )
+
+        mock_run.assert_called_once_with(
+            ["kubectl", "get", "pods"],
+            cwd=None,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.command, ["kubectl", "get", "pods"])
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "ok")
+        self.assertEqual(result.stderr, "")
+
     def test_backup_returns_timestamped_path(self):
         """Test that backup() returns the timestamped directory path."""
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- document the accepted Bandit `B404` and `B603` suppressions in `scripts/operations_toolkit.py`
- keep subprocess execution behavior unchanged while making the security boundary explicit
- add direct tests for `run_command()` dry-run and execution behavior

## Validation
- `./.venv/bin/bandit -q scripts/operations_toolkit.py`
- `./.venv/bin/python -m pytest -q test/scripts/test_operations_toolkit.py`
- `./.venv/bin/pre-commit run --files scripts/operations_toolkit.py test/scripts/test_operations_toolkit.py`

Closes #1608