### PR TITLE
Harden websocket admin and dashboard endpoints

### DIFF
--- a/src/admin_ui/metrics.py
+++ b/src/admin_ui/metrics.py
@@ -1,5 +1,7 @@
 import asyncio
+import json
 import logging
+import os
 from base64 import b64decode
 
 from fastapi import (
@@ -13,6 +15,10 @@ from fastapi import (
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBasicCredentials
 
+from src.shared.audit import log_event
+from src.shared.metrics import OPERATIONAL_EVENTS, SECURITY_EVENTS
+from src.shared.observability import WebSocketConnectionLimiter
+
 from .auth import _require_auth_core, require_auth
 from .metrics_admin_ui import get_metrics
 
@@ -20,6 +26,10 @@ logger = logging.getLogger(__name__)
 
 METRICS_TRULY_AVAILABLE = True
 WEBSOCKET_METRICS_INTERVAL = 5
+WEBSOCKET_MAX_CONNECTIONS = int(os.getenv("ADMIN_UI_METRICS_WS_MAX_CONNECTIONS", "5"))
+WEBSOCKET_MAX_MESSAGE_BYTES = int(
+    os.getenv("ADMIN_UI_METRICS_WS_MAX_MESSAGE_BYTES", "65536")
+)
 SECURITY_KPI_PREFIXES = {
     "security_events_total": "security_events_total",
     "errors_total": "errors_total",
@@ -28,6 +38,42 @@ SECURITY_KPI_PREFIXES = {
 }
 
 router = APIRouter()
+WEBSOCKET_LIMITER = WebSocketConnectionLimiter(max_total=WEBSOCKET_MAX_CONNECTIONS)
+
+
+def _websocket_close_try_again_later() -> int:
+    return getattr(status, "WS_1013_TRY_AGAIN_LATER", 1013)
+
+
+def _client_ip(websocket: WebSocket) -> str:
+    client = websocket.client
+    return client.host if client and client.host else "unknown"
+
+
+def _record_websocket_event(action: str, **details) -> None:
+    OPERATIONAL_EVENTS.labels(event_type=f"admin_ui_metrics_ws_{action}").inc()
+    log_event("admin_ui", f"admin_ui_metrics_websocket_{action}", details)
+
+
+def _record_websocket_security_event(action: str, **details) -> None:
+    SECURITY_EVENTS.labels(event_type=f"admin_ui_metrics_ws_{action}").inc()
+    log_event("admin_ui", f"admin_ui_metrics_websocket_{action}", details)
+
+
+async def _send_limited_json(websocket: WebSocket, payload: dict) -> bool:
+    encoded = json.dumps(payload, default=str).encode("utf-8")
+    if WEBSOCKET_MAX_MESSAGE_BYTES and len(encoded) > WEBSOCKET_MAX_MESSAGE_BYTES:
+        _record_websocket_security_event(
+            "payload_too_large",
+            client_ip=_client_ip(websocket),
+            payload_bytes=len(encoded),
+            max_bytes=WEBSOCKET_MAX_MESSAGE_BYTES,
+        )
+        await websocket.send_json({"error": "Metrics payload too large"})
+        await websocket.close(code=_websocket_close_try_again_later())
+        return False
+    await websocket.send_json(payload)
+    return True
 
 
 def _parse_prometheus_metrics(text: str) -> dict:
@@ -93,6 +139,7 @@ async def metrics_endpoint(user: str = Depends(require_auth)):
 @router.websocket("/ws/metrics")
 async def metrics_websocket(websocket: WebSocket):
     """Stream metrics to the client over a WebSocket connection."""
+    client_ip = _client_ip(websocket)
     auth = websocket.headers.get("Authorization")
     if auth:
         try:
@@ -112,26 +159,53 @@ async def metrics_websocket(websocket: WebSocket):
                         x_2fa_code=x_2fa_code,
                         x_2fa_token=x_2fa_token,
                         x_2fa_backup_code=None,
-                        client_ip=websocket.client.host,
+                        client_ip=client_ip,
                     )
                 except HTTPException:
+                    _record_websocket_security_event(
+                        "denied",
+                        client_ip=client_ip,
+                        reason="authentication_failed",
+                    )
                     await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
                     return
         except Exception as exc:
             logger.error("Error during websocket auth", exc_info=exc)
+            _record_websocket_security_event(
+                "denied",
+                client_ip=client_ip,
+                reason="invalid_authorization_header",
+            )
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
             return
     else:
+        _record_websocket_security_event(
+            "denied",
+            client_ip=client_ip,
+            reason="missing_authorization_header",
+        )
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
-    await websocket.accept()
-
-    if not METRICS_TRULY_AVAILABLE:
-        await websocket.send_json({"error": "Metrics module not available"})
-        await websocket.close()
+    acquired = await WEBSOCKET_LIMITER.try_acquire()
+    if not acquired:
+        _record_websocket_security_event(
+            "denied",
+            client_ip=client_ip,
+            reason="connection_limit_exceeded",
+        )
+        await websocket.close(code=_websocket_close_try_again_later())
         return
-
     try:
+        await websocket.accept()
+        _record_websocket_event("opened", client_ip=client_ip)
+
+        if not METRICS_TRULY_AVAILABLE:
+            await _send_limited_json(
+                websocket, {"error": "Metrics module not available"}
+            )
+            await websocket.close()
+            return
+
         while True:
             try:
                 metrics_dict = _get_metrics_dict_func()
@@ -140,11 +214,14 @@ async def metrics_websocket(websocket: WebSocket):
                     "An error occurred in the websocket metrics endpoint",
                     exc_info=exc,
                 )
-                await websocket.send_json({"error": "An internal error occurred"})
+                await _send_limited_json(
+                    websocket, {"error": "An internal error occurred"}
+                )
                 await websocket.close()
                 break
 
-            await websocket.send_json(metrics_dict)
+            if not await _send_limited_json(websocket, metrics_dict):
+                break
 
             if isinstance(metrics_dict, dict) and metrics_dict.get("error"):
                 await websocket.close()
@@ -156,3 +233,6 @@ async def metrics_websocket(websocket: WebSocket):
                 break
     except WebSocketDisconnect:  # pragma: no cover - normal disconnect
         pass
+    finally:
+        await WEBSOCKET_LIMITER.release()
+        _record_websocket_event("closed", client_ip=client_ip)

--- a/src/cloud_dashboard/cloud_dashboard_api.py
+++ b/src/cloud_dashboard/cloud_dashboard_api.py
@@ -14,10 +14,13 @@ from redis.exceptions import RedisError
 from starlette.websockets import WebSocketState
 
 from src.shared.api_key_auth import is_api_key_valid, load_api_key
+from src.shared.audit import log_event
 from src.shared.config import tenant_key
+from src.shared.metrics import OPERATIONAL_EVENTS, SECURITY_EVENTS
 from src.shared.middleware import create_app
 from src.shared.observability import (
     HealthCheckResult,
+    WebSocketConnectionLimiter,
     register_health_check,
     trace_span,
 )
@@ -38,6 +41,17 @@ MAX_INSTALLATION_ID_LENGTH = int(
 )
 MAX_METRICS_KEYS = int(os.getenv("CLOUD_DASHBOARD_MAX_METRICS_KEYS", "200"))
 MAX_METRIC_KEY_LENGTH = int(os.getenv("CLOUD_DASHBOARD_MAX_METRIC_KEY_LENGTH", "64"))
+MAX_WEBSOCKET_CONNECTIONS = int(os.getenv("CLOUD_DASHBOARD_WS_MAX_CONNECTIONS", "100"))
+MAX_WEBSOCKET_CONNECTIONS_PER_INSTALLATION = int(
+    os.getenv("CLOUD_DASHBOARD_WS_MAX_CONNECTIONS_PER_INSTALLATION", "5")
+)
+MAX_WEBSOCKET_MESSAGE_BYTES = int(
+    os.getenv("CLOUD_DASHBOARD_WS_MAX_MESSAGE_BYTES", "65536")
+)
+WEBSOCKET_LIMITER = WebSocketConnectionLimiter(
+    max_total=MAX_WEBSOCKET_CONNECTIONS,
+    max_per_key=MAX_WEBSOCKET_CONNECTIONS_PER_INSTALLATION,
+)
 
 
 def _validate_installation_id(installation_id: Any) -> str | None:
@@ -56,6 +70,54 @@ def _validate_metrics(metrics: Any) -> bool:
     for key in metrics.keys():
         if not isinstance(key, str) or len(key) > MAX_METRIC_KEY_LENGTH:
             return False
+    return True
+
+
+def _websocket_close_try_again_later() -> int:
+    return 1013
+
+
+def _client_ip(websocket: WebSocket) -> str:
+    client = websocket.client
+    return client.host if client and client.host else "unknown"
+
+
+def _registration_key(installation_id: str) -> str:
+    return tenant_key(f"cloud:install:registered:{installation_id}")
+
+
+def _is_registered_installation(redis_conn: Any, installation_id: str) -> bool:
+    if not redis_conn:
+        return False
+    return bool(redis_conn.get(_registration_key(installation_id)))
+
+
+def _record_websocket_event(action: str, **details) -> None:
+    OPERATIONAL_EVENTS.labels(event_type=f"cloud_dashboard_ws_{action}").inc()
+    log_event("cloud_dashboard", f"cloud_dashboard_websocket_{action}", details)
+
+
+def _record_websocket_security_event(action: str, **details) -> None:
+    SECURITY_EVENTS.labels(event_type=f"cloud_dashboard_ws_{action}").inc()
+    log_event("cloud_dashboard", f"cloud_dashboard_websocket_{action}", details)
+
+
+async def _send_limited_json(
+    websocket: WebSocket, payload: dict, *, installation_id: str
+) -> bool:
+    encoded = json.dumps(payload, default=str).encode("utf-8")
+    if MAX_WEBSOCKET_MESSAGE_BYTES and len(encoded) > MAX_WEBSOCKET_MESSAGE_BYTES:
+        _record_websocket_security_event(
+            "payload_too_large",
+            installation_id=installation_id,
+            client_ip=_client_ip(websocket),
+            payload_bytes=len(encoded),
+            max_bytes=MAX_WEBSOCKET_MESSAGE_BYTES,
+        )
+        await websocket.send_json({"error": "Metrics payload too large"})
+        await websocket.close(code=_websocket_close_try_again_later())
+        return False
+    await websocket.send_json(payload)
     return True
 
 
@@ -160,12 +222,25 @@ async def push_metrics(payload: Dict[str, Any], request: Request):
         return JSONResponse({"error": "Redis service unavailable"}, status_code=503)
     async with WATCHERS_LOCK:
         sockets = list(WATCHERS.get(installation_id, []))
+    stale_sockets: list[WebSocket] = []
     for ws in sockets:
         try:
-            await ws.send_json(metrics)
+            if not await _send_limited_json(
+                ws, metrics, installation_id=installation_id
+            ):
+                stale_sockets.append(ws)
         except Exception as e:
             # best-effort fanout
             logger.warning(f"WebSocket send_json failed during metrics fanout: {e}")
+            stale_sockets.append(ws)
+    if stale_sockets:
+        async with WATCHERS_LOCK:
+            remaining = WATCHERS.get(installation_id, [])
+            WATCHERS[installation_id] = [
+                ws for ws in remaining if ws not in stale_sockets
+            ]
+            if not WATCHERS[installation_id]:
+                WATCHERS.pop(installation_id, None)
     return {"status": "ok"}
 
 
@@ -198,21 +273,63 @@ async def get_metrics(installation_id: str, request: Request):
 
 @app.websocket("/ws/{installation_id}")
 async def metrics_websocket(websocket: WebSocket, installation_id: str):
+    client_ip = _client_ip(websocket)
     if API_KEY and not is_api_key_valid(websocket.headers.get("X-API-Key"), API_KEY):
+        _record_websocket_security_event(
+            "denied",
+            installation_id=installation_id,
+            client_ip=client_ip,
+            reason="api_key_invalid",
+        )
         await websocket.close(code=1008)
         return
     if not _validate_installation_id(installation_id):
+        _record_websocket_security_event(
+            "denied",
+            installation_id=installation_id,
+            client_ip=client_ip,
+            reason="invalid_installation_id",
+        )
         await websocket.close(code=1008)
         return
-    await websocket.accept()
-    async with WATCHERS_LOCK:
-        WATCHERS.setdefault(installation_id, []).append(websocket)
+    redis_conn = get_redis_connection()
+    if not redis_conn:
+        _record_websocket_security_event(
+            "denied",
+            installation_id=installation_id,
+            client_ip=client_ip,
+            reason="storage_unavailable",
+        )
+        await websocket.close(code=_websocket_close_try_again_later())
+        return
+    if not _is_registered_installation(redis_conn, installation_id):
+        _record_websocket_security_event(
+            "denied",
+            installation_id=installation_id,
+            client_ip=client_ip,
+            reason="installation_not_registered",
+        )
+        await websocket.close(code=1008)
+        return
+    acquired = await WEBSOCKET_LIMITER.try_acquire(installation_id)
+    if not acquired:
+        _record_websocket_security_event(
+            "denied",
+            installation_id=installation_id,
+            client_ip=client_ip,
+            reason="connection_limit_exceeded",
+        )
+        await websocket.close(code=_websocket_close_try_again_later())
+        return
     try:
-        redis_conn = get_redis_connection()
-        if not redis_conn:
-            await websocket.send_json({"error": "storage unavailable"})
-            await websocket.close()
-            return
+        await websocket.accept()
+        async with WATCHERS_LOCK:
+            WATCHERS.setdefault(installation_id, []).append(websocket)
+        _record_websocket_event(
+            "opened",
+            installation_id=installation_id,
+            client_ip=client_ip,
+        )
 
         key = tenant_key(f"cloud:install:{installation_id}")
 
@@ -229,12 +346,18 @@ async def metrics_websocket(websocket: WebSocket, installation_id: str):
                 return {"error": "corrupted metrics data"}
 
         # Initial snapshot
-        await websocket.send_json(read_metrics())
+        if not await _send_limited_json(
+            websocket, read_metrics(), installation_id=installation_id
+        ):
+            return
 
         # Periodic updates
         while True:
             await asyncio.sleep(WEBSOCKET_METRICS_INTERVAL)
-            await websocket.send_json(read_metrics())
+            if not await _send_limited_json(
+                websocket, read_metrics(), installation_id=installation_id
+            ):
+                break
     except WebSocketDisconnect:
         pass
     finally:
@@ -248,3 +371,9 @@ async def metrics_websocket(websocket: WebSocket, installation_id: str):
                     pass
                 if not lst:
                     WATCHERS.pop(installation_id, None)
+        await WEBSOCKET_LIMITER.release(installation_id)
+        _record_websocket_event(
+            "closed",
+            installation_id=installation_id,
+            client_ip=client_ip,
+        )

--- a/src/shared/observability.py
+++ b/src/shared/observability.py
@@ -10,12 +10,13 @@ structured data that external collectors can scrape.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 import time
 import uuid
-from collections import deque
+from collections import defaultdict, deque
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -189,6 +190,37 @@ class ObservabilityState:
 
     def record_span(self, span: SpanContext) -> None:
         self.trace_buffer.append(span)
+
+
+class WebSocketConnectionLimiter:
+    """Track concurrent websocket connections with optional keyed limits."""
+
+    def __init__(self, *, max_total: int = 0, max_per_key: int = 0) -> None:
+        self.max_total = max_total
+        self.max_per_key = max_per_key
+        self._total = 0
+        self._counts: dict[str, int] = defaultdict(int)
+        self._lock = asyncio.Lock()
+
+    async def try_acquire(self, key: str = "__global__") -> bool:
+        async with self._lock:
+            if self.max_total and self._total >= self.max_total:
+                return False
+            if self.max_per_key and self._counts[key] >= self.max_per_key:
+                return False
+            self._total += 1
+            self._counts[key] += 1
+            return True
+
+    async def release(self, key: str = "__global__") -> None:
+        async with self._lock:
+            count = self._counts.get(key, 0)
+            if count <= 1:
+                self._counts.pop(key, None)
+            elif count > 1:
+                self._counts[key] = count - 1
+            if self._total > 0:
+                self._total -= 1
 
 
 def _get_or_create_state(app: FastAPI) -> ObservabilityState:
@@ -758,6 +790,7 @@ __all__ = [
     "ObservabilitySettings",
     "register_health_check",
     "HealthCheckResult",
+    "WebSocketConnectionLimiter",
     "trace_span",
     "get_request_id",
     "get_current_span",

--- a/test/admin_ui/test_admin_ui.py
+++ b/test/admin_ui/test_admin_ui.py
@@ -10,8 +10,10 @@ from unittest.mock import MagicMock, patch
 import bcrypt
 import pyotp
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from src.admin_ui import admin_ui, auth, blocklist, metrics, webauthn
+from src.shared.observability import WebSocketConnectionLimiter
 
 
 class TestAdminUIComprehensive(unittest.TestCase):
@@ -560,6 +562,52 @@ class TestAdminUIComprehensive(unittest.TestCase):
             data = websocket.receive_json()
         self.assertEqual(data, {"active_connections": 5})
         mock_get_metrics.assert_called()
+
+    @patch("src.admin_ui.metrics.log_event")
+    def test_metrics_websocket_rejects_missing_auth(self, mock_log_event):
+        """WebSocket should reject clients that do not provide auth headers."""
+        with self.assertRaises(WebSocketDisconnect):
+            with self.client.websocket_connect("/ws/metrics"):
+                pass
+        mock_log_event.assert_called()
+        self.assertIn("denied", mock_log_event.call_args.args[1])
+
+    @patch("src.admin_ui.metrics._get_metrics_dict_func")
+    def test_metrics_websocket_rejects_when_connection_limit_exceeded(
+        self, mock_get_metrics
+    ):
+        """WebSocket should reject excess concurrent admin metrics streams."""
+        mock_get_metrics.return_value = {"active_connections": 5}
+        headers = {
+            "Authorization": "Basic YWRtaW46dGVzdHBhc3M=",
+            **self._totp_headers(),
+        }
+        with patch.object(
+            metrics,
+            "WEBSOCKET_LIMITER",
+            WebSocketConnectionLimiter(max_total=1),
+        ):
+            with self.client.websocket_connect("/ws/metrics", headers=headers) as first:
+                self.assertEqual(first.receive_json(), {"active_connections": 5})
+                with self.assertRaises(WebSocketDisconnect):
+                    with self.client.websocket_connect("/ws/metrics", headers=headers):
+                        pass
+
+    @patch("src.admin_ui.metrics._get_metrics_dict_func")
+    def test_metrics_websocket_rejects_oversized_payload(self, mock_get_metrics):
+        """WebSocket should close when a metrics payload exceeds the size cap."""
+        mock_get_metrics.return_value = {"blob": "x" * 128}
+        headers = {
+            "Authorization": "Basic YWRtaW46dGVzdHBhc3M=",
+            **self._totp_headers(),
+        }
+        with patch.object(metrics, "WEBSOCKET_MAX_MESSAGE_BYTES", 32):
+            with self.client.websocket_connect("/ws/metrics", headers=headers) as ws:
+                self.assertEqual(
+                    ws.receive_json(), {"error": "Metrics payload too large"}
+                )
+                with self.assertRaises(WebSocketDisconnect):
+                    ws.receive_json()
 
     @patch("src.admin_ui.metrics.METRICS_TRULY_AVAILABLE", False)
     def test_metrics_websocket_module_unavailable(self):

--- a/test/cloud_dashboard/test_cloud_dashboard_api.py
+++ b/test/cloud_dashboard/test_cloud_dashboard_api.py
@@ -4,8 +4,10 @@ import unittest
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from src.cloud_dashboard import cloud_dashboard_api as cd
+from src.shared.observability import WebSocketConnectionLimiter
 
 
 class TestCloudDashboardAPI(unittest.TestCase):
@@ -76,6 +78,49 @@ class TestCloudDashboardAPI(unittest.TestCase):
             self.assertIn("ws2", cd.WATCHERS)
         self.assertNotIn("ws2", cd.WATCHERS)
 
+    def test_websocket_requires_registered_installation(self):
+        with self.assertRaises(WebSocketDisconnect):
+            with self.client.websocket_connect("/ws/unregistered"):
+                pass
+
+    def test_websocket_rejects_when_connection_limit_exceeded(self):
+        self.client.post("/register", json={"installation_id": "ws-limit"})
+        with patch.object(
+            cd,
+            "WEBSOCKET_LIMITER",
+            WebSocketConnectionLimiter(max_total=1, max_per_key=1),
+        ):
+            with self.client.websocket_connect("/ws/ws-limit") as first:
+                self.assertEqual(first.receive_json(), {})
+                with self.assertRaises(WebSocketDisconnect):
+                    with self.client.websocket_connect("/ws/ws-limit"):
+                        pass
+
+    @patch("src.cloud_dashboard.cloud_dashboard_api.log_event")
+    def test_websocket_rejection_is_audited(self, mock_log_event):
+        with self.assertRaises(WebSocketDisconnect):
+            with self.client.websocket_connect("/ws/not-registered"):
+                pass
+        mock_log_event.assert_called()
+        self.assertIn("denied", mock_log_event.call_args.args[1])
+
+    def test_websocket_rejects_oversized_payload(self):
+        self.client.post("/register", json={"installation_id": "ws-big"})
+        self.client.post(
+            "/metrics",
+            json={
+                "installation_id": "ws-big",
+                "metrics": {"blob": "x" * 128},
+            },
+        )
+        with patch.object(cd, "MAX_WEBSOCKET_MESSAGE_BYTES", 32):
+            with self.client.websocket_connect("/ws/ws-big") as ws:
+                self.assertEqual(
+                    ws.receive_json(), {"error": "Metrics payload too large"}
+                )
+                with self.assertRaises(WebSocketDisconnect):
+                    ws.receive_json()
+
     def test_api_key_enforced_when_configured(self):
         with patch.dict(os.environ, {"CLOUD_DASHBOARD_API_KEY": "sek"}):
             importlib.reload(cd)
@@ -114,6 +159,13 @@ class TestCloudDashboardAPI(unittest.TestCase):
                 self.assertEqual(resp.status_code, 401)
                 resp = client.get("/metrics/x", headers={"X-API-Key": "sek"})
                 self.assertEqual(resp.status_code, 200)
+                with self.assertRaises(WebSocketDisconnect):
+                    with client.websocket_connect("/ws/x"):
+                        pass
+                with client.websocket_connect(
+                    "/ws/x", headers={"X-API-Key": "sek"}
+                ) as ws:
+                    self.assertEqual(ws.receive_json(), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add connection and payload guardrails for the admin metrics websocket and cloud dashboard websocket
- require registered installations for cloud dashboard websocket access and audit websocket accept/reject events
- add regression tests for unauthorized access, connection limits, and oversized payload handling

## Testing
- ./.venv/bin/pre-commit run --files src/shared/observability.py src/admin_ui/metrics.py src/cloud_dashboard/cloud_dashboard_api.py test/admin_ui/test_admin_ui.py test/cloud_dashboard/test_cloud_dashboard_api.py
- ./.venv/bin/python -m pytest -q test/admin_ui/test_admin_ui.py test/cloud_dashboard/test_cloud_dashboard_api.py
- ./.venv/bin/python -m pytest -q test

Closes #1635