### PR TITLE
Add Linux installer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ installs dependencies, and starts Docker Compose. See
 ### Linux
 1. [Install Docker Engine](https://docs.docker.com/engine/install/) and ensure it is running.
 2. Install Python 3.10 or newer (`sudo apt install python3 python3-venv` on Debian-based distros).
-3. Clone the repository and execute the quickstart script:
+3. Clone the repository and execute the Linux installer:
    ```bash
    git clone https://github.com/your-username/ai-scraping-defense.git
    cd ai-scraping-defense
-    sudo ./scripts/linux/quickstart_dev.sh
+   sudo ./scripts/linux/install.sh
    ```
 4. When the containers finish starting, open [http://localhost:5002](http://localhost:5002) to view the Admin UI dashboard.
 5. If you see "Cannot connect to the Docker daemon," start the service with
@@ -196,7 +196,7 @@ installs dependencies, and starts Docker Compose. See
 
 ## Quick Local Setup
 
-Run the automated script after cloning the repository:
+Run the automated installer after cloning the repository:
 
 ```bash
 git clone https://github.com/your-username/ai-scraping-defense.git
@@ -205,7 +205,7 @@ cd ai-scraping-defense
 cp sample.env .env
 python scripts/validate_env.py
 
-sudo ./scripts/linux/quickstart_dev.sh   # Linux
+sudo ./scripts/linux/install.sh          # Linux
 ./scripts/macos/quickstart_dev.zsh   # macOS
 
 ```
@@ -214,9 +214,11 @@ For the security testing environment, a helper `scripts/linux/security_setup.sh`
 
 On Windows, open an **Administrator PowerShell** window and run `scripts\windows\quickstart_dev.ps1` instead.
 
-The script generates secrets, installs Python requirements with
+The Linux installer generates local secrets, installs Python requirements with
 `pip install -r requirements.txt -c constraints.txt`, re-runs
-`python scripts/validate_env.py`, and launches Docker Compose for you.
+`python scripts/validate_env.py`, launches Docker Compose through the selected
+reverse-proxy helper, and runs the Linux smoke test for you. For Linux-specific
+rollback and uninstall steps, see [docs/linux_installer.md](docs/linux_installer.md).
 The stack requires Rust 1.78.0. `mise` (or `rustup`) installs this toolchain automatically.
 
 If you want local GGUF inference through the `llamacpp://` adapter, install the

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,18 +4,18 @@ This guide will walk you through setting up the AI Scraping Defense project for 
 
 ## **Quick Local Setup**
 
-Run the helper script after cloning the repository:
+Run the helper installer after cloning the repository:
 
 ```bash
 git clone https://github.com/your-username/ai-scraping-defense.git
 cd ai-scraping-defense
-sudo ./scripts/linux/quickstart_dev.sh  # Linux
+sudo ./scripts/linux/install.sh         # Linux
 ./scripts/macos/quickstart_dev.zsh      # macOS
 ```
 
 On Windows, run `scripts\\windows\\quickstart_dev.ps1` from an **Administrator PowerShell** window instead of the shell script.
 
-The script copies `sample.env`, generates secrets, installs dependencies, and launches Docker Compose.
+The Linux installer copies `sample.env`, generates secrets when needed, installs dependencies, launches Docker Compose through the selected reverse-proxy helper, and runs the Linux smoke test.
 If you encounter setup issues, see [Troubleshooting](troubleshooting.md) for common fixes.
 
 ## **Project Structure**

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ graph TD
 To get a full understanding of the project, please review the following documents:
 
 - [**Getting Started**](getting_started.md)**:** The essential first step. This guide provides detailed instructions for setting up the complete development environment on your local machine using Docker Compose.
+- [**Linux Installer**](linux_installer.md)**:** Guided Linux setup, smoke validation, and uninstall/rollback commands.
 - [**Ubuntu Reverse Proxy Deployment**](ubuntu_reverse_proxy.md)**:** Recommended Ubuntu Server topology when host Apache or nginx already owns ports 80/443.
 - [**Test to Production Guide**](test_to_production.md)**:** How to graduate from local testing to a secure production deployment.
 - [**System Architecture**](architecture.md)**:** A high-level overview of the different components of the system and how they fit together. This is the best place to start to understand the overall design.

--- a/docs/linux_installer.md
+++ b/docs/linux_installer.md
@@ -1,0 +1,106 @@
+# Linux Installer
+
+The Linux installer promotes the existing setup, proxy, and smoke-test scripts
+into one guided entrypoint:
+
+```bash
+sudo ./scripts/linux/install.sh
+```
+
+By default it:
+
+1. Verifies Docker, Compose, Python 3.10+, `htpasswd`, `curl`, and other
+   required host tools.
+2. Creates `.env` from `sample.env` if needed.
+3. Creates local directories and local development secrets.
+4. Resets the Python virtual environment and installs project dependencies.
+5. Validates `.env`.
+6. Starts the stack behind the recommended containerized Nginx proxy.
+7. Runs `scripts/linux/stack_smoke_test.sh` to confirm the install.
+
+## Common Modes
+
+Local coexistence with host Apache or nginx:
+
+```bash
+sudo ./scripts/linux/install.sh
+```
+
+Apache-backed install instead of Nginx:
+
+```bash
+sudo ./scripts/linux/install.sh --proxy apache
+```
+
+Take over ports `80` and `443` after snapshotting host web-server config:
+
+```bash
+sudo ./scripts/linux/install.sh --takeover
+```
+
+Reuse an existing virtual environment:
+
+```bash
+./scripts/linux/install.sh --skip-venv-reset
+```
+
+Regenerate local secrets:
+
+```bash
+./scripts/linux/install.sh --regenerate-secrets
+```
+
+## Smoke Contract
+
+The installer calls:
+
+```bash
+scripts/linux/stack_smoke_test.sh --proxy nginx
+```
+
+or:
+
+```bash
+scripts/linux/stack_smoke_test.sh --proxy apache
+```
+
+Success output is line-oriented and intended to be human-readable:
+
+```text
+=== Stack Smoke Test (Linux / nginx) ===
+[OK] postgres_markov_db is running (health=healthy)
+[OK] redis_store is running (health=healthy)
+...
+Smoke test passed.
+```
+
+Any failed assertion prints a `[FAIL]` line and exits non-zero.
+
+## Rollback and Uninstall
+
+Stop the stack while keeping data volumes:
+
+```bash
+./scripts/linux/uninstall.sh
+```
+
+Stop the stack and remove Docker volumes:
+
+```bash
+./scripts/linux/uninstall.sh --purge-data
+```
+
+Restore the most recent Apache/nginx host snapshot after a takeover install:
+
+```bash
+./scripts/linux/uninstall.sh --restore-webserver latest
+```
+
+Restore a specific snapshot:
+
+```bash
+./scripts/linux/uninstall.sh --restore-webserver backups/webserver/<timestamp>
+```
+
+If you used `--takeover`, the pre-takeover snapshot lives under
+`backups/webserver/`.

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "Unsupported OS: $(uname -s). This installer supports Linux only." >&2
+  echo "Use scripts/macos/*.zsh on macOS or scripts/windows/*.ps1 on Windows." >&2
+  exit 1
+fi
+
+# shellcheck source=scripts/linux/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PROXY="nginx"
+TAKEOVER=false
+FORCE_ENV=false
+REGENERATE_SECRETS=false
+SKIP_VENV_RESET=false
+RUN_TESTS=false
+SKIP_SMOKE=false
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/linux/install.sh [options]
+
+Options:
+  --proxy <nginx|apache>  Reverse proxy to expose during install. Default: nginx
+  --takeover              Stop host web services and bind the selected proxy to 80/443
+  --force-env             Replace .env with sample.env before continuing
+  --regenerate-secrets    Recreate local development secrets even if they already exist
+  --skip-venv-reset       Skip reset_venv.sh and reuse the existing .venv
+  --run-tests             Run test/run_all_tests.py before starting containers
+  --skip-smoke            Skip the post-install stack smoke test
+  -h, --help              Show this help text
+USAGE
+}
+
+need_cmd() {
+  local cmd="$1" package_hint="${2:-}"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "Missing required command: $cmd" >&2
+  if [ -n "$package_hint" ]; then
+    echo "Install it with: sudo apt-get install -y ${package_hint}" >&2
+  fi
+  exit 1
+}
+
+verify_python() {
+  if ! python3 - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
+PY
+  then
+    echo "Python 3.10 or newer is required." >&2
+    exit 1
+  fi
+
+  if ! python3 -m venv --help >/dev/null 2>&1; then
+    echo "python3-venv support is required. Install it with: sudo apt-get install -y python3-venv" >&2
+    exit 1
+  fi
+}
+
+verify_prerequisites() {
+  need_cmd docker docker.io
+  need_cmd git git
+  need_cmd python3 python3
+  need_cmd curl curl
+  need_cmd openssl openssl
+  need_cmd awk gawk
+  need_cmd sed sed
+  need_cmd ss iproute2
+  need_cmd htpasswd apache2-utils
+
+  verify_python
+
+  if ! $(docker_ctx) info >/dev/null 2>&1; then
+    echo "Docker daemon is not reachable for context '${DOCKER_CONTEXT}'." >&2
+    echo "Start Docker Engine and verify it with: docker --context ${DOCKER_CONTEXT} info" >&2
+    exit 1
+  fi
+
+  if ! compose >/dev/null 2>&1; then
+    exit 1
+  fi
+
+  if [ "$SKIP_VENV_RESET" = false ] && [ "$(id -u)" -ne 0 ] && ! sudo -n true >/dev/null 2>&1; then
+    echo "reset_venv.sh requires root privileges for apt packages." >&2
+    echo "Run this installer with sudo or pre-authorize sudo for the session." >&2
+    exit 1
+  fi
+}
+
+ensure_env_file() {
+  if [ "$FORCE_ENV" = true ] || [ ! -f .env ]; then
+    cp sample.env .env
+    chmod 600 .env
+    echo "Prepared .env from sample.env"
+  fi
+}
+
+secrets_initialized() {
+  [ -s "$ROOT_DIR/secrets/pg_password.txt" ] &&
+    [ -s "$ROOT_DIR/secrets/redis_password.txt" ] &&
+    awk -F= '$1=="ADMIN_UI_PASSWORD_HASH" && length($2) > 0 { found=1 } END { exit(found ? 0 : 1) }' .env
+}
+
+ensure_secrets() {
+  if [ "$REGENERATE_SECRETS" = true ] || ! secrets_initialized; then
+    bash "$SCRIPT_DIR/generate_secrets.sh" --update-env
+  else
+    echo "Reusing existing local secrets. Pass --regenerate-secrets to replace them."
+  fi
+}
+
+prepare_python_environment() {
+  if [ "$SKIP_VENV_RESET" = false ]; then
+    if [ "$(id -u)" -eq 0 ]; then
+      bash "$SCRIPT_DIR/reset_venv.sh"
+    else
+      sudo bash "$SCRIPT_DIR/reset_venv.sh"
+    fi
+  elif [ ! -x "$ROOT_DIR/.venv/bin/python" ]; then
+    echo "No usable .venv found. Re-run without --skip-venv-reset." >&2
+    exit 1
+  fi
+
+  "$ROOT_DIR/.venv/bin/pip" install -r requirements.txt -c constraints.txt
+  "$ROOT_DIR/.venv/bin/python" scripts/validate_env.py
+
+  if [ "$RUN_TESTS" = true ]; then
+    "$ROOT_DIR/.venv/bin/python" test/run_all_tests.py
+  fi
+}
+
+launch_stack() {
+  if [ "$TAKEOVER" = true ]; then
+    bash "$SCRIPT_DIR/quick_takeover.sh" "$PROXY"
+  else
+    bash "$SCRIPT_DIR/quick_proxy.sh" "$PROXY"
+  fi
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --proxy)
+        PROXY="${2:-}"
+        shift 2
+        ;;
+      --takeover)
+        TAKEOVER=true
+        shift
+        ;;
+      --force-env)
+        FORCE_ENV=true
+        shift
+        ;;
+      --regenerate-secrets)
+        REGENERATE_SECRETS=true
+        shift
+        ;;
+      --skip-venv-reset)
+        SKIP_VENV_RESET=true
+        shift
+        ;;
+      --run-tests)
+        RUN_TESTS=true
+        shift
+        ;;
+      --skip-smoke)
+        SKIP_SMOKE=true
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+
+  case "$PROXY" in
+    nginx|apache) ;;
+    *)
+      echo "Unsupported proxy: ${PROXY}" >&2
+      usage
+      exit 2
+      ;;
+  esac
+
+  echo "=== AI Scraping Defense: Linux Installer ==="
+  verify_prerequisites
+  ensure_env_file
+  bash "$SCRIPT_DIR/setup_local_dirs.sh"
+  ensure_secrets
+  prepare_python_environment
+  ensure_no_new_privileges_env
+  launch_stack
+
+  if [ "$SKIP_SMOKE" = false ]; then
+    bash "$SCRIPT_DIR/stack_smoke_test.sh" --proxy "$PROXY"
+  fi
+
+  echo ""
+  echo "Install complete."
+  echo "Proxy mode: ${PROXY}"
+  if [ "$TAKEOVER" = true ]; then
+    echo "Takeover mode is active. Roll back host web services with:"
+    echo "  scripts/linux/reset_web_server.sh restore-latest"
+  fi
+  echo "Uninstall the stack with:"
+  echo "  scripts/linux/uninstall.sh"
+}
+
+main "$@"

--- a/scripts/linux/lib.sh
+++ b/scripts/linux/lib.sh
@@ -100,3 +100,20 @@ wait_for_mariadb() {
     sleep 2
   done
 }
+
+supports_no_new_privileges() {
+  $(docker_ctx) run --rm --security-opt no-new-privileges:true alpine:3.20 true >/dev/null 2>&1
+}
+
+ensure_no_new_privileges_env() {
+  if [ -n "${NO_NEW_PRIVILEGES:-}" ]; then
+    return 0
+  fi
+
+  if supports_no_new_privileges; then
+    export NO_NEW_PRIVILEGES=true
+  else
+    export NO_NEW_PRIVILEGES=false
+    echo "Runtime does not support no-new-privileges:true; setting NO_NEW_PRIVILEGES=false."
+  fi
+}

--- a/scripts/linux/quick_proxy.sh
+++ b/scripts/linux/quick_proxy.sh
@@ -25,14 +25,7 @@ fi
 
 PROXY=${1:-nginx}
 
-if [ -z "${NO_NEW_PRIVILEGES:-}" ]; then
-  if $(docker_ctx) run --rm --security-opt no-new-privileges:true alpine:3.20 true >/dev/null 2>&1; then
-    export NO_NEW_PRIVILEGES=true
-  else
-    export NO_NEW_PRIVILEGES=false
-    echo "Runtime does not support no-new-privileges:true; setting NO_NEW_PRIVILEGES=false."
-  fi
-fi
+ensure_no_new_privileges_env
 
 env_file_value() {
   local key="$1"

--- a/scripts/linux/quick_takeover.sh
+++ b/scripts/linux/quick_takeover.sh
@@ -29,14 +29,7 @@ PROXY=${1:-nginx}
 
 # Detect runtime support for no-new-privileges; keep containers launchable on
 # engines that reject no-new-privileges:true.
-if [ -z "${NO_NEW_PRIVILEGES:-}" ]; then
-  if $(docker_ctx) run --rm --security-opt no-new-privileges:true alpine:3.20 true >/dev/null 2>&1; then
-    export NO_NEW_PRIVILEGES=true
-  else
-    export NO_NEW_PRIVILEGES=false
-    echo "Runtime does not support no-new-privileges:true; setting NO_NEW_PRIVILEGES=false."
-  fi
-fi
+ensure_no_new_privileges_env
 
 # Snapshot host webserver config before takeover unless explicitly disabled.
 if [ "${TAKEOVER_SNAPSHOT:-1}" = "1" ]; then
@@ -66,8 +59,8 @@ case "$PROXY" in
     APACHE_HTTP_PORT=80 $(compose) up -d apache_proxy
     ;;
   nginx)
-    echo "Launching stack with Nginx on port 80..."
-    $(compose) up -d nginx_proxy
+    echo "Launching stack with Nginx on ports 80/443..."
+    NGINX_HTTP_PORT=80 NGINX_HTTPS_PORT=443 $(compose) up -d nginx_proxy
     ;;
   *)
     echo "Usage: $0 [apache|nginx]"

--- a/scripts/linux/quickstart_dev.sh
+++ b/scripts/linux/quickstart_dev.sh
@@ -1,55 +1,6 @@
 #!/usr/bin/env bash
-# Quick setup script for local development
 set -euo pipefail
 
-# Warn if not running as root on Linux/macOS
-if [ "$(id -u)" -ne 0 ]; then
-  echo "WARNING: It's recommended to run this script with sudo on Linux/macOS" >&2
-fi
-
-# Always operate from the repository root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-cd "$ROOT_DIR"
 
-# OS guard: Linux only for this entrypoint
-if [ "$(uname -s)" != "Linux" ]; then
-  echo "Unsupported OS: $(uname -s). This entrypoint supports Linux only." >&2
-  echo "Use scripts/macos/*.zsh on macOS or scripts/windows/*.ps1 on Windows." >&2
-  exit 1
-fi
-
-# Helpers
-# shellcheck source=scripts/linux/lib.sh
-source "$SCRIPT_DIR/lib.sh"
-
-echo "=== AI Scraping Defense: Development Quickstart ==="
-
-# Copy sample.env if .env doesn't exist
-if [ ! -f .env ]; then
-  cp sample.env .env
-  echo "Created .env from sample.env"
-fi
-
-# Prepare local directories
-bash "$SCRIPT_DIR/setup_local_dirs.sh"
-
-# Generate local secrets
-bash "$SCRIPT_DIR/generate_secrets.sh"
-
-# Reset Python virtual environment (requires sudo for system packages)
-sudo bash "$SCRIPT_DIR/reset_venv.sh"
-
-# Install Python requirements with constraints
-./.venv/bin/pip install -r requirements.txt -c constraints.txt
-
-# Validate .env configuration
-./.venv/bin/python scripts/validate_env.py
-
-# Run tests to ensure environment integrity
-./.venv/bin/python test/run_all_tests.py
-
-# Launch the stack with Docker Compose
-$(compose) up --build -d
-
-echo "Development environment is up and running!"
+exec "$SCRIPT_DIR/install.sh" --run-tests "$@"

--- a/scripts/linux/stack_smoke_test.sh
+++ b/scripts/linux/stack_smoke_test.sh
@@ -8,7 +8,33 @@ cd "$ROOT_DIR"
 # shellcheck source=scripts/linux/lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
-echo "=== Stack Smoke Test (Linux) ==="
+PROXY="nginx"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/linux/stack_smoke_test.sh [--proxy nginx|apache]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --proxy)
+      PROXY="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+echo "=== Stack Smoke Test (Linux / ${PROXY}) ==="
 
 assert_running_and_healthy() {
   local container="$1"
@@ -29,18 +55,38 @@ assert_running_and_healthy() {
   echo "[OK] $container is running (health=$health)"
 }
 
-for svc in postgres_markov_db redis_store admin_ui escalation_engine tarpit_api nginx_proxy; do
+core_services=(postgres_markov_db redis_store admin_ui escalation_engine tarpit_api)
+case "$PROXY" in
+  nginx)
+    proxy_container="nginx_proxy"
+    ;;
+  apache)
+    proxy_container="apache_proxy"
+    ;;
+  *)
+    echo "[FAIL] Unsupported proxy: ${PROXY}" >&2
+    exit 2
+    ;;
+esac
+
+for svc in "${core_services[@]}" "$proxy_container"; do
   assert_running_and_healthy "$svc"
 done
 
-http_port=$($(docker_ctx) inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' nginx_proxy)
-https_port=$($(docker_ctx) inspect -f '{{(index (index .NetworkSettings.Ports "443/tcp") 0).HostPort}}' nginx_proxy)
+http_port=$(
+  $(docker_ctx) inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' "$proxy_container"
+)
 
 curl -fsS "http://127.0.0.1:${http_port}/" >/dev/null
-echo "[OK] nginx_proxy HTTP is reachable on port ${http_port}"
+echo "[OK] ${proxy_container} HTTP is reachable on port ${http_port}"
 
-curl -kfsS "https://127.0.0.1:${https_port}/" >/dev/null
-echo "[OK] nginx_proxy HTTPS is reachable on port ${https_port}"
+if [ "$PROXY" = "nginx" ]; then
+  https_port=$(
+    $(docker_ctx) inspect -f '{{(index (index .NetworkSettings.Ports "443/tcp") 0).HostPort}}' nginx_proxy
+  )
+  curl -kfsS "https://127.0.0.1:${https_port}/" >/dev/null
+  echo "[OK] nginx_proxy HTTPS is reachable on port ${https_port}"
+fi
 
 $(docker_ctx) exec admin_ui curl -fsS "http://127.0.0.1:5002/observability/health" >/dev/null
 echo "[OK] admin_ui health endpoint is reachable"

--- a/scripts/linux/uninstall.sh
+++ b/scripts/linux/uninstall.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "Unsupported OS: $(uname -s). This uninstall helper supports Linux only." >&2
+  exit 1
+fi
+
+# shellcheck source=scripts/linux/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PURGE_DATA=false
+REMOVE_IMAGES=false
+RESTORE_WEBSERVER=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/linux/uninstall.sh [options]
+
+Options:
+  --purge-data                 Remove Docker volumes as part of compose down
+  --remove-images              Remove locally built project images after shutdown
+  --restore-webserver latest   Restore the newest host webserver snapshot
+  --restore-webserver <path>   Restore a specific webserver snapshot
+  -h, --help                   Show this help text
+USAGE
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --purge-data)
+        PURGE_DATA=true
+        shift
+        ;;
+      --remove-images)
+        REMOVE_IMAGES=true
+        shift
+        ;;
+      --restore-webserver)
+        RESTORE_WEBSERVER="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+
+  down_args=(down --remove-orphans)
+  if [ "$PURGE_DATA" = true ]; then
+    down_args+=(--volumes)
+  fi
+  $(compose) "${down_args[@]}"
+
+  if [ "$REMOVE_IMAGES" = true ]; then
+    $(docker_ctx) image rm ai-scraping-defense-ai_service ai-scraping-defense-admin_ui ai-scraping-defense-escalation_engine ai-scraping-defense-tarpit_api >/dev/null 2>&1 || true
+  fi
+
+  if [ -n "$RESTORE_WEBSERVER" ]; then
+    if [ "$RESTORE_WEBSERVER" = "latest" ]; then
+      bash "$SCRIPT_DIR/reset_web_server.sh" restore-latest
+    else
+      bash "$SCRIPT_DIR/reset_web_server.sh" restore "$RESTORE_WEBSERVER"
+    fi
+  fi
+
+  echo "Linux uninstall complete."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a guided Linux installer and uninstall helper for Docker-based installs
- make the Linux smoke test proxy-aware and fix Nginx takeover mode so it really binds 80/443
- document the Linux installer, smoke contract, and rollback path
- keep `quickstart_dev.sh` as a compatibility wrapper that now delegates to the installer

## Validation
- `bash -n scripts/linux/install.sh scripts/linux/uninstall.sh scripts/linux/quick_proxy.sh scripts/linux/quick_takeover.sh scripts/linux/quickstart_dev.sh scripts/linux/stack_smoke_test.sh scripts/linux/lib.sh`
- `docker compose --env-file sample.env config`
- `bash scripts/linux/install.sh --help`
- `bash scripts/linux/uninstall.sh --help`
- `bash scripts/linux/stack_smoke_test.sh --help`
- `./.venv/bin/pre-commit run --files README.md docs/getting_started.md docs/index.md docs/linux_installer.md scripts/linux/lib.sh scripts/linux/quick_proxy.sh scripts/linux/quick_takeover.sh scripts/linux/quickstart_dev.sh scripts/linux/stack_smoke_test.sh scripts/linux/install.sh scripts/linux/uninstall.sh`

Closes #1619