### PR TITLE
Document Ubuntu reverse proxy deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Follow these steps if you prefer to configure everything yourself.
     database at `secrets/local_secrets.db`. Delete this file or answer **n**
     during the prompt to disable the database and clear stored values.
 
-    Open `.env` and review the defaults. Set `TENANT_ID` for isolated deployments and add any API keys you plan to use. For **production** deployments update `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443`. Use `REAL_BACKEND_HOSTS` to supply a comma-separated list of backend servers for load balancing or `REAL_BACKEND_HOST` for a single destination.
+    Open `.env` and review the defaults. Set `TENANT_ID` for isolated deployments and add any API keys you plan to use. The sample file now defaults the containerized Nginx proxy to `8088`/`8443` so it can coexist with host Apache or nginx on Ubuntu. For **production** or takeover deployments, update `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443` once the stack is the only web listener on the host. Use `REAL_BACKEND_HOSTS` to supply a comma-separated list of backend servers for load balancing or `REAL_BACKEND_HOST` for a single destination. See [docs/ubuntu_reverse_proxy.md](docs/ubuntu_reverse_proxy.md) for the recommended host reverse-proxy topology.
 For a full walkthrough of bringing the stack live, review [docs/test_to_production.md](docs/test_to_production.md).
 
 3. **Set Up Python Virtual Environment:**
@@ -375,8 +375,9 @@ For a full walkthrough of bringing the stack live, review [docs/test_to_producti
     - **Cloud Dashboard:** `http://localhost:5006`
     - **Cloud Proxy:** `http://localhost:8008`
     - **Prompt Router:** `http://localhost:8009`
-    - **Your Application:** `http://localhost:8080`
-    - **HTTPS (if enabled):** `https://localhost:8443`
+    - **Nginx Proxy (recommended):** `http://localhost:8088`
+    - **Nginx Proxy HTTPS (if enabled):** `https://localhost:8443`
+    - **Apache Proxy (optional alternative):** `http://localhost:8080`
 
 ## Optional Features
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,7 +64,7 @@ python [scripts/interactive_setup.py](../scripts/interactive_setup.py)
 When run, the helper can store your secrets in a SQLite database at `secrets/local_secrets.db`. Delete this file or answer **n** to disable or clear the stored values.
 
 
-Now, open the .env file in your code editor. For now, you can leave the default values as they are. This is where you would add your real API keys for services like OpenAI or Mistral when you're ready to use them. For **production** deployments, update `NGINX_HTTP_PORT` to `80` and `NGINX_HTTPS_PORT` to `443` so the proxy listens on the standard web ports.
+Now, open the .env file in your code editor. For now, you can leave the default values as they are. This is where you would add your real API keys for services like OpenAI or Mistral when you're ready to use them. The sample file defaults `NGINX_HTTP_PORT` and `NGINX_HTTPS_PORT` to `8088` and `8443` so the stack can coexist with a host Apache or nginx service during Ubuntu testing. For **production** or takeover deployments, update those values to `80` and `443` so the proxy listens on the standard web ports.
 
 For a step-by-step path from local testing to a hardened production environment, see [test_to_production.md](test_to_production.md).
 #### **Minimal Required Variables**
@@ -77,7 +77,7 @@ To bring the stack up, only a handful of settings must be reviewed in `.env`:
   - `mistral://mistral-large-latest`
 - The API key matching your chosen provider: `OPENAI_API_KEY`, `MISTRAL_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, or `COHERE_API_KEY`.
 - `EXTERNAL_API_KEY` for optional integrations.
-- Port values such as `NGINX_HTTP_PORT`, `NGINX_HTTPS_PORT`, and `ADMIN_UI_PORT` typically work as-is.
+- Port values such as `NGINX_HTTP_PORT`, `NGINX_HTTPS_PORT`, and `ADMIN_UI_PORT` typically work as-is for local testing. On Ubuntu hosts that already run Apache or nginx, keep the default `8088`/`8443` mapping or choose another unused pair.
 - `PROMPT_ROUTER_HOST` and `PROMPT_ROUTER_PORT` define where the Escalation Engine sends its LLM requests.
 - `PROMETHEUS_PORT` and `GRAFANA_PORT` control the monitoring dashboard ports.
 - `REAL_BACKEND_HOSTS` can supply a comma-separated list of backend servers for load balancing. Use `REAL_BACKEND_HOST` for a single destination.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ graph TD
 To get a full understanding of the project, please review the following documents:
 
 - [**Getting Started**](getting_started.md)**:** The essential first step. This guide provides detailed instructions for setting up the complete development environment on your local machine using Docker Compose.
+- [**Ubuntu Reverse Proxy Deployment**](ubuntu_reverse_proxy.md)**:** Recommended Ubuntu Server topology when host Apache or nginx already owns ports 80/443.
 - [**Test to Production Guide**](test_to_production.md)**:** How to graduate from local testing to a secure production deployment.
 - [**System Architecture**](architecture.md)**:** A high-level overview of the different components of the system and how they fit together. This is the best place to start to understand the overall design.
 - [**Key Data Flows**](key_data_flows.md)**:** This document explains the lifecycle of a request as it moves through our defense layers, from initial filtering to deep analysis.

--- a/docs/ubuntu_reverse_proxy.md
+++ b/docs/ubuntu_reverse_proxy.md
@@ -1,0 +1,97 @@
+# Ubuntu Reverse Proxy Deployment
+
+This guide covers the recommended Ubuntu Server topology when Apache or nginx
+is already installed on the host and you want to run the defense stack without
+stealing ports `80` and `443`.
+
+## Recommended Topology
+
+Use the repository's containerized `nginx_proxy` as the primary application
+edge and keep the host web server as a thin front door:
+
+1. Host nginx or Apache listens on `80` and `443`.
+2. Host reverse proxy forwards traffic to the stack's `nginx_proxy` on
+   `127.0.0.1:8088` and `127.0.0.1:8443`.
+3. The stack's `nginx_proxy` applies the Lua/WAF/blocklist logic and forwards
+   allowed traffic to `REAL_BACKEND_HOST` or `REAL_BACKEND_HOSTS`.
+
+This keeps the defense logic in one place while avoiding collisions with
+existing Ubuntu web services.
+
+## Port Plan
+
+- Host web server: `80` / `443`
+- Stack `nginx_proxy`: `8088` / `8443`
+- Optional stack `apache_proxy`: `8080`
+
+If `8088`, `8443`, or `8080` are already in use, override them in `.env`.
+
+## Minimal `.env` Checklist
+
+```dotenv
+NGINX_HTTP_PORT=8088
+NGINX_HTTPS_PORT=8443
+APACHE_HTTP_PORT=8080
+REAL_BACKEND_HOST=http://127.0.0.1:8082
+ENABLE_HTTPS=true
+TLS_CERT_PATH=./nginx/certs/tls.crt
+TLS_KEY_PATH=./nginx/certs/tls.key
+```
+
+For takeover or production mode, switch `NGINX_HTTP_PORT` / `NGINX_HTTPS_PORT`
+to `80` / `443` only after disabling the host listener or putting the host
+proxy in front of another address.
+
+## Host Nginx Example
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8088;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+    }
+}
+```
+
+## Host Apache Example
+
+```apache
+ProxyPreserveHost On
+ProxyPass / http://127.0.0.1:8088/
+ProxyPassReverse / http://127.0.0.1:8088/
+RequestHeader set X-Forwarded-Proto "http"
+```
+
+## Launch Sequence
+
+1. Copy `sample.env` to `.env`.
+2. Set `REAL_BACKEND_HOST` or `REAL_BACKEND_HOSTS`.
+3. Generate secrets with `bash ./scripts/linux/generate_secrets.sh --update-env`.
+4. Start the stack with `docker compose up --build -d`.
+5. Run `bash ./scripts/linux/stack_smoke_test.sh`.
+
+## Validation Checklist
+
+- `docker compose ps` shows `nginx_proxy`, `admin_ui`, `tarpit_api`,
+  `escalation_engine`, `postgres_markov_db`, and `redis_store` healthy.
+- `curl -fsS http://127.0.0.1:8088/` returns a response.
+- `curl -kfsS https://127.0.0.1:8443/` returns a response when HTTPS is enabled.
+- The host reverse proxy forwards `Host`, `X-Forwarded-For`, and
+  `X-Forwarded-Proto`.
+- TLS is terminated either on the host proxy or inside the stack, but the
+  choice is explicit and documented for the deployment.
+- Any port collisions are resolved by changing `.env`, not by editing compose
+  manifests directly.
+
+## Apache Alternative
+
+The repository still ships `apache_proxy`, and `scripts/linux/quick_proxy.sh`
+supports `apache` for quick local tests. For Ubuntu production deployments,
+prefer the Nginx-based stack path unless you specifically need Apache modules or
+want Apache as the thin host-side reverse proxy example shown above.

--- a/sample.env
+++ b/sample.env
@@ -28,13 +28,11 @@ MODEL_URI=sklearn:///app/models/bot_detection_rf_model.joblib
 # Optional explicit model type override
 MODEL_TYPE=
 
-# --- Service Ports (Defaults are usually fine for local testing) ---
-# For production deployments you will typically expose the proxy
-# on the standard HTTP/HTTPS ports. Set these to 80 and 443
-# when deploying to a public-facing environment.
-# Use standard ports for a production deployment
-NGINX_HTTP_PORT=80
-NGINX_HTTPS_PORT=443
+# --- Service Ports (Defaults are chosen to avoid host Apache/nginx conflicts) ---
+# For production or takeover deployments, update these to 80 and 443 once the
+# stack is the only web listener on the host.
+NGINX_HTTP_PORT=8088
+NGINX_HTTPS_PORT=8443
 APACHE_HTTP_PORT=8080
 AI_SERVICE_PORT=8000
 TARPIT_API_PORT=8001


### PR DESCRIPTION
## Summary
- switch the sample Nginx host-port defaults to `8088` and `8443` so Ubuntu hosts can keep Apache or nginx on `80` and `443`
- add a dedicated Ubuntu reverse-proxy deployment guide with recommended topology, minimal config examples, and a validation checklist
- update the README and getting-started docs to point users at the safer default port story

## Validation
- `docker compose --env-file sample.env config`
- `./.venv/bin/pre-commit run --files sample.env README.md docs/getting_started.md docs/index.md docs/ubuntu_reverse_proxy.md`

Closes #1587