### PR TITLE
Harden local model training provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,13 @@ python src/rag/training.py --model xgb
 
 This flexibility makes it easy to experiment with different classifiers.
 
+The fine-tuning path now expects provenance sidecars next to exported
+`*.jsonl` datasets. The normal `src/rag/training.py` export flow writes these
+metadata files automatically; imported datasets should provide matching
+`*.metadata.json` files or `src/rag/finetune.py` will reject them by default.
+See [docs/local_model_training.md](docs/local_model_training.md) for the trust
+boundary and review expectations.
+
 ## Quick Kubernetes Deployment
 
 Run the helper script to deploy everything to Kubernetes in one step. Ensure the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,7 @@ JWT verification is used by some internal APIs (for example, the escalation engi
 | `TARPIT_LLM_MAX_TOKENS` | `400` | Max tokens for tarpit LLM |
 | `ENABLE_AI_LABYRINTH` | `true` | Enable endless labyrinth pages |
 | `TARPIT_LABYRINTH_DEPTH` | `5` | Depth for AI labyrinth |
+| `TRAINING_REQUIRE_DATASET_PROVENANCE` | `true` | Require `*.metadata.json` provenance sidecars before local fine-tuning datasets are loaded |
 | `ENABLE_FINGERPRINTING` | `true` | Track browser fingerprints |
 
 ## Tracking Windows

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ To get a full understanding of the project, please review the following document
 - [**System Architecture**](architecture.md)**:** A high-level overview of the different components of the system and how they fit together. This is the best place to start to understand the overall design.
 - [**Key Data Flows**](key_data_flows.md)**:** This document explains the lifecycle of a request as it moves through our defense layers, from initial filtering to deep analysis.
 - [**Model Adapter Guide**](model_adapter_guide.md)**:** A technical deep-dive into the flexible Model Adapter pattern, which allows the system to easily switch between different machine learning models and LLM providers.
+- [**Local Model Training**](local_model_training.md)**:** Provenance requirements, trust boundaries, and audit expectations for local training and fine-tuning datasets.
 - [**Prompt Router**](prompt_router.md)**:** Explains how LLM requests are routed between local containers and the cloud.
 - [**Monitoring Stack**](monitoring_stack.md)**:** Using Prometheus, Grafana, and Watchtower for observability and automatic updates.
 - [**Release Checklist**](release_checklist.md)**:** Practical validation steps before cutting a tagged release.

--- a/docs/local_model_training.md
+++ b/docs/local_model_training.md
@@ -1,0 +1,39 @@
+# Local Model Training
+
+The local training and fine-tuning flow is intentionally treated as a trust
+boundary.
+
+## Provenance Contract
+
+- `src/rag/training.py` writes `*.metadata.json` sidecars next to the exported
+  `finetuning_data_*.jsonl` files.
+- `src/rag/finetune.py` requires those provenance files by default through
+  `TRAINING_REQUIRE_DATASET_PROVENANCE=true`.
+- the sidecar records where the dataset came from, how many records it contains,
+  and that operator review is expected before the data is used to produce a
+  model artifact
+
+If you import datasets from outside the normal training export flow, generate a
+matching provenance sidecar first or the fine-tuning loader will reject the
+dataset.
+
+## Feedback Overrides
+
+The training pipeline can override heuristic labels using:
+
+- honeypot hit logs
+- CAPTCHA success logs
+
+Those overrides are now surfaced in the audit trail, including conflicts where
+the same IP appears in both feedback sources. Treat those conflicts as review
+items before promoting the resulting dataset or model.
+
+## Trust Boundary
+
+- log files, honeypot events, and CAPTCHA feedback are untrusted inputs
+- generated JSONL exports are derived artifacts, not authoritative truth
+- trained local model files should only be produced from reviewed datasets in a
+  trusted `models/` directory
+
+For production releases, keep provenance enforcement enabled and review both the
+dataset sidecars and the audit/security-event export before fine-tuning.

--- a/src/rag/finetune.py
+++ b/src/rag/finetune.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import time  # Added for timing
+from pathlib import Path
 
 from datasets import load_dataset  # Using Hugging Face datasets library
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
@@ -44,6 +45,14 @@ HF_DATASET_REVISION = os.getenv("HF_DATASET_REVISION", HF_REVISION)
 HF_MODEL_REVISION = os.getenv("HF_MODEL_REVISION", HF_REVISION)
 # Commit hashes are 7-40 hex characters in length.
 REVISION_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
+PROVENANCE_REQUIRED_FIELDS = {
+    "schema_version",
+    "generated_at",
+    "generated_by",
+    "record_count",
+    "source",
+    "trust_boundary",
+}
 
 
 def resolve_model_revision() -> str:
@@ -55,6 +64,54 @@ def resolve_model_revision() -> str:
             "(7-40 hexadecimal characters)."
         )
     return revision
+
+
+def _is_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _require_dataset_provenance() -> bool:
+    return _is_truthy(os.getenv("TRAINING_REQUIRE_DATASET_PROVENANCE", "true"))
+
+
+def _dataset_metadata_path(file_path: str) -> Path:
+    return Path(f"{file_path}.metadata.json")
+
+
+def load_dataset_provenance(file_path: str) -> dict | None:
+    metadata_path = _dataset_metadata_path(file_path)
+    if not metadata_path.exists():
+        if _require_dataset_provenance():
+            print(f"ERROR: Missing dataset provenance metadata: {metadata_path}")
+        return None
+
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to parse dataset provenance metadata {metadata_path}: {exc}"
+        )
+        return None
+
+    missing = sorted(PROVENANCE_REQUIRED_FIELDS - set(metadata))
+    if missing:
+        print(
+            "ERROR: Dataset provenance metadata missing required fields "
+            f"{missing}: {metadata_path}"
+        )
+        return None
+    if not isinstance(metadata.get("source"), dict):
+        print(f"ERROR: Dataset provenance source must be an object: {metadata_path}")
+        return None
+    if not isinstance(metadata.get("trust_boundary"), dict):
+        print(f"ERROR: Dataset trust_boundary must be an object: {metadata_path}")
+        return None
+    if int(metadata.get("record_count", 0)) < 1:
+        print(
+            f"ERROR: Dataset provenance record_count must be positive: {metadata_path}"
+        )
+        return None
+    return metadata
 
 
 # BASE_MODEL_NAME = "bert-base-uncased"
@@ -120,6 +177,10 @@ def load_and_prepare_dataset(file_path, tokenizer):
     """Loads JSON lines data, prepares text fields, and tokenizes."""
     print(f"Loading and preparing dataset from: {file_path}")
     try:
+        metadata = load_dataset_provenance(file_path)
+        if _require_dataset_provenance() and metadata is None:
+            return None
+
         # Load from JSON Lines file
         # Expected format per line: {"log_data": {parsed_log_dict}, "label": "bot" or "human"}
         # Local JSON dataset only (local_files_only=True); no remote download.
@@ -175,6 +236,25 @@ def load_and_prepare_dataset(file_path, tokenizer):
                 "label",
             ],  # Remove original columns after processing
         )
+
+        if metadata is not None:
+            expected_records = int(metadata["record_count"])
+            actual_records = None
+            if isinstance(processed_dataset, dict):
+                labels = processed_dataset.get("label")
+                if isinstance(labels, list):
+                    actual_records = len(labels)
+            if actual_records is None:
+                try:
+                    actual_records = len(processed_dataset)
+                except Exception:
+                    actual_records = None
+            if actual_records is not None and actual_records != expected_records:
+                print(
+                    "ERROR: Dataset provenance record count mismatch for "
+                    f"{file_path}: expected {expected_records}, got {actual_records}"
+                )
+                return None
 
         try:
             if isinstance(

--- a/src/rag/training.py
+++ b/src/rag/training.py
@@ -6,6 +6,8 @@
 import argparse
 import json
 import os
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional, Tuple
 
 import joblib
@@ -73,6 +75,7 @@ HUMAN_LABEL_THRESHOLD = float(os.getenv("TRAINING_HUMAN_LABEL_THRESHOLD", 0.5))
 ROBOTS_TXT_PATH = os.getenv("TRAINING_ROBOTS_TXT_PATH", "/app/config/robots.txt")
 HONEYPOT_HIT_LOG = os.getenv("TRAINING_HONEYPOT_LOG", "/app/logs/honeypot_hits.log")
 CAPTCHA_SUCCESS_LOG = os.getenv("TRAINING_CAPTCHA_LOG", "/app/logs/captcha_success.log")
+PROVENANCE_SCHEMA_VERSION = 1
 
 # Path to GeoIP database used for IP country lookup
 GEOIP_DB_PATH = os.getenv("GEOIP_DB_PATH", "/app/GeoLite2-Country.mmdb")
@@ -94,6 +97,85 @@ KNOWN_BENIGN_CRAWLERS_UAS_STR = os.getenv(
 KNOWN_BENIGN_CRAWLERS_UAS = [
     ua.strip().lower() for ua in KNOWN_BENIGN_CRAWLERS_UAS_STR.split(",") if ua.strip()
 ]
+
+
+def _log_training_audit(action: str, details: dict) -> None:
+    """Best-effort audit logging for training pipeline events."""
+    try:
+        from src.shared.audit import log_event
+
+        log_event("training_pipeline", action, details)
+    except Exception as exc:
+        print(f"Warning: failed to write training audit event {action}: {exc}")
+
+
+def _dataset_metadata_path(file_path: str) -> str:
+    return f"{file_path}.metadata.json"
+
+
+def _feedback_override_summary(
+    original_labels: pd.Series,
+    df: pd.DataFrame,
+    honeypot_triggers: set,
+    captcha_successes: set,
+) -> dict:
+    bot_override_mask = df["ip"].isin(honeypot_triggers)
+    human_override_mask = df["ip"].isin(captcha_successes)
+    conflicting_ips = sorted(honeypot_triggers & captcha_successes)
+    return {
+        "bot_override_count": int(bot_override_mask.sum()),
+        "human_override_count": int(human_override_mask.sum()),
+        "bot_label_changes": int(
+            (bot_override_mask & (original_labels != "bot")).sum()
+        ),
+        "human_label_changes": int(
+            (human_override_mask & (original_labels != "human")).sum()
+        ),
+        "conflicting_ip_count": len(conflicting_ips),
+        "conflicting_ips_sample": conflicting_ips[:10],
+    }
+
+
+def _build_dataset_provenance(
+    split_name: str,
+    file_path: str,
+    data: pd.DataFrame,
+) -> dict:
+    return {
+        "schema_version": PROVENANCE_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_by": "src.rag.training.save_data_for_finetuning",
+        "dataset_path": str(Path(file_path).name),
+        "split": split_name,
+        "record_count": int(len(data)),
+        "source": {
+            "kind": "derived_training_export",
+            "log_file_path": LOG_FILE_PATH,
+            "robots_txt_path": ROBOTS_TXT_PATH,
+            "honeypot_log_path": os.getenv("TRAINING_HONEYPOT_LOG", HONEYPOT_HIT_LOG),
+            "captcha_log_path": os.getenv("TRAINING_CAPTCHA_LOG", CAPTCHA_SUCCESS_LOG),
+        },
+        "feedback_overrides": dict(data.attrs.get("feedback_override_summary", {})),
+        "trust_boundary": {
+            "review_required": True,
+            "notes": (
+                "This dataset may contain heuristic labels and local feedback "
+                "overrides. Review provenance and data quality before fine-tuning "
+                "or sharing model artifacts."
+            ),
+        },
+    }
+
+
+def _write_dataset_provenance(
+    split_name: str, file_path: str, data: pd.DataFrame
+) -> None:
+    metadata_path = _dataset_metadata_path(file_path)
+    metadata = _build_dataset_provenance(split_name, file_path, data)
+    with open(metadata_path, "w", encoding="utf-8") as handle:
+        json.dump(metadata, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    print(f"Saved provenance metadata to: {metadata_path}")
 
 
 # --- Database Setup ---
@@ -411,10 +493,32 @@ def assign_labels_and_scores(
     df["label"] = "suspicious"
     df.loc[df["bot_score"] >= BOT_LABEL_THRESHOLD, "label"] = "bot"
     df.loc[df["bot_score"] <= HUMAN_LABEL_THRESHOLD, "label"] = "human"
+    original_labels = df["label"].copy()
 
     # Override labels based on feedback files (highest priority)
     df.loc[df["ip"].isin(honeypot_triggers), "label"] = "bot"
     df.loc[df["ip"].isin(captcha_successes), "label"] = "human"
+    override_summary = _feedback_override_summary(
+        original_labels,
+        df,
+        honeypot_triggers,
+        captcha_successes,
+    )
+    df.attrs["feedback_override_summary"] = override_summary
+    if (
+        override_summary["bot_override_count"]
+        or override_summary["human_override_count"]
+        or override_summary["conflicting_ip_count"]
+    ):
+        _log_training_audit("training_feedback_overrides_applied", override_summary)
+    if override_summary["conflicting_ip_count"]:
+        _log_training_audit(
+            "training_feedback_override_conflicts_detected",
+            {
+                "conflicting_ip_count": override_summary["conflicting_ip_count"],
+                "conflicting_ips_sample": override_summary["conflicting_ips_sample"],
+            },
+        )
 
     print("Labeling complete. Label distribution:")
     print(df["label"].value_counts())
@@ -528,7 +632,7 @@ def save_data_for_finetuning(
             stratify=finetune_df["label"],
         )
 
-    def write_jsonl(data: pd.DataFrame, file_path: str):
+    def write_jsonl(data: pd.DataFrame, file_path: str, split_name: str):
         if not file_path:
             return
         data_to_write = data.to_dict("records")
@@ -550,11 +654,12 @@ def save_data_for_finetuning(
                     )  # Use default=str for datetime etc.
                     f.write("\n")
             print(f"Saved {len(data)} records for fine-tuning to: {file_path}")
+            _write_dataset_provenance(split_name, file_path, data)
         except Exception as e:
             print(f"ERROR: Failed to save fine-tuning data to {file_path}: {e}")
 
-    write_jsonl(train_df, train_file)
-    write_jsonl(eval_df, eval_file)
+    write_jsonl(train_df, train_file, "train")
+    write_jsonl(eval_df, eval_file, "eval")
 
 
 # --- Main Execution ---

--- a/test/rag/test_finetune.py
+++ b/test/rag/test_finetune.py
@@ -2,12 +2,14 @@
 import json
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 
+sys.modules.setdefault("markov_train_rs", MagicMock())
 from rag import finetune
 
 
@@ -47,6 +49,23 @@ class TestFinetuneScriptComprehensive(unittest.TestCase):
                 )
                 + "\\n"
             )
+        for split_name, file_path in (
+            ("train", self.train_file),
+            ("eval", self.eval_file),
+        ):
+            with open(f"{file_path}.metadata.json", "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "schema_version": 1,
+                        "generated_at": "2026-03-17T00:00:00+00:00",
+                        "generated_by": "test-suite",
+                        "record_count": 1,
+                        "source": {"kind": "test"},
+                        "trust_boundary": {"review_required": True},
+                        "split": split_name,
+                    },
+                    handle,
+                )
 
         self.env_patcher = patch.dict(
             os.environ,
@@ -119,6 +138,21 @@ class TestFinetuneScriptComprehensive(unittest.TestCase):
         self.assertIn("input_ids", prepared_data)
         # Check that the label was correctly mapped
         self.assertEqual(prepared_data["label"], [1])  # bot -> 1
+
+    @patch("rag.finetune.load_dataset")
+    def test_load_and_prepare_dataset_requires_provenance(self, mock_load_dataset):
+        os.remove(f"{self.train_file}.metadata.json")
+        prepared_data = finetune.load_and_prepare_dataset(self.train_file, MagicMock())
+        self.assertIsNone(prepared_data)
+        mock_load_dataset.assert_not_called()
+
+    @patch("rag.finetune.load_dataset")
+    def test_load_and_prepare_dataset_rejects_bad_provenance(self, mock_load_dataset):
+        with open(f"{self.train_file}.metadata.json", "w", encoding="utf-8") as handle:
+            json.dump({"schema_version": 1}, handle)
+        prepared_data = finetune.load_and_prepare_dataset(self.train_file, MagicMock())
+        self.assertIsNone(prepared_data)
+        mock_load_dataset.assert_not_called()
 
     def test_compute_metrics(self):
         """Test the metrics computation for evaluation, including argmax logic."""

--- a/test/rag/test_training.py
+++ b/test/rag/test_training.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pandas as pd
 
+sys.modules.setdefault("markov_train_rs", MagicMock())
 from rag import training
 
 
@@ -112,7 +113,10 @@ class TestTrainingPipelineComprehensive(unittest.TestCase):
             }
         )
 
-        labeled_df = training.assign_labels_and_scores(df, honeypot_ips, captcha_ips)
+        with patch("rag.training._log_training_audit") as mock_audit:
+            labeled_df = training.assign_labels_and_scores(
+                df, honeypot_ips, captcha_ips
+            )
 
         # Honeypot IP -> bot
         self.assertEqual(labeled_df[labeled_df.ip == "1.1.1.1"].label.iloc[0], "bot")
@@ -124,6 +128,13 @@ class TestTrainingPipelineComprehensive(unittest.TestCase):
         self.assertEqual(labeled_df[labeled_df.ip == "5.5.5.5"].label.iloc[0], "bot")
         # Benign-looking request -> human
         self.assertEqual(labeled_df[labeled_df.ip == "2.2.2.2"].label.iloc[0], "human")
+        self.assertEqual(
+            labeled_df.attrs["feedback_override_summary"]["bot_override_count"], 1
+        )
+        self.assertEqual(
+            labeled_df.attrs["feedback_override_summary"]["human_override_count"], 1
+        )
+        mock_audit.assert_called_once()
 
     @patch("rag.training.joblib.dump")
     @patch("sklearn.ensemble.RandomForestClassifier.fit")
@@ -187,6 +198,37 @@ class TestTrainingPipelineComprehensive(unittest.TestCase):
             self.assertEqual(log_data_inner["ip"], "1.1.1.1")
             self.assertNotIn("bot_score", log_data_inner)
         self.assertNotIn("labeling_reasons", log_data_inner)
+        metadata_path = f"{self.finetune_train_path}.metadata.json"
+        self.assertTrue(os.path.exists(metadata_path))
+        with open(metadata_path, "r", encoding="utf-8") as handle:
+            metadata = json.load(handle)
+        self.assertEqual(metadata["split"], "train")
+        self.assertEqual(
+            metadata["generated_by"], "src.rag.training.save_data_for_finetuning"
+        )
+        self.assertEqual(metadata["trust_boundary"]["review_required"], True)
+
+    def test_assign_labels_logs_conflicting_feedback(self):
+        df = pd.DataFrame(
+            {
+                "ip": ["1.1.1.1"],
+                "user_agent": ["Mozilla"],
+                "path": ["/home"],
+                "status": [200],
+                "referer": ["https://example.com"],
+                "req_freq_60s": [1],
+                "time_since_last_sec": [60],
+            }
+        )
+
+        with patch("rag.training._log_training_audit") as mock_audit:
+            training.assign_labels_and_scores(df, {"1.1.1.1"}, {"1.1.1.1"})
+
+        self.assertEqual(mock_audit.call_count, 2)
+        self.assertEqual(
+            mock_audit.call_args_list[1].args[0],
+            "training_feedback_override_conflicts_detected",
+        )
 
     @patch("rag.training.joblib.dump")
     def test_model_accuracy_comparison(self, mock_dump):


### PR DESCRIPTION
## Summary
- add provenance sidecars for exported fine-tuning datasets and audit feedback override activity
- require and validate dataset provenance during fine-tuning dataset loading
- document the training provenance contract and cover it with regression tests

Closes #1673

## Validation
- ./.venv/bin/pre-commit run --files src/rag/training.py src/rag/finetune.py test/rag/test_training.py test/rag/test_finetune.py docs/local_model_training.md docs/index.md README.md docs/configuration.md
- ./.venv/bin/python -m pytest -q test/rag/test_training.py test/rag/test_finetune.py
- ./.venv/bin/python -m pytest -q test