### PR TITLE
Harden proxy forwarding trust

### DIFF
--- a/src/iis_gateway/main.py
+++ b/src/iis_gateway/main.py
@@ -60,6 +60,24 @@ redis_client = redis.Redis(
 )
 
 BLOCK_CACHE = TTLCache(maxsize=10000, ttl=60)
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+FORWARDED_HEADER_NAMES = {
+    "host",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-port",
+    "x-forwarded-proto",
+    "x-real-ip",
+}
 
 
 @register_health_check(app, "iis_gateway_redis", critical=True)
@@ -125,6 +143,29 @@ async def escalate(ip: str, reason: str) -> None:
             logger.exception("Escalation failed")
 
 
+def _build_forward_headers(request: Request) -> dict[str, str]:
+    """Build canonical proxy headers and drop spoofable client-supplied values."""
+
+    forwarded_headers = {
+        key: value
+        for key, value in request.headers.items()
+        if key.lower() not in HOP_BY_HOP_HEADERS | FORWARDED_HEADER_NAMES
+    }
+
+    client_ip = request.client.host if request.client else "unknown"
+    forwarded_headers["Host"] = request.headers.get("host", request.url.netloc)
+    forwarded_headers["X-Forwarded-For"] = client_ip
+    forwarded_headers["X-Forwarded-Host"] = request.headers.get(
+        "host", request.url.netloc
+    )
+    scheme = request.url.scheme
+    default_port = 443 if scheme == "https" else 80
+    forwarded_headers["X-Forwarded-Port"] = str(request.url.port or default_port)
+    forwarded_headers["X-Forwarded-Proto"] = scheme
+    forwarded_headers["X-Real-IP"] = client_ip
+    return forwarded_headers
+
+
 @app.api_route(
     "/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 )
@@ -165,7 +206,7 @@ async def proxy(path: str, request: Request) -> Response:
                 resp = await client.request(
                     request.method,
                     url,
-                    headers=request.headers.raw,
+                    headers=_build_forward_headers(request),
                     content=request.stream(),
                     params=request.query_params,
                 )

--- a/src/shared/middleware.py
+++ b/src/shared/middleware.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import os
 import time
@@ -22,6 +23,8 @@ from .errors import register_error_handlers
 from .observability import ObservabilitySettings, configure_observability
 
 logger = logging.getLogger(__name__)
+
+TrustedProxyNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 
 
 @dataclass(frozen=True)
@@ -98,6 +101,36 @@ def _parse_host_list(name: str) -> list[str]:
             seen.add(host)
             unique.append(host)
     return unique
+
+
+def _parse_trusted_proxy_networks(name: str) -> list[TrustedProxyNetwork]:
+    """Parse a comma-separated list of trusted proxy IPs or CIDR ranges."""
+
+    raw = os.getenv(name, "")
+    networks: list[TrustedProxyNetwork] = []
+    for entry in raw.split(","):
+        candidate = entry.strip()
+        if not candidate:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(candidate, strict=False))
+        except ValueError as exc:
+            raise ValueError(
+                f"Environment variable {name} contains invalid proxy network {candidate!r}"
+            ) from exc
+    return networks
+
+
+def _request_from_trusted_proxy(
+    request: Request, trusted_proxies: list[TrustedProxyNetwork]
+) -> bool:
+    if not trusted_proxies or request.client is None or not request.client.host:
+        return False
+    try:
+        client_ip = ipaddress.ip_address(request.client.host)
+    except ValueError:
+        return False
+    return any(client_ip in network for network in trusted_proxies)
 
 
 class RequestTargetLimitMiddleware(BaseHTTPMiddleware):
@@ -301,10 +334,15 @@ def add_security_middleware(
     if settings.enable_https:
         canonical = os.getenv("SECURITY_HTTPS_REDIRECT_CANONICAL_HOST", "").strip()
         allowed_hosts = _parse_host_list("SECURITY_HTTPS_REDIRECT_ALLOWED_HOSTS")
+        trusted_proxies = _parse_trusted_proxy_networks("SECURITY_TRUSTED_PROXY_CIDRS")
 
         @app.middleware("http")
         async def _enforce_https(request, call_next):
-            forwarded = request.headers.get("x-forwarded-proto")
+            forwarded = (
+                request.headers.get("x-forwarded-proto")
+                if _request_from_trusted_proxy(request, trusted_proxies)
+                else None
+            )
             scheme = (
                 forwarded.split(",")[0].strip() if forwarded else request.url.scheme
             )

--- a/test/iis_gateway/test_iis_gateway_app.py
+++ b/test/iis_gateway/test_iis_gateway_app.py
@@ -32,6 +32,7 @@ class TestIISGateway(unittest.TestCase):
         async_client_instance.request.return_value = MagicMock(
             content=b"ok", status_code=200, headers={}
         )
+        self.async_client_instance = async_client_instance
         self.httpx_patch = patch("src.iis_gateway.main.httpx.AsyncClient")
         self.httpx_mock = self.httpx_patch.start()
         self.httpx_mock.return_value.__aenter__.return_value = async_client_instance
@@ -56,6 +57,33 @@ class TestIISGateway(unittest.TestCase):
         self.assertEqual(resp1.status_code, 403)
         self.assertEqual(resp2.status_code, 403)
         self.redis_mock.exists.assert_called_once()
+
+    def test_proxy_sanitizes_spoofed_forward_headers(self):
+        self.redis_mock.exists.return_value = False
+        self.redis_mock.incr.return_value = 1
+        self.redis_mock.expire.return_value = True
+
+        response = self.client.get(
+            "/proxy-target",
+            headers={
+                "Host": "public.example",
+                "X-Forwarded-For": "8.8.8.8",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "spoofed.example",
+                "X-Forwarded-Port": "443",
+                "X-Real-IP": "7.7.7.7",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        request_call = self.async_client_instance.request.await_args
+        forwarded_headers = request_call.kwargs["headers"]
+        self.assertEqual(forwarded_headers["Host"], "public.example")
+        self.assertEqual(forwarded_headers["X-Forwarded-Host"], "public.example")
+        self.assertEqual(forwarded_headers["X-Forwarded-For"], "testclient")
+        self.assertEqual(forwarded_headers["X-Real-IP"], "testclient")
+        self.assertEqual(forwarded_headers["X-Forwarded-Proto"], "http")
+        self.assertEqual(forwarded_headers["X-Forwarded-Port"], "80")
 
 
 if __name__ == "__main__":

--- a/test/test_security_middleware.py
+++ b/test/test_security_middleware.py
@@ -127,6 +127,43 @@ def test_https_redirect_uses_allowlist_when_configured(monkeypatch):
     assert response.headers["location"].startswith("https://good.test/ping")
 
 
+def test_https_redirect_ignores_spoofed_forwarded_proto_from_untrusted_client(
+    monkeypatch,
+):
+    settings = SecuritySettings(
+        rate_limit_requests=5,
+        rate_limit_window=60,
+        max_body_size=1024,
+        enable_https=True,
+    )
+    client = TestClient(_build_app(settings))
+
+    response = client.get(
+        "/ping",
+        headers={"X-Forwarded-Proto": "https"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"].startswith("https://testserver/ping")
+
+
+def test_https_redirect_trusts_forwarded_proto_from_configured_proxy(monkeypatch):
+    monkeypatch.setenv("SECURITY_TRUSTED_PROXY_CIDRS", "127.0.0.0/8")
+    settings = SecuritySettings(
+        rate_limit_requests=5,
+        rate_limit_window=60,
+        max_body_size=1024,
+        enable_https=True,
+    )
+    client = TestClient(_build_app(settings), client=("127.0.0.1", 50000))
+
+    response = client.get("/ping", headers={"X-Forwarded-Proto": "https"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
 def test_request_target_limit_rejects_long_paths(monkeypatch):
     monkeypatch.setenv("SECURITY_MAX_PATH_LENGTH", "10")
     settings = SecuritySettings(


### PR DESCRIPTION
## Summary
- trust `X-Forwarded-Proto` only from configured proxy CIDRs in shared security middleware
- sanitize and rebuild forwarded headers in the IIS gateway before proxying upstream
- add regression coverage for spoofed forwarded headers and trusted proxy redirects

## Testing
- `./.venv/bin/pre-commit run --files src/shared/middleware.py src/iis_gateway/main.py test/test_security_middleware.py test/iis_gateway/test_iis_gateway_app.py`
- `./.venv/bin/python -m pytest -q test/test_security_middleware.py test/iis_gateway/test_iis_gateway_app.py`

Closes #1634.
