### PR TITLE
Enforce container runtime hardening baseline

### DIFF
--- a/config/security_hardening.yaml
+++ b/config/security_hardening.yaml
@@ -2,11 +2,17 @@ version: 1
 
 compose:
   required_services:
+    - nginx_proxy
     - ai_service
     - escalation_engine
     - tarpit_api
+    - admin_ui
+    - captcha_service
+    - cloud_dashboard
     - cloud_proxy
     - config_recommender
+    - prompt_router
+    - blocklist_sync
 
   service_requirements:
     security_opt:
@@ -21,3 +27,65 @@ compose:
   secret_volume_prefixes:
     - "./secrets:/run/secrets"
   secret_volume_readonly: true
+  documented_exceptions:
+    mailhog: "Developer SMTP sink only; upstream image remains a documented dev-only exception."
+    mock_external_api: "CI and local mock dependency; not shipped as part of the hardened production path."
+    apache_proxy: "Alternate local proxy path pending dedicated hardened image/runtime profile."
+    postgres: "Stateful upstream database container uses its own writable runtime layout and entrypoint."
+    redis: "Stateful upstream cache container uses its own writable runtime layout and entrypoint."
+    fail2ban: "Requires host networking and NET_ADMIN/NET_RAW for ban enforcement."
+    suricata: "Requires packet-capture privileges and host networking."
+    traefik: "Third-party ingress control plane with Docker socket access."
+    llama3: "Optional local LLM runtime with model cache and upstream runtime constraints."
+    mixtral: "Optional local LLM runtime with model cache and upstream runtime constraints."
+    prometheus: "Third-party metrics store with upstream runtime profile."
+    grafana: "Third-party dashboard service with persistent writable data directory."
+    watchtower: "Host-level update controller with Docker socket access."
+
+kubernetes:
+  restricted_workloads:
+    admin-ui-deployment.yaml:
+      - admin-ui
+    ai-service-deployment.yaml:
+      - ai-service
+    archive-rotator-deployment.yaml:
+      - archive-rotator
+    corpus-updater-cronjob.yaml:
+      - corpus-updater
+    escalation-engine-deployment.yaml:
+      - escalation-engine
+    markov-model-trainer.yaml:
+      - markov-trainer
+    robots-fetcher-cronjob.yaml:
+      - robots-fetcher
+    tarpit-api-deployment.yaml:
+      - tarpit-api
+    waf-rules-fetcher-cronjob.yaml:
+      - owasp-crs-fetcher
+  documented_exceptions:
+    fail2ban-deployment.yaml: "Requires NET_ADMIN/NET_RAW to enforce bans."
+    nginx-deployment.yaml: "Ingress container still binds 80/443 directly and needs a dedicated capability exception path."
+    postgres-statefulset.yaml: "Stateful upstream database workload with writable storage and upstream runtime defaults."
+    redis-statefulset.yaml: "Stateful upstream cache workload with writable storage and upstream runtime defaults."
+    suricata-deployment.yaml: "Requires packet-capture privileges and relaxed runtime settings."
+
+installers:
+  required_call_tokens:
+    scripts/linux/install.sh:
+      - ensure_no_new_privileges_env
+    scripts/linux/quick_proxy.sh:
+      - ensure_no_new_privileges_env
+    scripts/linux/quick_takeover.sh:
+      - ensure_no_new_privileges_env
+    scripts/macos/install.zsh:
+      - ensure_no_new_privileges_env
+    scripts/macos/quick_proxy.zsh:
+      - ensure_no_new_privileges_env
+    scripts/macos/quick_takeover.zsh:
+      - ensure_no_new_privileges_env
+    scripts/windows/install.ps1:
+      - Ensure-NoNewPrivileges
+    scripts/windows/quick_proxy.ps1:
+      - Ensure-NoNewPrivileges
+    scripts/windows/quick_takeover.ps1:
+      - Ensure-NoNewPrivileges

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
     tmpfs:
       - /tmp
       - /var/run
+    read_only: true
     ports:
       - "${NGINX_HTTP_PORT:-80}:80"
       - "${NGINX_HTTPS_PORT:-443}:443"
@@ -530,6 +531,13 @@ services:
     networks:
       - defense_network
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:${NO_NEW_PRIVILEGES:-true}
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
 
   fail2ban:
     image: crazymax/fail2ban:1.1.0@sha256:a1476ec3587dd7c6756d8cdb448fb0a262c242042d8a71557da6b5aa7aecd911

--- a/docs/SECURITY_BASELINE_GATE.md
+++ b/docs/SECURITY_BASELINE_GATE.md
@@ -14,6 +14,14 @@ runs on pull requests and mainline pushes and must be green before merge.
 - Trivy filesystem scan (container-scan job)
 - Trivy config scan (compose-config-scan job)
 
+The hardening gate is driven by `config/security_hardening.yaml`. That baseline
+must account for every Compose service, every Kubernetes workload, and every
+installer entrypoint as either:
+
+- a strict baseline target that enforces non-root / no-new-privileges /
+  capability-drop / read-only filesystem controls, or
+- a documented exception with an explicit operational reason
+
 Optional:
 - `kubernetes-dependency-audit` runs only on manual dispatch with
   `audit_kubernetes=true`.
@@ -30,7 +38,7 @@ Optional:
 - Trivy findings do not fail the job by default (exit-code set to `0`); treat
   findings as follow-up issues if needed.
 - If baseline checks fail, fix the underlying issue or update the baseline
-  (e.g., security hardening config) and re-run the workflow.
+  (for example `config/security_hardening.yaml`) and re-run the workflow.
 
 ## Deep scan scripts
 

--- a/docs/installer_contract.md
+++ b/docs/installer_contract.md
@@ -10,6 +10,17 @@ Platform wrappers may still exist for operator convenience, but they should
 delegate to this shared contract where possible instead of re-implementing the
 health checks independently.
 
+## Runtime Hardening Contract
+
+Installers and proxy helpers must preserve the runtime hardening baseline rather
+than silently weakening it. In practice that means:
+
+- Linux and macOS entrypoints call `ensure_no_new_privileges_env`
+- Windows entrypoints call `Ensure-NoNewPrivileges`
+- any unavoidable local-runtime exception (for example the documented
+  `docker-compose.local.yaml` workaround for snap-packaged Docker) is explicit
+  and opt-in rather than baked into the default install path
+
 ## Required Success Output
 
 Installers should surface smoke-test results as line-oriented text:

--- a/kubernetes/admin-ui-deployment.yaml
+++ b/kubernetes/admin-ui-deployment.yaml
@@ -27,6 +27,13 @@ spec:
       labels:
         app: admin-ui
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: admin-ui
         # IMPORTANT: Replace with your actual container image registry and tag.
@@ -43,6 +50,11 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
         envFrom:
         - configMapRef:
             name: app-config
@@ -50,6 +62,9 @@ spec:
             name: admin-ui-credentials
         - secretRef:
             name: redis-credentials
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         readinessProbe:
           httpGet:
             path: /health
@@ -62,3 +77,6 @@ spec:
             port: 5002
           initialDelaySeconds: 10
           periodSeconds: 10
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/kubernetes/ai-service-deployment.yaml
+++ b/kubernetes/ai-service-deployment.yaml
@@ -27,6 +27,13 @@ spec:
       labels:
         app: ai-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: ai-service
         image: your-registry/ai-scraping-defense:latest
@@ -45,6 +52,14 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         readinessProbe:
           httpGet:
             path: /health
@@ -57,6 +72,9 @@ spec:
             port: 8000
           initialDelaySeconds: 10
           periodSeconds: 10
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/kubernetes/archive-rotator-deployment.yaml
+++ b/kubernetes/archive-rotator-deployment.yaml
@@ -14,6 +14,13 @@ spec:
       labels:
         app: archive-rotator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: archive-rotator
         image: your-registry/ai-scraping-defense:latest
@@ -30,10 +37,19 @@ spec:
           limits:
             memory: "256Mi"
             cpu: "500m"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
         volumeMounts:
         - name: archives-storage
           mountPath: /app/archives
+        - name: tmp
+          mountPath: /tmp
       volumes:
       - name: archives-storage
         persistentVolumeClaim:
           claimName: archives-pvc
+      - name: tmp
+        emptyDir: {}

--- a/kubernetes/corpus-updater-cronjob.yaml
+++ b/kubernetes/corpus-updater-cronjob.yaml
@@ -11,6 +11,13 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: corpus-updater
             image: your-registry/ai-scraping-defense:latest
@@ -24,14 +31,23 @@ spec:
               limits:
                 cpu: "500m"
                 memory: "512Mi"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
             env:
             - name: CORPUS_FILE_PATH
               value: "/corpus_data/wikipedia_corpus.txt"
             volumeMounts:
             - name: corpus-storage
               mountPath: /corpus_data
+            - name: tmp
+              mountPath: /tmp
           restartPolicy: OnFailure
           volumes:
           - name: corpus-storage
             persistentVolumeClaim:
               claimName: corpus-data-pvc
+          - name: tmp
+            emptyDir: {}

--- a/kubernetes/escalation-engine-deployment.yaml
+++ b/kubernetes/escalation-engine-deployment.yaml
@@ -27,6 +27,13 @@ spec:
       labels:
         app: escalation-engine
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: escalation-engine
         image: your-registry/ai-scraping-defense:latest
@@ -49,6 +56,11 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
         readinessProbe:
           httpGet:
             path: /health
@@ -65,7 +77,11 @@ spec:
         - name: models-storage
           mountPath: /app/models
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
       volumes:
       - name: models-storage
         persistentVolumeClaim:
           claimName: models-pvc
+      - name: tmp
+        emptyDir: {}

--- a/kubernetes/markov-model-trainer.yaml
+++ b/kubernetes/markov-model-trainer.yaml
@@ -11,6 +11,13 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: markov-trainer
             image: your-registry/ai-scraping-defense:latest
@@ -24,6 +31,11 @@ spec:
               limits:
                 cpu: "1000m"
                 memory: "2Gi"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
             envFrom:
             - configMapRef:
                 name: app-config
@@ -36,8 +48,12 @@ spec:
             - name: corpus-storage
               mountPath: /corpus_data
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           restartPolicy: OnFailure
           volumes:
           - name: corpus-storage
             persistentVolumeClaim:
               claimName: corpus-data-pvc
+          - name: tmp
+            emptyDir: {}

--- a/kubernetes/robots-fetcher-cronjob.yaml
+++ b/kubernetes/robots-fetcher-cronjob.yaml
@@ -14,6 +14,13 @@ spec:
           # This job requires special permissions to edit ConfigMaps,
           # so it needs a dedicated ServiceAccount.
           serviceAccountName: configmap-editor-sa
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: robots-fetcher
             image: your-registry/ai-scraping-defense:latest
@@ -27,6 +34,11 @@ spec:
               limits:
                 cpu: "250m"
                 memory: "256Mi"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
             env:
             - name: REAL_BACKEND_HOST
               value: "http://nginx-proxy.ai-defense.svc.cluster.local"
@@ -38,4 +50,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           restartPolicy: OnFailure
+          volumes:
+          - name: tmp
+            emptyDir: {}

--- a/scripts/security/run_static_security_checks.py
+++ b/scripts/security/run_static_security_checks.py
@@ -22,11 +22,17 @@ def _fail(message: str) -> None:
 DEFAULT_HARDENING_BASELINE: Dict[str, Any] = {
     "compose": {
         "required_services": [
+            "nginx_proxy",
             "ai_service",
             "escalation_engine",
             "tarpit_api",
+            "admin_ui",
+            "captcha_service",
+            "cloud_dashboard",
             "cloud_proxy",
             "config_recommender",
+            "prompt_router",
+            "blocklist_sync",
         ],
         "service_requirements": {
             "security_opt": ["no-new-privileges:true"],
@@ -37,8 +43,27 @@ DEFAULT_HARDENING_BASELINE: Dict[str, Any] = {
         },
         "secret_volume_prefixes": ["./secrets:/run/secrets"],
         "secret_volume_readonly": True,
-    }
+        "documented_exceptions": {},
+    },
+    "kubernetes": {
+        "restricted_workloads": {
+            "admin-ui-deployment.yaml": ["admin-ui"],
+            "ai-service-deployment.yaml": ["ai-service"],
+            "archive-rotator-deployment.yaml": ["archive-rotator"],
+            "corpus-updater-cronjob.yaml": ["corpus-updater"],
+            "escalation-engine-deployment.yaml": ["escalation-engine"],
+            "markov-model-trainer.yaml": ["markov-trainer"],
+            "robots-fetcher-cronjob.yaml": ["robots-fetcher"],
+            "tarpit-api-deployment.yaml": ["tarpit-api"],
+            "waf-rules-fetcher-cronjob.yaml": ["owasp-crs-fetcher"],
+        },
+        "documented_exceptions": {},
+    },
+    "installers": {
+        "required_call_tokens": {},
+    },
 }
+WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"}
 
 
 def _load_hardening_baseline() -> Dict[str, Any]:
@@ -50,6 +75,12 @@ def _load_hardening_baseline() -> Dict[str, Any]:
     merged_compose = dict(DEFAULT_HARDENING_BASELINE.get("compose", {}))
     merged_compose.update(baseline.get("compose", {}))
     merged["compose"] = merged_compose
+    merged_kubernetes = dict(DEFAULT_HARDENING_BASELINE.get("kubernetes", {}))
+    merged_kubernetes.update(baseline.get("kubernetes", {}))
+    merged["kubernetes"] = merged_kubernetes
+    merged_installers = dict(DEFAULT_HARDENING_BASELINE.get("installers", {}))
+    merged_installers.update(baseline.get("installers", {}))
+    merged["installers"] = merged_installers
     return merged
 
 
@@ -66,6 +97,33 @@ def _matches_required_value(actual: Any, expected: str) -> bool:
             )
         )
     return False
+
+
+def _extract_pod_spec(document: Dict[str, Any]) -> Dict[str, Any]:
+    kind = document.get("kind")
+    spec = document.get("spec") or {}
+    if kind in {"Deployment", "StatefulSet", "DaemonSet", "Job"}:
+        return ((spec.get("template") or {}).get("spec")) or {}
+    if kind == "CronJob":
+        return (
+            (
+                (((spec.get("jobTemplate") or {}).get("spec") or {}).get("template"))
+                or {}
+            )
+        ).get("spec", {})
+    return {}
+
+
+def _iter_kubernetes_workloads() -> (
+    Iterable[tuple[Path, Dict[str, Any], Dict[str, Any]]]
+):
+    for manifest_path in sorted((PROJECT_ROOT / "kubernetes").glob("*.y*ml")):
+        for document in yaml.safe_load_all(manifest_path.read_text()):
+            if not isinstance(document, dict):
+                continue
+            if document.get("kind") not in WORKLOAD_KINDS:
+                continue
+            yield manifest_path, document, _extract_pod_spec(document)
 
 
 def ensure_nginx_headers_and_limits() -> None:
@@ -109,6 +167,21 @@ def ensure_compose_security() -> None:
 
     compose = yaml.safe_load((PROJECT_ROOT / "docker-compose.yaml").read_text())
     services = compose.get("services", {})
+    documented_exceptions = compose_baseline.get("documented_exceptions", {})
+    covered_services = set(required_services) | set(documented_exceptions)
+    missing_coverage = sorted(set(services) - covered_services)
+    if missing_coverage:
+        _fail(
+            "docker-compose services missing hardening coverage: "
+            + ", ".join(missing_coverage)
+        )
+    stale_exceptions = sorted(set(documented_exceptions) - set(services))
+    if stale_exceptions:
+        _fail(
+            "security_hardening.yaml lists stale compose exceptions: "
+            + ", ".join(stale_exceptions)
+        )
+
     for service_name in required_services:
         service = services.get(service_name)
         if not service:
@@ -145,6 +218,99 @@ def ensure_compose_security() -> None:
                     _fail("Secret volumes must be read-only")
 
 
+def ensure_kubernetes_runtime_security() -> None:
+    baseline = _load_hardening_baseline()
+    kubernetes_baseline = baseline.get("kubernetes", {})
+    restricted_workloads = kubernetes_baseline.get("restricted_workloads", {})
+    documented_exceptions = kubernetes_baseline.get("documented_exceptions", {})
+
+    discovered_workloads = {
+        path.name: (document, pod_spec)
+        for path, document, pod_spec in _iter_kubernetes_workloads()
+    }
+    covered_workloads = set(restricted_workloads) | set(documented_exceptions)
+    missing_coverage = sorted(set(discovered_workloads) - covered_workloads)
+    if missing_coverage:
+        _fail(
+            "Kubernetes workloads missing hardening coverage: "
+            + ", ".join(missing_coverage)
+        )
+    stale_coverage = sorted(covered_workloads - set(discovered_workloads))
+    if stale_coverage:
+        _fail(
+            "security_hardening.yaml lists stale Kubernetes entries: "
+            + ", ".join(stale_coverage)
+        )
+
+    for manifest_name, required_containers in restricted_workloads.items():
+        _, pod_spec = discovered_workloads[manifest_name]
+        pod_security_context = pod_spec.get("securityContext") or {}
+        if pod_security_context.get("runAsNonRoot") is not True:
+            _fail(f"{manifest_name} must set pod securityContext.runAsNonRoot=true")
+        if pod_security_context.get("runAsUser") != 1000:
+            _fail(f"{manifest_name} must set pod securityContext.runAsUser=1000")
+        if pod_security_context.get("runAsGroup") != 1000:
+            _fail(f"{manifest_name} must set pod securityContext.runAsGroup=1000")
+        if pod_security_context.get("fsGroup") != 1000:
+            _fail(f"{manifest_name} must set pod securityContext.fsGroup=1000")
+        if (
+            pod_security_context.get("seccompProfile", {}).get("type")
+            != "RuntimeDefault"
+        ):
+            _fail(
+                f"{manifest_name} must set pod securityContext.seccompProfile.type=RuntimeDefault"
+            )
+
+        volumes = {
+            volume.get("name"): volume for volume in (pod_spec.get("volumes") or [])
+        }
+        if "tmp" not in volumes or "emptyDir" not in volumes["tmp"]:
+            _fail(f"{manifest_name} must define an emptyDir tmp volume")
+
+        containers = {
+            container.get("name"): container
+            for container in (pod_spec.get("containers") or [])
+        }
+        for container_name in required_containers:
+            container = containers.get(container_name)
+            if not container:
+                _fail(f"{manifest_name} missing container {container_name}")
+            security_context = container.get("securityContext") or {}
+            if security_context.get("allowPrivilegeEscalation") is not False:
+                _fail(
+                    f"{manifest_name}:{container_name} must set allowPrivilegeEscalation=false"
+                )
+            if security_context.get("readOnlyRootFilesystem") is not True:
+                _fail(
+                    f"{manifest_name}:{container_name} must set readOnlyRootFilesystem=true"
+                )
+            if security_context.get("capabilities", {}).get("drop") != ["ALL"]:
+                _fail(f"{manifest_name}:{container_name} must drop all capabilities")
+            volume_mounts = {
+                mount.get("name"): mount
+                for mount in (container.get("volumeMounts") or [])
+            }
+            if volume_mounts.get("tmp", {}).get("mountPath") != "/tmp":
+                _fail(f"{manifest_name}:{container_name} must mount tmp at /tmp")
+
+
+def ensure_installer_hardening_hooks() -> None:
+    baseline = _load_hardening_baseline()
+    required_call_tokens = baseline.get("installers", {}).get(
+        "required_call_tokens", {}
+    )
+    for relative_path, tokens in required_call_tokens.items():
+        file_path = PROJECT_ROOT / relative_path
+        if not file_path.exists():
+            _fail(
+                f"Missing installer path referenced by hardening baseline: {relative_path}"
+            )
+        contents = file_path.read_text()
+        for token in tokens:
+            if token not in contents:
+                _fail(f"{relative_path} missing required hardening call: {token}")
+
+
 SECRET_PATTERN = re.compile(r"=(?:sk-|AIza|mistral-|coh-|key-for-)")
 
 
@@ -163,6 +329,8 @@ def ensure_no_plaintext_secrets() -> None:
 CHECKS: Iterable[Callable[[], None]] = (
     ensure_nginx_headers_and_limits,
     ensure_compose_security,
+    ensure_kubernetes_runtime_security,
+    ensure_installer_hardening_hooks,
     ensure_no_plaintext_secrets,
 )
 

--- a/test/test_security_baselines.py
+++ b/test/test_security_baselines.py
@@ -2,14 +2,13 @@ from pathlib import Path
 
 import yaml
 
-HARDENED_SERVICES = {
-    "ai_service",
-    "escalation_engine",
-    "tarpit_api",
-    "cloud_proxy",
-    "config_recommender",
-}
 WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"}
+BASELINE = yaml.safe_load(Path("config/security_hardening.yaml").read_text())
+HARDENED_SERVICES = set(BASELINE["compose"]["required_services"])
+COMPOSE_EXCEPTIONS = set(BASELINE["compose"]["documented_exceptions"])
+RESTRICTED_WORKLOADS = BASELINE["kubernetes"]["restricted_workloads"]
+KUBERNETES_EXCEPTIONS = set(BASELINE["kubernetes"]["documented_exceptions"])
+INSTALLER_CALL_TOKENS = BASELINE["installers"]["required_call_tokens"]
 
 
 def _load_compose() -> dict:
@@ -98,6 +97,13 @@ def test_compose_services_drop_privileges():
         assert any(str(volume).endswith(":ro") for volume in volumes)
 
 
+def test_compose_services_have_full_hardening_coverage():
+    compose = _load_compose()
+    services = set(compose.get("services", {}))
+
+    assert services == HARDENED_SERVICES | COMPOSE_EXCEPTIONS
+
+
 def test_compose_mounts_secret_directory_read_only():
     compose = _load_compose()
     services = compose.get("services", {})
@@ -124,15 +130,19 @@ def test_kubernetes_workloads_define_resource_limits():
     )
 
 
-def test_selected_kubernetes_workloads_define_restricted_security_contexts():
-    required_workloads = {
-        "tarpit-api-deployment.yaml": {"tarpit-api"},
-        "waf-rules-fetcher-cronjob.yaml": {"owasp-crs-fetcher"},
+def test_kubernetes_workloads_have_full_hardening_coverage():
+    discovered = {
+        manifest_path.name for manifest_path, _, _ in _iter_kubernetes_workload_specs()
     }
-    seen = {name: set() for name in required_workloads}
+
+    assert discovered == set(RESTRICTED_WORKLOADS) | KUBERNETES_EXCEPTIONS
+
+
+def test_selected_kubernetes_workloads_define_restricted_security_contexts():
+    seen = {name: set() for name in RESTRICTED_WORKLOADS}
 
     for manifest_path, _, pod_spec in _iter_kubernetes_workload_specs():
-        required_containers = required_workloads.get(manifest_path.name)
+        required_containers = RESTRICTED_WORKLOADS.get(manifest_path.name)
         if not required_containers:
             continue
 
@@ -140,6 +150,7 @@ def test_selected_kubernetes_workloads_define_restricted_security_contexts():
         assert pod_security_context.get("runAsNonRoot") is True
         assert pod_security_context.get("runAsUser") == 1000
         assert pod_security_context.get("runAsGroup") == 1000
+        assert pod_security_context.get("fsGroup") == 1000
         assert pod_security_context.get("seccompProfile", {}).get("type") == (
             "RuntimeDefault"
         )
@@ -162,5 +173,12 @@ def test_selected_kubernetes_workloads_define_restricted_security_contexts():
             }
             assert volume_mounts.get("tmp", {}).get("mountPath") == "/tmp"
 
-    for manifest_name, container_names in required_workloads.items():
-        assert seen[manifest_name] == container_names
+    for manifest_name, container_names in RESTRICTED_WORKLOADS.items():
+        assert seen[manifest_name] == set(container_names)
+
+
+def test_installer_scripts_preserve_no_new_privileges_detection():
+    for relative_path, tokens in INSTALLER_CALL_TOKENS.items():
+        contents = Path(relative_path).read_text()
+        for token in tokens:
+            assert token in contents


### PR DESCRIPTION
## Summary\n- codify the runtime hardening baseline in config/security_hardening.yaml across Compose, Kubernetes, and installers\n- harden the remaining first-party Compose services and selected Kubernetes workloads to match the baseline\n- extend static checks and security baseline tests so undocumented runtime-hardening drift fails CI\n\n## Testing\n- ./.venv/bin/pre-commit run --files config/security_hardening.yaml docker-compose.yaml docs/SECURITY_BASELINE_GATE.md docs/installer_contract.md kubernetes/admin-ui-deployment.yaml kubernetes/ai-service-deployment.yaml kubernetes/archive-rotator-deployment.yaml kubernetes/corpus-updater-cronjob.yaml kubernetes/escalation-engine-deployment.yaml kubernetes/markov-model-trainer.yaml kubernetes/robots-fetcher-cronjob.yaml scripts/security/run_static_security_checks.py test/test_security_baselines.py\n- ./.venv/bin/python scripts/security/run_static_security_checks.py\n- ./.venv/bin/python -m pytest -q test/test_security_baselines.py test/scripts/test_run_static_security_checks.py\n- ./.venv/bin/python -m pytest -q test\n\nCloses #1633