### PR TITLE
Add internal service auth baseline

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,16 @@ JWT verification is used by some internal APIs (for example, the escalation engi
 | `AUTH_JWT_ISSUER` | *(none)* | Optional expected `iss` claim |
 | `AUTH_JWT_AUDIENCE` | *(none)* | Optional expected `aud` claim |
 
+## Internal Service Authentication
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `INTERNAL_AUTH_MODE` | `shared_key` | Supported internal HTTP auth baseline; current release supports `shared_key` |
+| `SHARED_SECRET` | *(none)* | Bearer secret required by `prompt_router` |
+| `PROXY_KEY` | *(none)* | Header secret injected by `prompt_router` when calling `cloud_proxy` |
+| `ESCALATION_API_KEY` | *(none)* | Shared key for Admin UI to call Escalation Engine admin endpoints |
+| `WEBHOOK_SHARED_SECRET` | *(none)* | HMAC secret for Escalation Engine webhook calls into `ai_service` |
+
 ## Error Handling
 
 | Variable | Default | Description |

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ To get a full understanding of the project, please review the following document
 - [**Key Data Flows**](key_data_flows.md)**:** This document explains the lifecycle of a request as it moves through our defense layers, from initial filtering to deep analysis.
 - [**Model Adapter Guide**](model_adapter_guide.md)**:** A technical deep-dive into the flexible Model Adapter pattern, which allows the system to easily switch between different machine learning models and LLM providers.
 - [**Prompt Router**](prompt_router.md)**:** Explains how LLM requests are routed between local containers and the cloud.
+- [**Inter-Service Authentication**](inter_service_auth.md)**:** Defines the current shared-key contract for internal HTTP calls.
 - [**Monitoring Stack**](monitoring_stack.md)**:** Using Prometheus, Grafana, and Watchtower for observability and automatic updates.
 - [**Release Checklist**](release_checklist.md)**:** Practical validation steps before cutting a tagged release.
 - [**Release Artifacts**](release_artifacts.md)**:** Semver tags, GHCR image publication, signatures, and provenance policy.

--- a/docs/inter_service_auth.md
+++ b/docs/inter_service_auth.md
@@ -1,0 +1,36 @@
+# Inter-Service Authentication
+
+The current supported production baseline for internal HTTP calls is
+`INTERNAL_AUTH_MODE=shared_key`.
+
+This release does not claim mTLS or workload-identity support. Instead, it makes
+the existing shared-secret contract explicit, validates it in production, and
+tests the protected call paths that already exist in the stack.
+
+## Internal HTTP Auth Matrix
+
+| Caller | Callee | Endpoint / hop | Auth contract |
+| --- | --- | --- | --- |
+| External caller or trusted edge service | `prompt_router` | `POST /route` | `Authorization: Bearer $SHARED_SECRET` |
+| `prompt_router` | `cloud_proxy` | `POST /api/chat` | `X-Proxy-Key: $PROXY_KEY` |
+| `admin_ui` | `escalation_engine` | `/admin/reload_plugins` and other admin calls | `X-API-Key: $ESCALATION_API_KEY` |
+| `escalation_engine` | `ai_service` | `/webhook` | `X-Signature` HMAC using `$WEBHOOK_SHARED_SECRET` |
+
+## Production Validation
+
+When `APP_ENV=production` and `INTERNAL_AUTH_MODE=shared_key`, the configuration
+validator requires:
+
+- `SHARED_SECRET`
+- `PROXY_KEY`
+- `ESCALATION_API_KEY`
+- `WEBHOOK_SHARED_SECRET`
+
+This keeps the stack from bootstrapping a production deployment with missing
+internal auth secrets.
+
+## Next Step
+
+If the project later adds mTLS or workload identity, it should be introduced as
+an additional explicit `INTERNAL_AUTH_MODE` with its own config validation and
+endpoint tests, rather than as an implicit side path.

--- a/docs/prompt_router.md
+++ b/docs/prompt_router.md
@@ -15,6 +15,8 @@ Set the following variables in `.env`:
 
 - `PROMPT_ROUTER_HOST` – hostname or container name running the router.
 - `PROMPT_ROUTER_PORT` – port the router listens on.
+- `INTERNAL_AUTH_MODE` – currently `shared_key`; defines the supported internal HTTP auth mode.
+- `SHARED_SECRET` – bearer secret required by the router’s `/route` endpoint.
 - `PROXY_KEY` – shared secret sent to the cloud proxy via the `X-Proxy-Key` header.
 
 ```env

--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -14,6 +14,7 @@ from src.shared.mcp_client import MCPClientError, call_mcp_tool
 from src.shared.middleware import SecuritySettings, create_app
 from src.shared.observability import ObservabilitySettings
 from src.shared.request_utils import read_json_body
+from src.shared.service_identity import build_cloud_proxy_headers
 
 INTERNAL_SERVICE_SCHEME = os.getenv("INTERNAL_SERVICE_SCHEME", "http")
 LOCAL_LLM_URL = os.getenv("LOCAL_LLM_URL") or (
@@ -74,8 +75,15 @@ async def _dispatch_prompt(target: str, payload: dict) -> dict:
         except MCPClientError as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
 
+    headers = {}
+    if target == CLOUD_PROXY_URL:
+        try:
+            headers = build_cloud_proxy_headers()
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
     async with httpx.AsyncClient() as client:
-        resp = await client.post(target, json=payload, timeout=60)
+        resp = await client.post(target, json=payload, headers=headers, timeout=60)
         resp.raise_for_status()
         return resp.json()
 

--- a/sample.env
+++ b/sample.env
@@ -86,6 +86,14 @@ REAL_BACKEND_HOSTS=http://localhost:8082
 # Fallback single backend host when REAL_BACKEND_HOSTS is empty
 REAL_BACKEND_HOST=http://localhost:8082
 
+# --- Internal Service Authentication ---
+# Current supported production baseline: shared secrets on internal HTTP hops.
+INTERNAL_AUTH_MODE=shared_key
+# Bearer token required by prompt-router `/route`
+SHARED_SECRET=
+# Header secret used by prompt-router when it forwards oversized prompts to cloud_proxy
+PROXY_KEY=
+
 # --- Alert SMTP Configuration ---
 ALERT_SMTP_USE_TLS=false
 ALERT_SMTP_USER=

--- a/src/shared/config_schema.py
+++ b/src/shared/config_schema.py
@@ -7,6 +7,8 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from .service_identity import InternalAuthMode
+
 MASKED_VALUE = "***MASKED***"
 
 
@@ -205,6 +207,7 @@ class SecurityConfig(BaseModel):
     tls_key_path: Optional[str] = None
     enable_waf: bool = Field(default=True)
     waf_rules_path: Optional[str] = None
+    internal_auth_mode: InternalAuthMode = Field(default=InternalAuthMode.SHARED_KEY)
     jwt_secret: Optional[str] = Field(default=None, repr=False)
     jwt_secret_file: Optional[str] = None
     jwt_public_key: Optional[str] = Field(default=None, repr=False)

--- a/src/shared/config_validator.py
+++ b/src/shared/config_validator.py
@@ -25,6 +25,7 @@ from .config_schema import (
     ServiceEndpoint,
     TarpitConfig,
 )
+from .service_identity import InternalAuthMode
 
 logger = logging.getLogger(__name__)
 BCRYPT_PATTERN = re.compile(r"^\$(2[aby])\$(\d\d)\$[./A-Za-z0-9]{53}$")
@@ -252,6 +253,7 @@ class ConfigLoader:
             tls_key_path=env.get("TLS_KEY_PATH"),
             enable_waf=env.get("ENABLE_WAF", "true").lower() == "true",
             waf_rules_path=env.get("WAF_RULES_PATH"),
+            internal_auth_mode=env.get("INTERNAL_AUTH_MODE", "shared_key"),
             jwt_secret=env.get("AUTH_JWT_SECRET"),
             jwt_secret_file=env.get("AUTH_JWT_SECRET_FILE"),
             jwt_public_key=env.get("AUTH_JWT_PUBLIC_KEY"),
@@ -334,6 +336,18 @@ class ConfigLoader:
                 not config.security.tls_cert_path or not config.security.tls_key_path
             ):
                 errors.append("TLS certificate and key required when HTTPS is enabled")
+            if config.security.internal_auth_mode == InternalAuthMode.SHARED_KEY:
+                required_secrets = {
+                    "SHARED_SECRET": os.getenv("SHARED_SECRET"),
+                    "PROXY_KEY": os.getenv("PROXY_KEY"),
+                    "ESCALATION_API_KEY": os.getenv("ESCALATION_API_KEY"),
+                    "WEBHOOK_SHARED_SECRET": os.getenv("WEBHOOK_SHARED_SECRET"),
+                }
+                for secret_name, value in required_secrets.items():
+                    if not value:
+                        errors.append(
+                            f"{secret_name} required when INTERNAL_AUTH_MODE=shared_key in production"
+                        )
         if config.security.admin_ui_password_hash:
             match = BCRYPT_PATTERN.match(config.security.admin_ui_password_hash)
             if not match:

--- a/src/shared/service_identity.py
+++ b/src/shared/service_identity.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import Mapping
+
+
+class InternalAuthMode(str, Enum):
+    SHARED_KEY = "shared_key"
+
+
+def load_internal_auth_mode(
+    env: Mapping[str, str] | None = None,
+) -> InternalAuthMode:
+    source = env or os.environ
+    raw_value = source.get("INTERNAL_AUTH_MODE", InternalAuthMode.SHARED_KEY.value)
+    normalized = raw_value.strip().lower()
+    try:
+        return InternalAuthMode(normalized)
+    except ValueError as exc:
+        raise ValueError(
+            "INTERNAL_AUTH_MODE must be one of: "
+            + ", ".join(mode.value for mode in InternalAuthMode)
+        ) from exc
+
+
+def build_cloud_proxy_headers(
+    env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    source = env or os.environ
+    auth_mode = load_internal_auth_mode(source)
+    if auth_mode is InternalAuthMode.SHARED_KEY:
+        proxy_key = source.get("PROXY_KEY", "").strip()
+        if not proxy_key:
+            raise RuntimeError(
+                "PROXY_KEY is required when INTERNAL_AUTH_MODE=shared_key"
+            )
+        return {"X-Proxy-Key": proxy_key}
+    return {}

--- a/test/prompt_router/test_prompt_router.py
+++ b/test/prompt_router/test_prompt_router.py
@@ -30,6 +30,7 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
                 "MAX_LOCAL_TOKENS": "10",
                 "LOCAL_LLM_URL": "http://local",
                 "CLOUD_PROXY_URL": "http://cloud",
+                "PROXY_KEY": "proxy-secret",
                 "SHARED_SECRET": self.shared_secret,
             },
         )
@@ -61,8 +62,8 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
             async def __aexit__(self, exc_type, exc, tb):
                 pass
 
-            async def post(self, url, json, timeout):
-                self.post_calls.append((url, json, timeout))
+            async def post(self, url, json, headers, timeout):
+                self.post_calls.append((url, json, headers, timeout))
                 return mock_resp
 
         with patch.object(pr_module, "httpx") as httpx_mod:
@@ -100,8 +101,8 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
             async def __aexit__(self, exc_type, exc, tb):
                 pass
 
-            async def post(self, url, json, timeout):
-                self.post_calls.append((url, json, timeout))
+            async def post(self, url, json, headers, timeout):
+                self.post_calls.append((url, json, headers, timeout))
                 return mock_resp
 
         with patch.object(pr_module, "httpx") as httpx_mod:
@@ -120,6 +121,10 @@ class TestPromptRouterRouting(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.json(), {"route": "cloud"})
         client_inst = DummyClient.instances[-1]
         self.assertIn("http://cloud", [c[0] for c in client_inst.post_calls])
+        cloud_call = next(
+            call for call in client_inst.post_calls if call[0] == "http://cloud"
+        )
+        self.assertEqual(cloud_call[2]["X-Proxy-Key"], "proxy-secret")
 
 
 class TestAuthAndRateLimit(unittest.IsolatedAsyncioTestCase):
@@ -131,6 +136,7 @@ class TestAuthAndRateLimit(unittest.IsolatedAsyncioTestCase):
                 "MAX_LOCAL_TOKENS": "10",
                 "LOCAL_LLM_URL": "http://local",
                 "CLOUD_PROXY_URL": "http://cloud",
+                "PROXY_KEY": "proxy-secret",
                 "SHARED_SECRET": self.shared_secret,
                 "RATE_LIMIT_REQUESTS": "2",
                 "RATE_LIMIT_WINDOW": "10",
@@ -284,6 +290,33 @@ class TestAuthAndRateLimit(unittest.IsolatedAsyncioTestCase):
                     }
                 )
         self.assertNotIn("1.1.1.1", pr_module._request_counts)
+
+    async def test_cloud_route_requires_proxy_key_in_shared_key_mode(self):
+        with patch.dict(
+            os.environ,
+            {
+                "MAX_LOCAL_TOKENS": "1",
+                "LOCAL_LLM_URL": "http://local",
+                "CLOUD_PROXY_URL": "http://cloud",
+                "PROXY_KEY": "",
+                "SHARED_SECRET": self.shared_secret,
+            },
+        ):
+            spec.loader.exec_module(pr_module)
+            global app
+            app = pr_module.app
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as ac:
+                response = await ac.post(
+                    "/route",
+                    json={"prompt": "x x"},
+                    headers={"Authorization": f"Bearer {self.shared_secret}"},
+                )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("PROXY_KEY", response.text)
 
 
 if __name__ == "__main__":

--- a/test/prompt_router/test_routing_behavior.py
+++ b/test/prompt_router/test_routing_behavior.py
@@ -28,6 +28,7 @@ class TestRoutingBehavior(unittest.IsolatedAsyncioTestCase):
                 "MAX_LOCAL_TOKENS": "5",
                 "LOCAL_LLM_URL": "http://local",
                 "CLOUD_PROXY_URL": "http://cloud",
+                "PROXY_KEY": "proxy-secret",
                 "SHARED_SECRET": self.shared_secret,
             },
         )
@@ -46,8 +47,8 @@ class TestRoutingBehavior(unittest.IsolatedAsyncioTestCase):
         mock_resp.raise_for_status.return_value = None
         calls = []
 
-        async def dummy_post(url, json, timeout):
-            calls.append((url, json, timeout))
+        async def dummy_post(url, json, headers, timeout):
+            calls.append((url, json, headers, timeout))
             return mock_resp
 
         async_client = AsyncMock()
@@ -74,6 +75,7 @@ class TestRoutingBehavior(unittest.IsolatedAsyncioTestCase):
     async def test_long_prompt_goes_cloud(self):
         calls = await self._send_prompt(" ".join(["x"] * 6))
         self.assertEqual(calls[0][0], "http://cloud")
+        self.assertEqual(calls[0][2]["X-Proxy-Key"], "proxy-secret")
 
 
 if __name__ == "__main__":

--- a/test/shared/test_config_validator.py
+++ b/test/shared/test_config_validator.py
@@ -269,8 +269,85 @@ class TestConfigLoader(unittest.TestCase):
         # Should require OPENAI_API_KEY
         with patch.dict(os.environ, {}, clear=True):
             is_valid, errors = loader.validate_config(config)
-            self.assertFalse(is_valid)
-            self.assertTrue(any("OPENAI_API_KEY" in e for e in errors))
+        self.assertFalse(is_valid)
+        self.assertTrue(any("OPENAI_API_KEY" in e for e in errors))
+
+    def test_load_internal_auth_mode(self):
+        env = self.minimal_env.copy()
+        env["INTERNAL_AUTH_MODE"] = "shared_key"
+
+        loader = ConfigLoader(strict=False)
+        config = loader.load_from_env(env)
+
+        self.assertEqual(config.security.internal_auth_mode.value, "shared_key")
+
+    def test_load_invalid_internal_auth_mode_raises(self):
+        env = self.minimal_env.copy()
+        env["INTERNAL_AUTH_MODE"] = "mtls"
+
+        loader = ConfigLoader(strict=True)
+        with self.assertRaises(ConfigValidationError):
+            loader.load_from_env(env)
+
+    def test_validate_production_requires_internal_auth_secrets(self):
+        env = self.minimal_env.copy()
+        env.update(
+            {
+                "APP_ENV": "production",
+                "DEBUG": "false",
+                "ENABLE_EXTERNAL_API_CLASSIFICATION": "false",
+                "ADMIN_UI_PASSWORD_HASH": "$2b$12$" + "." * 53,
+            }
+        )
+
+        loader = ConfigLoader(strict=False)
+        config = loader.load_from_env(env)
+
+        with patch.dict(
+            os.environ,
+            {
+                "MODEL_URI": env["MODEL_URI"],
+                "ENABLE_EXTERNAL_API_CLASSIFICATION": "false",
+            },
+            clear=True,
+        ):
+            is_valid, errors = loader.validate_config(config)
+
+        self.assertFalse(is_valid)
+        self.assertTrue(any("SHARED_SECRET required" in e for e in errors))
+        self.assertTrue(any("PROXY_KEY required" in e for e in errors))
+        self.assertTrue(any("ESCALATION_API_KEY required" in e for e in errors))
+        self.assertTrue(any("WEBHOOK_SHARED_SECRET required" in e for e in errors))
+
+    def test_validate_production_internal_auth_shared_key_succeeds(self):
+        env = self.minimal_env.copy()
+        env.update(
+            {
+                "APP_ENV": "production",
+                "DEBUG": "false",
+                "ENABLE_EXTERNAL_API_CLASSIFICATION": "false",
+                "ADMIN_UI_PASSWORD_HASH": "$2b$12$" + "." * 53,
+            }
+        )
+
+        loader = ConfigLoader(strict=False)
+        config = loader.load_from_env(env)
+
+        with patch.dict(
+            os.environ,
+            {
+                "MODEL_URI": env["MODEL_URI"],
+                "ENABLE_EXTERNAL_API_CLASSIFICATION": "false",
+                "SHARED_SECRET": "shared-secret",
+                "PROXY_KEY": "proxy-secret",
+                "ESCALATION_API_KEY": "escalation-secret",
+                "WEBHOOK_SHARED_SECRET": "webhook-secret",
+            },
+            clear=True,
+        ):
+            is_valid, errors = loader.validate_config(config)
+
+        self.assertTrue(is_valid, errors)
 
     def test_validate_captcha_config(self):
         """Test CAPTCHA configuration validation."""

--- a/test/shared/test_service_identity.py
+++ b/test/shared/test_service_identity.py
@@ -1,0 +1,30 @@
+import unittest
+
+from src.shared.service_identity import (
+    InternalAuthMode,
+    build_cloud_proxy_headers,
+    load_internal_auth_mode,
+)
+
+
+class TestServiceIdentity(unittest.TestCase):
+    def test_load_internal_auth_mode_defaults_to_shared_key(self):
+        mode = load_internal_auth_mode({})
+        self.assertEqual(mode, InternalAuthMode.SHARED_KEY)
+
+    def test_load_internal_auth_mode_rejects_unknown_value(self):
+        with self.assertRaises(ValueError):
+            load_internal_auth_mode({"INTERNAL_AUTH_MODE": "mtls"})
+
+    def test_build_cloud_proxy_headers_requires_proxy_key(self):
+        with self.assertRaises(RuntimeError):
+            build_cloud_proxy_headers({"INTERNAL_AUTH_MODE": "shared_key"})
+
+    def test_build_cloud_proxy_headers_returns_proxy_key(self):
+        headers = build_cloud_proxy_headers(
+            {
+                "INTERNAL_AUTH_MODE": "shared_key",
+                "PROXY_KEY": "proxy-secret",
+            }
+        )
+        self.assertEqual(headers["X-Proxy-Key"], "proxy-secret")


### PR DESCRIPTION
## Summary
- make `shared_key` the explicit internal HTTP auth baseline in config and docs
- send `X-Proxy-Key` from prompt_router to cloud_proxy and fail fast when that secret is missing
- add validator and regression coverage for the internal service auth contract

Closes #1674

## Validation
- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files src/shared/service_identity.py src/shared/config_schema.py src/shared/config_validator.py prompt-router/main.py test/prompt_router/test_prompt_router.py test/prompt_router/test_routing_behavior.py test/shared/test_config_validator.py test/shared/test_service_identity.py sample.env docs/configuration.md docs/inter_service_auth.md docs/index.md docs/prompt_router.md
- /home/rich/dev/ai-scraping-defense/.venv/bin/python -m pytest -q test/prompt_router/test_prompt_router.py test/prompt_router/test_routing_behavior.py test/shared/test_config_validator.py test/shared/test_service_identity.py
- /home/rich/dev/ai-scraping-defense/.venv/bin/python -m pytest -q test