### PR TITLE
Define installer smoke test contract

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ graph TD
 To get a full understanding of the project, please review the following documents:
 
 - [**Getting Started**](getting_started.md)**:** The essential first step. This guide provides detailed instructions for setting up the complete development environment on your local machine using Docker Compose.
+- [**Installer Contract**](installer_contract.md)**:** Shared smoke-test and uninstall expectations for platform installers.
 - [**Linux Installer**](linux_installer.md)**:** Guided Linux setup, smoke validation, and uninstall/rollback commands.
 - [**Ubuntu Reverse Proxy Deployment**](ubuntu_reverse_proxy.md)**:** Recommended Ubuntu Server topology when host Apache or nginx already owns ports 80/443.
 - [**Test to Production Guide**](test_to_production.md)**:** How to graduate from local testing to a secure production deployment.

--- a/docs/installer_contract.md
+++ b/docs/installer_contract.md
@@ -1,0 +1,67 @@
+# Installer Smoke and Uninstall Contract
+
+This repository now defines one shared post-install validation path:
+
+```bash
+python scripts/installer_smoke_test.py --platform <linux|windows|macos> --proxy <nginx|apache>
+```
+
+Platform wrappers may still exist for operator convenience, but they should
+delegate to this shared contract where possible instead of re-implementing the
+health checks independently.
+
+## Required Success Output
+
+Installers should surface smoke-test results as line-oriented text:
+
+```text
+=== Stack Smoke Test (linux / nginx) ===
+[OK] postgres_markov_db is running (health=healthy)
+[OK] redis_store is running (health=healthy)
+...
+Smoke test passed.
+```
+
+Failures should emit exactly one `[FAIL]` line describing the first unmet
+contract and exit non-zero.
+
+## Current Coverage
+
+- `linux`: implemented via `scripts/linux/stack_smoke_test.sh`, which delegates
+  to `scripts/installer_smoke_test.py`
+- `windows`: pending installer wrapper
+- `macos`: pending installer wrapper
+
+## Required Checks
+
+The shared smoke path validates:
+
+- core containers are running and healthy:
+  - `postgres_markov_db`
+  - `redis_store`
+  - `admin_ui`
+  - `escalation_engine`
+  - `tarpit_api`
+- selected proxy container is running and healthy:
+  - `nginx_proxy` or `apache_proxy`
+- selected proxy serves HTTP on the mapped host port
+- `nginx_proxy` also serves HTTPS on the mapped host port
+- `admin_ui` health endpoint is reachable
+- `tarpit_api` health endpoint is reachable
+- `escalation_engine` health payload reports `healthy` or `degraded`
+
+## Uninstall and Rollback Guidance
+
+Every platform installer should document:
+
+1. how to stop the stack while preserving data
+2. how to remove persistent volumes or local caches
+3. how to restore any host web-server state if takeover mode was used
+
+Current Linux commands:
+
+```bash
+./scripts/linux/uninstall.sh
+./scripts/linux/uninstall.sh --purge-data
+./scripts/linux/uninstall.sh --restore-webserver latest
+```

--- a/docs/linux_installer.md
+++ b/docs/linux_installer.md
@@ -52,16 +52,17 @@ Regenerate local secrets:
 
 ## Smoke Contract
 
-The installer calls:
+The installer calls the shared contract defined in
+[installer_contract.md](installer_contract.md):
+
+```bash
+python scripts/installer_smoke_test.py --platform linux --proxy nginx
+```
+
+For shell compatibility, the Linux wrapper remains:
 
 ```bash
 scripts/linux/stack_smoke_test.sh --proxy nginx
-```
-
-or:
-
-```bash
-scripts/linux/stack_smoke_test.sh --proxy apache
 ```
 
 Success output is line-oriented and intended to be human-readable:

--- a/scripts/installer_smoke_test.py
+++ b/scripts/installer_smoke_test.py
@@ -1,0 +1,192 @@
+"""Shared post-install smoke test contract for Docker-based installs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SmokeConfig:
+    platform: str
+    proxy: str
+    docker_context: str = "default"
+
+
+class SmokeFailure(RuntimeError):
+    """Raised when a smoke-test contract assertion fails."""
+
+
+CORE_SERVICES = (
+    "postgres_markov_db",
+    "redis_store",
+    "admin_ui",
+    "escalation_engine",
+    "tarpit_api",
+)
+PROXY_CONTAINERS = {
+    "nginx": "nginx_proxy",
+    "apache": "apache_proxy",
+}
+
+
+def docker_prefix(docker_context: str) -> list[str]:
+    return ["docker", "--context", docker_context]
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_docker(config: SmokeConfig, *args: str) -> subprocess.CompletedProcess[str]:
+    return run_command(docker_prefix(config.docker_context) + list(args))
+
+
+def fail(message: str) -> None:
+    raise SmokeFailure(message)
+
+
+def assert_running_and_healthy(config: SmokeConfig, container: str) -> None:
+    status = run_docker(
+        config, "inspect", "-f", "{{.State.Status}}", container
+    ).stdout.strip()
+    if status != "running":
+        fail(f"{container} is not running (status={status or 'missing'})")
+
+    health = run_docker(
+        config,
+        "inspect",
+        "-f",
+        "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+        container,
+    ).stdout.strip()
+    if health not in {"none", "healthy"}:
+        fail(f"{container} health is not healthy (health={health})")
+
+    print(f"[OK] {container} is running (health={health})")
+
+
+def host_port_for_container(config: SmokeConfig, container: str, port: str) -> str:
+    result = run_docker(
+        config,
+        "inspect",
+        "-f",
+        f'{{{{(index (index .NetworkSettings.Ports "{port}") 0).HostPort}}}}',
+        container,
+    )
+    host_port = result.stdout.strip()
+    if not host_port:
+        fail(f"{container} does not expose {port}")
+    return host_port
+
+
+def assert_http(url: str, *, insecure: bool = False) -> None:
+    context = ssl._create_unverified_context() if insecure else None
+    try:
+        with urllib.request.urlopen(url, timeout=10, context=context) as response:
+            if response.status >= 400:
+                fail(f"{url} returned HTTP {response.status}")
+    except urllib.error.URLError as exc:
+        fail(f"{url} is not reachable ({exc})")
+
+
+def assert_container_http(
+    config: SmokeConfig, container: str, url: str, expected_pattern: str | None = None
+) -> None:
+    result = run_docker(config, "exec", container, "curl", "-fsS", url)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        fail(f"{container} could not reach {url} ({stderr})")
+    if expected_pattern and not re.search(expected_pattern, result.stdout):
+        fail(
+            f"{container} returned unexpected payload for {url}: {result.stdout.strip()}"
+        )
+
+
+def run_smoke_test(config: SmokeConfig) -> None:
+    if config.proxy not in PROXY_CONTAINERS:
+        raise ValueError(f"Unsupported proxy: {config.proxy}")
+
+    print(f"=== Stack Smoke Test ({config.platform} / {config.proxy}) ===")
+
+    proxy_container = PROXY_CONTAINERS[config.proxy]
+    for container in (*CORE_SERVICES, proxy_container):
+        assert_running_and_healthy(config, container)
+
+    http_port = host_port_for_container(config, proxy_container, "80/tcp")
+    assert_http(f"http://127.0.0.1:{http_port}/")
+    print(f"[OK] {proxy_container} HTTP is reachable on port {http_port}")
+
+    if config.proxy == "nginx":
+        https_port = host_port_for_container(config, proxy_container, "443/tcp")
+        assert_http(f"https://127.0.0.1:{https_port}/", insecure=True)
+        print(f"[OK] nginx_proxy HTTPS is reachable on port {https_port}")
+
+    assert_container_http(
+        config, "admin_ui", "http://127.0.0.1:5002/observability/health"
+    )
+    print("[OK] admin_ui health endpoint is reachable")
+
+    assert_container_http(config, "tarpit_api", "http://127.0.0.1:8001/health")
+    print("[OK] tarpit_api health endpoint is reachable")
+
+    assert_container_http(
+        config,
+        "escalation_engine",
+        "http://127.0.0.1:8003/health",
+        expected_pattern=r'"status":"(healthy|degraded)"',
+    )
+    print("[OK] escalation_engine health payload is acceptable")
+    print("Smoke test passed.")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--platform",
+        default="linux",
+        choices=("linux", "windows", "macos"),
+        help="Platform label for the smoke-test banner",
+    )
+    parser.add_argument(
+        "--proxy",
+        default="nginx",
+        choices=tuple(PROXY_CONTAINERS),
+        help="Reverse proxy under test",
+    )
+    parser.add_argument(
+        "--docker-context",
+        default="default",
+        help="Docker context to target",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = SmokeConfig(
+        platform=args.platform,
+        proxy=args.proxy,
+        docker_context=args.docker_context,
+    )
+    try:
+        run_smoke_test(config)
+    except SmokeFailure as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/linux/stack_smoke_test.sh
+++ b/scripts/linux/stack_smoke_test.sh
@@ -5,9 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROOT_DIR"
 
-# shellcheck source=scripts/linux/lib.sh
-source "$SCRIPT_DIR/lib.sh"
-
 PROXY="nginx"
 
 usage() {
@@ -34,71 +31,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo "=== Stack Smoke Test (Linux / ${PROXY}) ==="
-
-assert_running_and_healthy() {
-  local container="$1"
-  local status health
-
-  status=$($(docker_ctx) inspect -f '{{.State.Status}}' "$container" 2>/dev/null || true)
-  if [ "$status" != "running" ]; then
-    echo "[FAIL] $container is not running (status=$status)" >&2
-    return 1
-  fi
-
-  health=$($(docker_ctx) inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" 2>/dev/null || true)
-  if [ "$health" != "none" ] && [ "$health" != "healthy" ]; then
-    echo "[FAIL] $container health is not healthy (health=$health)" >&2
-    return 1
-  fi
-
-  echo "[OK] $container is running (health=$health)"
-}
-
-core_services=(postgres_markov_db redis_store admin_ui escalation_engine tarpit_api)
-case "$PROXY" in
-  nginx)
-    proxy_container="nginx_proxy"
-    ;;
-  apache)
-    proxy_container="apache_proxy"
-    ;;
-  *)
-    echo "[FAIL] Unsupported proxy: ${PROXY}" >&2
-    exit 2
-    ;;
-esac
-
-for svc in "${core_services[@]}" "$proxy_container"; do
-  assert_running_and_healthy "$svc"
-done
-
-http_port=$(
-  $(docker_ctx) inspect -f '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' "$proxy_container"
-)
-
-curl -fsS "http://127.0.0.1:${http_port}/" >/dev/null
-echo "[OK] ${proxy_container} HTTP is reachable on port ${http_port}"
-
-if [ "$PROXY" = "nginx" ]; then
-  https_port=$(
-    $(docker_ctx) inspect -f '{{(index (index .NetworkSettings.Ports "443/tcp") 0).HostPort}}' nginx_proxy
-  )
-  curl -kfsS "https://127.0.0.1:${https_port}/" >/dev/null
-  echo "[OK] nginx_proxy HTTPS is reachable on port ${https_port}"
+PYTHON_BIN="./.venv/bin/python"
+if [ ! -x "$PYTHON_BIN" ]; then
+  PYTHON_BIN="python3"
 fi
 
-$(docker_ctx) exec admin_ui curl -fsS "http://127.0.0.1:5002/observability/health" >/dev/null
-echo "[OK] admin_ui health endpoint is reachable"
-
-$(docker_ctx) exec tarpit_api curl -fsS "http://127.0.0.1:8001/health" >/dev/null
-echo "[OK] tarpit_api health endpoint is reachable"
-
-esc_health=$($(docker_ctx) exec escalation_engine curl -sS "http://127.0.0.1:8003/health")
-if ! echo "$esc_health" | grep -Eq '"status":"(healthy|degraded)"'; then
-  echo "[FAIL] escalation_engine health payload is unexpected: $esc_health" >&2
-  exit 1
-fi
-echo "[OK] escalation_engine health payload is acceptable"
-
-echo "Smoke test passed."
+exec "$PYTHON_BIN" scripts/installer_smoke_test.py --platform linux --proxy "$PROXY"

--- a/test/scripts/test_installer_smoke_test.py
+++ b/test/scripts/test_installer_smoke_test.py
@@ -1,0 +1,150 @@
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest.mock import patch
+
+from scripts import installer_smoke_test
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return installer_smoke_test.subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestInstallerSmokeTest(unittest.TestCase):
+    def test_run_smoke_test_for_nginx_contract(self):
+        outputs = {
+            (
+                "inspect",
+                "-f",
+                "{{.State.Status}}",
+                "postgres_markov_db",
+            ): _completed(stdout="running\n"),
+            (
+                "inspect",
+                "-f",
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+                "postgres_markov_db",
+            ): _completed(stdout="healthy\n"),
+            ("inspect", "-f", "{{.State.Status}}", "redis_store"): _completed(
+                stdout="running\n"
+            ),
+            (
+                "inspect",
+                "-f",
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+                "redis_store",
+            ): _completed(stdout="healthy\n"),
+            ("inspect", "-f", "{{.State.Status}}", "admin_ui"): _completed(
+                stdout="running\n"
+            ),
+            (
+                "inspect",
+                "-f",
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+                "admin_ui",
+            ): _completed(stdout="healthy\n"),
+            ("inspect", "-f", "{{.State.Status}}", "escalation_engine"): _completed(
+                stdout="running\n"
+            ),
+            (
+                "inspect",
+                "-f",
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+                "escalation_engine",
+            ): _completed(stdout="healthy\n"),
+            ("inspect", "-f", "{{.State.Status}}", "tarpit_api"): _completed(
+                stdout="running\n"
+            ),
+            (
+                "inspect",
+                "-f",
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+                "tarpit_api",
+            ): _completed(stdout="healthy\n"),
+            ("inspect", "-f", "{{.State.Status}}", "nginx_proxy"): _completed(
+                stdout="running\n"
+            ),
+            (
+                "inspect",
+                "-f",
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}",
+                "nginx_proxy",
+            ): _completed(stdout="healthy\n"),
+            (
+                "inspect",
+                "-f",
+                '{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}',
+                "nginx_proxy",
+            ): _completed(stdout="8088\n"),
+            (
+                "inspect",
+                "-f",
+                '{{(index (index .NetworkSettings.Ports "443/tcp") 0).HostPort}}',
+                "nginx_proxy",
+            ): _completed(stdout="8443\n"),
+            (
+                "exec",
+                "admin_ui",
+                "curl",
+                "-fsS",
+                "http://127.0.0.1:5002/observability/health",
+            ): _completed(stdout="ok"),
+            (
+                "exec",
+                "tarpit_api",
+                "curl",
+                "-fsS",
+                "http://127.0.0.1:8001/health",
+            ): _completed(stdout="ok"),
+            (
+                "exec",
+                "escalation_engine",
+                "curl",
+                "-fsS",
+                "http://127.0.0.1:8003/health",
+            ): _completed(stdout='{"status":"healthy"}'),
+        }
+
+        def fake_run(*command):
+            key = tuple(command[1:])
+            return outputs[key]
+
+        with (
+            patch("scripts.installer_smoke_test.run_docker", side_effect=fake_run),
+            patch("scripts.installer_smoke_test.assert_http") as mock_http,
+            io.StringIO() as buf,
+            redirect_stdout(buf),
+        ):
+            installer_smoke_test.run_smoke_test(
+                installer_smoke_test.SmokeConfig(platform="linux", proxy="nginx")
+            )
+            output = buf.getvalue()
+
+        self.assertIn("=== Stack Smoke Test (linux / nginx) ===", output)
+        self.assertIn("[OK] nginx_proxy HTTPS is reachable on port 8443", output)
+        self.assertIn("Smoke test passed.", output)
+        self.assertEqual(mock_http.call_count, 2)
+
+    def test_main_reports_failures_with_contract_prefix(self):
+        with (
+            patch(
+                "scripts.installer_smoke_test.run_smoke_test",
+                side_effect=installer_smoke_test.SmokeFailure(
+                    "redis_store is not running"
+                ),
+            ),
+            io.StringIO() as stderr,
+            redirect_stderr(stderr),
+        ):
+            result = installer_smoke_test.main(
+                ["--platform", "linux", "--proxy", "nginx"]
+            )
+            error_output = stderr.getvalue()
+
+        self.assertEqual(result, 1)
+        self.assertIn("[FAIL] redis_store is not running", error_output)


### PR DESCRIPTION
## Summary
- add a shared Python smoke-test runner for Docker-based installers
- make the Linux smoke-test wrapper delegate to the shared contract instead of owning its own health logic
- document the shared smoke/uninstall contract for future Linux, Windows, and macOS installers
- add focused unit tests for the shared smoke runner

## Validation
- `./.venv/bin/python -m pytest -q test/scripts/test_installer_smoke_test.py test/scripts/test_operations_toolkit.py`
- `bash -n scripts/linux/stack_smoke_test.sh`
- `./.venv/bin/python scripts/installer_smoke_test.py --help`
- `bash scripts/linux/stack_smoke_test.sh --help`
- `./.venv/bin/pre-commit run --files scripts/installer_smoke_test.py test/scripts/test_installer_smoke_test.py scripts/linux/stack_smoke_test.sh docs/installer_contract.md docs/index.md docs/linux_installer.md`

Closes #1617