### PR TITLE
Persist and export security events

### DIFF
--- a/docs/security/monitoring_and_response.md
+++ b/docs/security/monitoring_and_response.md
@@ -9,6 +9,14 @@ in production.
 - **Log aggregation** – All services emit JSON-formatted audit events via
   `src/shared/audit.py`. Forward `/app/logs/audit.log` and service-specific logs
   to a centralized SIEM (e.g., Elastic, Splunk). Retain logs for 180 days.
+- **Durable security events** – Security-relevant audit, decision, alert-delivery,
+  and operational events are also persisted to `SECURITY_EVENTS_DB_PATH`
+  (default: `/app/data/security_events.db`) through `src/shared/security_events.py`.
+  Export them without scraping ad hoc logs:
+
+  ```bash
+  python scripts/export_security_events.py --output reports/security-events.jsonl
+  ```
 - **Metrics** – Expose FastAPI metrics via `prometheus-client` and scrape
   latency, error rates, and rate-limit violations. Alerts trigger when 5xx rates
   exceed 1% of traffic or rate-limit denials spike for 10 minutes.
@@ -23,6 +31,8 @@ in production.
 - **Coverage** – All authentication flows log success/failure events via
   `src/shared/audit.log_event`. Ensure API controllers record user ID, IP, and
   action scope.
+- **Export** – JSONL exports redact secrets and direct IP fields before writing
+  investigation artifacts suitable for SIEM ingestion or offline review.
 - **Protection** – File permissions hardened to `600`. Rotate audit logs daily
   and back up to encrypted object storage with bucket policies enforcing
   write-only access from workloads.

--- a/scripts/export_security_events.py
+++ b/scripts/export_security_events.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Export durable security events as JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from src.shared.security_events import export_security_events
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output")
+    parser.add_argument("--limit", type=int, default=1000)
+    parser.add_argument("--event-type")
+    args = parser.parse_args(argv)
+
+    count, jsonl = export_security_events(
+        output_path=args.output,
+        limit=args.limit,
+        event_type=args.event_type,
+    )
+    if args.output:
+        print(f"Exported {count} security events to {args.output}")
+    else:
+        sys.stdout.write(jsonl)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/shared/audit.py
+++ b/src/shared/audit.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from .log_filter import configure_sensitive_logging
+from .security_events import record_security_event
 
 LOG_PATH = os.getenv("AUDIT_LOG_FILE", "/app/logs/audit.log")
 _audit_log_available = False
@@ -68,3 +69,13 @@ def log_event(user: str, action: str, details: Optional[dict] = None) -> None:
     if details:
         msg += "\t" + json.dumps(details, sort_keys=True)
     logger.info(msg)
+    try:
+        record_security_event(
+            "audit_event",
+            actor=user,
+            action=action,
+            source="audit",
+            payload=details or {},
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to persist audit security event: %s", exc)

--- a/src/shared/decision_db.py
+++ b/src/shared/decision_db.py
@@ -7,6 +7,7 @@ import sqlite3
 from contextlib import contextmanager
 
 from src.shared.config import CONFIG
+from src.shared.security_events import record_security_event
 
 DEFAULT_DB_DIR = "/app/data"
 DB_PATH = os.getenv(
@@ -81,3 +82,21 @@ def record_decision(
                 timestamp,
             ),
         )
+    try:
+        record_security_event(
+            "security_decision",
+            actor=tid,
+            action=action,
+            source=source,
+            severity="high" if action in {"block", "tarpit"} else "info",
+            payload={
+                "tenant_id": tid,
+                "ip": ip,
+                "score": score,
+                "is_bot": is_bot,
+                "timestamp": timestamp,
+            },
+            created_at=timestamp,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logging.warning("Failed to persist decision security event: %s", exc)

--- a/src/shared/http_alert.py
+++ b/src/shared/http_alert.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 from .http_client import AsyncHttpClient, httpx
+from .security_events import record_security_event
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,25 @@ def _safe_endpoint_for_logs(url: str) -> str:
         origin = "<invalid-url>"
     fp = hashlib.sha256(url.encode("utf-8")).hexdigest()[:10]
     return f"{origin} (id={fp})"
+
+
+def _record_delivery_event(
+    action: str,
+    *,
+    severity: str,
+    payload: dict[str, Any],
+) -> None:
+    try:
+        record_security_event(
+            "alert_delivery",
+            actor="system",
+            action=action,
+            source="http_alert",
+            severity=severity,
+            payload=payload,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to persist alert delivery event: %s", exc)
 
 
 class AlertDeliveryError(Exception):
@@ -216,6 +236,16 @@ class HttpAlertSender:
                 safe_endpoint,
                 response.status_code,
             )
+            _record_delivery_event(
+                "delivered",
+                severity="info",
+                payload={
+                    "alert_type": payload.get("alert_type"),
+                    "alert_severity": payload.get("severity"),
+                    "endpoint": safe_endpoint,
+                    "status_code": response.status_code,
+                },
+            )
             return True
 
         except httpx.TimeoutException:
@@ -223,6 +253,11 @@ class HttpAlertSender:
                 "Timeout delivering alert to %s (attempts %s)",
                 safe_endpoint,
                 max_attempts,
+            )
+            _record_delivery_event(
+                "timeout",
+                severity="warning",
+                payload={"endpoint": safe_endpoint, "attempts": max_attempts},
             )
 
         except httpx.HTTPStatusError as e:
@@ -236,6 +271,16 @@ class HttpAlertSender:
                 max_attempts,
                 response_body,
             )
+            _record_delivery_event(
+                "http_error",
+                severity="warning",
+                payload={
+                    "endpoint": safe_endpoint,
+                    "attempts": max_attempts,
+                    "status_code": e.response.status_code,
+                    "response_body": response_body,
+                },
+            )
 
         except httpx.RequestError as e:
             logger.error(
@@ -244,6 +289,15 @@ class HttpAlertSender:
                 max_attempts,
                 e,
             )
+            _record_delivery_event(
+                "request_error",
+                severity="warning",
+                payload={
+                    "endpoint": safe_endpoint,
+                    "attempts": max_attempts,
+                    "error": str(e),
+                },
+            )
 
         except Exception as e:
             logger.error(
@@ -251,6 +305,15 @@ class HttpAlertSender:
                 safe_endpoint,
                 max_attempts,
                 e,
+            )
+            _record_delivery_event(
+                "unexpected_error",
+                severity="warning",
+                payload={
+                    "endpoint": safe_endpoint,
+                    "attempts": max_attempts,
+                    "error": str(e),
+                },
             )
 
         logger.error("Failed to deliver alert after %s attempts", max_attempts)

--- a/src/shared/operational_events.py
+++ b/src/shared/operational_events.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from src.shared.metrics import OPERATIONAL_EVENTS
 from src.shared.redis_client import get_redis_connection
+from src.shared.security_events import record_security_event
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,18 @@ def publish_operational_event(
 ) -> Optional[str]:
     """Publish an operational event to Redis when enabled."""
     OPERATIONAL_EVENTS.labels(event_type=event_type).inc()
+    try:
+        record_security_event(
+            "operational_event",
+            actor="system",
+            action=event_type,
+            source=str(payload.get("source", "operational_event")),
+            severity="warning" if "failed" in event_type else "info",
+            payload=payload,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to persist operational security event: %s", exc)
+
     if not _events_enabled():
         return None
 

--- a/src/shared/security_events.py
+++ b/src/shared/security_events.py
@@ -1,0 +1,220 @@
+"""Durable security-event storage and export helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+DEFAULT_DB_DIR = "/app/data"
+DB_PATH = os.getenv(
+    "SECURITY_EVENTS_DB_PATH",
+    os.path.join(DEFAULT_DB_DIR, "security_events.db"),
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+except OSError as exc:
+    logger.warning(
+        "Cannot create security event DB in %s: %s. Using temp dir.", DB_PATH, exc
+    )
+    DB_PATH = os.path.join(tempfile.gettempdir(), "security_events.db")
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS security_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    action TEXT,
+    source TEXT,
+    severity TEXT NOT NULL,
+    ip TEXT,
+    path TEXT,
+    payload_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_security_events_created_at
+    ON security_events (created_at);
+CREATE INDEX IF NOT EXISTS idx_security_events_type
+    ON security_events (event_type);
+CREATE INDEX IF NOT EXISTS idx_security_events_source
+    ON security_events (source);
+"""
+
+IP_FIELD_NAMES = {
+    "client_ip",
+    "forwarded_for",
+    "ip",
+    "ip_address",
+    "remote_ip",
+    "source_ip",
+}
+PATH_FIELD_NAMES = {"path", "request_path", "route"}
+SENSITIVE_FIELD_TOKENS = (
+    "api_key",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "secret",
+    "token",
+    "webhook",
+)
+
+
+def _is_sensitive_field(field_name: str | None) -> bool:
+    if not field_name:
+        return False
+    normalized = field_name.lower()
+    return any(token in normalized for token in SENSITIVE_FIELD_TOKENS)
+
+
+def redact_sensitive_data(value: Any, field_name: str | None = None) -> Any:
+    """Redact secrets while preserving enough structure for investigation."""
+    if isinstance(value, dict):
+        return {key: redact_sensitive_data(item, key) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact_sensitive_data(item, field_name) for item in value]
+    if isinstance(value, tuple):
+        return [redact_sensitive_data(item, field_name) for item in value]
+    if field_name and field_name.lower() in IP_FIELD_NAMES:
+        return "[REDACTED_IP]"
+    if _is_sensitive_field(field_name):
+        return "<redacted>"
+    return value
+
+
+def _extract_first(payload: dict[str, Any], field_names: Iterable[str]) -> str | None:
+    for field_name in field_names:
+        value = payload.get(field_name)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+@contextmanager
+def get_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.executescript(SCHEMA)
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def record_security_event(
+    event_type: str,
+    *,
+    actor: str = "system",
+    action: str | None = None,
+    source: str | None = None,
+    severity: str = "info",
+    payload: Optional[dict[str, Any]] = None,
+    created_at: str | None = None,
+) -> int:
+    """Persist a structured security event and return its row id."""
+    event_payload = redact_sensitive_data(payload or {})
+    event_created_at = created_at or datetime.now(timezone.utc).isoformat()
+    with get_conn() as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO security_events (
+                created_at,
+                event_type,
+                actor,
+                action,
+                source,
+                severity,
+                ip,
+                path,
+                payload_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_created_at,
+                event_type,
+                actor,
+                action,
+                source,
+                severity,
+                _extract_first(event_payload, IP_FIELD_NAMES),
+                _extract_first(event_payload, PATH_FIELD_NAMES),
+                json.dumps(event_payload, sort_keys=True, default=str),
+            ),
+        )
+        return int(cursor.lastrowid)
+
+
+def load_security_events(
+    *, limit: int = 1000, event_type: str | None = None
+) -> list[dict[str, Any]]:
+    """Load stored security events in newest-first order."""
+    query = """
+        SELECT
+            id,
+            created_at,
+            event_type,
+            actor,
+            action,
+            source,
+            severity,
+            ip,
+            path,
+            payload_json
+        FROM security_events
+    """
+    parameters: list[Any] = []
+    if event_type:
+        query += " WHERE event_type = ?"
+        parameters.append(event_type)
+    query += " ORDER BY id DESC LIMIT ?"
+    parameters.append(limit)
+    with get_conn() as conn:
+        rows = conn.execute(query, parameters).fetchall()
+
+    events = []
+    for row in reversed(rows):
+        payload_json = row[9] or "{}"
+        events.append(
+            {
+                "id": row[0],
+                "created_at": row[1],
+                "event_type": row[2],
+                "actor": row[3],
+                "action": row[4],
+                "source": row[5],
+                "severity": row[6],
+                "ip": row[7],
+                "path": row[8],
+                "payload": json.loads(payload_json),
+            }
+        )
+    return events
+
+
+def export_security_events(
+    *,
+    output_path: str | None = None,
+    limit: int = 1000,
+    event_type: str | None = None,
+) -> tuple[int, str]:
+    """Export events as JSONL and optionally write them to disk."""
+    events = load_security_events(limit=limit, event_type=event_type)
+    jsonl = "\n".join(json.dumps(event, sort_keys=True) for event in events)
+    if jsonl:
+        jsonl += "\n"
+    if output_path:
+        destination = Path(output_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(jsonl, encoding="utf-8")
+    return len(events), jsonl

--- a/test/scripts/test_export_security_events.py
+++ b/test/scripts/test_export_security_events.py
@@ -1,0 +1,34 @@
+import json
+
+from scripts import export_security_events
+
+
+def test_main_writes_jsonl_to_stdout(monkeypatch, capsys):
+    monkeypatch.setattr(
+        export_security_events,
+        "export_security_events",
+        lambda **_kwargs: (
+            1,
+            json.dumps({"event_type": "audit_event", "payload": {}}) + "\n",
+        ),
+    )
+
+    rc = export_security_events.main([])
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert '"event_type": "audit_event"' in captured.out
+
+
+def test_main_reports_output_path(monkeypatch, capsys):
+    monkeypatch.setattr(
+        export_security_events,
+        "export_security_events",
+        lambda **_kwargs: (3, ""),
+    )
+
+    rc = export_security_events.main(["--output", "reports/security-events.jsonl"])
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert "Exported 3 security events" in captured.out

--- a/test/shared/test_audit.py
+++ b/test/shared/test_audit.py
@@ -58,3 +58,19 @@ class TestAuditLogging(unittest.TestCase):
         assert '"ip": "[REDACTED_IP]"' in line
         assert '"api_key": "<redacted>"' in line
         assert '"password": "<redacted>"' in line
+
+    def test_log_event_persists_security_event(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = os.path.join(tmpdir, "audit.log")
+            with patch.dict(os.environ, {"AUDIT_LOG_FILE": log_file}):
+                from src.shared import audit
+
+                self.audit = audit
+                for h in list(audit.logger.handlers):
+                    audit.logger.removeHandler(h)
+                importlib.reload(audit)
+                with patch.object(audit, "record_security_event") as mock_record_event:
+                    audit.log_event("user", "action", {"path": "/admin"})
+
+        mock_record_event.assert_called_once()
+        self.assertEqual(mock_record_event.call_args.kwargs["action"], "action")

--- a/test/shared/test_decision_db.py
+++ b/test/shared/test_decision_db.py
@@ -101,6 +101,18 @@ class TestRecordDecision(unittest.TestCase):
 
         self.assertEqual(tid, "tenantX")
 
+    def test_record_decision_persists_security_event(self):
+        db_module = self.reload_module_with_temp_db()
+
+        with patch.object(db_module, "record_security_event") as mock_record_event:
+            db_module.record_decision(
+                "7.7.7.7", "unit_test", 0.95, 1, "block", "2024-04-04T00:00:00Z"
+            )
+
+        mock_record_event.assert_called_once()
+        self.assertEqual(mock_record_event.call_args.kwargs["action"], "block")
+        self.assertEqual(mock_record_event.call_args.kwargs["payload"]["ip"], "7.7.7.7")
+
     def test_directory_creation_failure(self):
         """Test that directory creation failure falls back to temp directory."""
         error = OSError("Permission denied")

--- a/test/shared/test_http_alert.py
+++ b/test/shared/test_http_alert.py
@@ -1,3 +1,6 @@
+import pytest
+
+from src.shared import http_alert
 from src.shared.http_alert import _safe_endpoint_for_logs
 
 
@@ -15,3 +18,37 @@ def test_safe_endpoint_for_logs_redacts_path_and_query() -> None:
 def test_safe_endpoint_for_logs_handles_invalid_url() -> None:
     safe = _safe_endpoint_for_logs("not a url")
     assert safe.startswith("<invalid-url>")
+
+
+@pytest.mark.asyncio
+async def test_send_alert_records_delivery_event(monkeypatch) -> None:
+    class DummyResponse:
+        status_code = 204
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def async_post_json(self, *_args, **_kwargs):
+            return DummyResponse()
+
+    recorded = []
+    monkeypatch.setattr(http_alert, "AsyncHttpClient", lambda **_kwargs: DummyClient())
+    monkeypatch.setattr(
+        http_alert,
+        "_record_delivery_event",
+        lambda action, severity, payload: recorded.append((action, severity, payload)),
+    )
+
+    sender = http_alert.HttpAlertSender("https://example.com/hooks/secret")
+    result = await sender.send_alert({"alert_type": "security", "severity": "high"})
+
+    assert result is True
+    assert recorded
+    assert recorded[0][0] == "delivered"

--- a/test/shared/test_operational_events.py
+++ b/test/shared/test_operational_events.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from src.shared import operational_events
+
+
+def test_publish_operational_event_persists_security_event():
+    with (
+        patch.object(operational_events, "record_security_event") as mock_record,
+        patch.object(operational_events, "_events_enabled", return_value=False),
+    ):
+        result = operational_events.publish_operational_event(
+            "blocklist_sync_completed",
+            {"source": "community", "ip": "1.2.3.4", "added": 2},
+        )
+
+    assert result is None
+    mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["action"] == "blocklist_sync_completed"

--- a/test/shared/test_security_events.py
+++ b/test/shared/test_security_events.py
@@ -1,0 +1,47 @@
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+class TestSecurityEvents(unittest.TestCase):
+    def test_record_and_export_redacts_sensitive_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(
+            os.environ,
+            {"SECURITY_EVENTS_DB_PATH": os.path.join(tmpdir, "security_events.db")},
+            clear=False,
+        ):
+            from src.shared import security_events
+
+            module = importlib.reload(security_events)
+            module.record_security_event(
+                "alert_delivery",
+                actor="system",
+                action="delivered",
+                source="http_alert",
+                payload={
+                    "ip": "192.168.1.10",
+                    "path": "/admin",
+                    "api_key": "super-secret",
+                    "nested": {"token": "abc"},
+                },
+                created_at="2026-03-15T13:30:00+00:00",
+            )
+
+            events = module.load_security_events(limit=10)
+            count, jsonl = module.export_security_events(limit=10)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event["event_type"], "alert_delivery")
+        self.assertEqual(event["ip"], "[REDACTED_IP]")
+        self.assertEqual(event["path"], "/admin")
+        self.assertEqual(event["payload"]["ip"], "[REDACTED_IP]")
+        self.assertEqual(event["payload"]["api_key"], "<redacted>")
+        self.assertEqual(event["payload"]["nested"]["token"], "<redacted>")
+
+        exported = json.loads(jsonl.strip())
+        self.assertEqual(exported["payload"]["api_key"], "<redacted>")


### PR DESCRIPTION
## Summary\n- add a durable SQLite-backed security event store plus JSONL export tooling\n- record audit, decision, alert-delivery, and operational events into the shared store with redaction\n- document the export workflow and add direct tests around redaction and producer integrations\n\n## Testing\n- ./.venv/bin/pre-commit run --files src/shared/security_events.py scripts/export_security_events.py src/shared/audit.py src/shared/decision_db.py src/shared/operational_events.py src/shared/http_alert.py docs/security/monitoring_and_response.md test/shared/test_security_events.py test/scripts/test_export_security_events.py test/shared/test_audit.py test/shared/test_decision_db.py test/shared/test_http_alert.py test/shared/test_operational_events.py\n- ./.venv/bin/python scripts/security/run_static_security_checks.py\n- ./.venv/bin/python -m pytest -q test/shared/test_security_events.py test/scripts/test_export_security_events.py test/shared/test_audit.py test/shared/test_decision_db.py test/shared/test_http_alert.py test/shared/test_operational_events.py\n- ./.venv/bin/python -m pytest -q test\n\nCloses #1630