### PR TITLE
Define API versioning policy

### DIFF
--- a/docs/api_versioning.md
+++ b/docs/api_versioning.md
@@ -1,0 +1,59 @@
+## API Versioning Policy
+
+The stack currently publishes a single supported HTTP/WebSocket contract: `unversioned-v1`.
+
+That means:
+
+- existing documented routes remain unversioned
+- explicit prefixes such as `/v2/...` or `/api/v2/...` are rejected
+- future breaking API generations must introduce an explicit versioned surface instead of silently changing the current paths
+
+## Route Classification
+
+Public routes:
+
+- `GET /list`
+- `GET /list/auth`
+- `POST /report`
+- `POST /webhook`
+- `POST /recommendations`
+- `POST /api/chat`
+
+Operator routes:
+
+- `GET /`
+- `GET /settings`
+- `GET /logs`
+- `GET /plugins`
+- `POST /gdpr/deletion-request`
+- `GET /gdpr/compliance-report`
+- `GET /metrics`
+- `POST /admin/reload_plugins`
+- `POST /register`
+- `GET /metrics/{installation_id}`
+- `GET /defense/*` and other documented management endpoints exposed by the stack
+
+Internal routes:
+
+- `POST /escalate`
+- `POST /route`
+- `GET /health`
+- `GET /ws/{installation_id}`
+
+Internal routes are not a public compatibility promise even when they are HTTP-based. They may evolve behind deployment-controlled service boundaries.
+
+## Deprecation Rules
+
+- `unversioned-v1` is the only supported public/operator contract in the current release line.
+- New optional fields may be added to JSON responses without bumping the contract.
+- Removing fields, changing semantics, or changing auth requirements requires a new explicit version and migration notes.
+- A new explicit version must be documented before release and the previous public/operator version must keep a published deprecation window.
+- Unsupported explicit version prefixes return a deterministic `404` JSON response so clients do not silently fall through to unrelated handlers.
+
+## Migration Expectation
+
+When a future `v2` surface is introduced, the repo should:
+
+- keep the existing `unversioned-v1` behavior documented for its deprecation window
+- document endpoint-by-endpoint migration notes
+- add test coverage for both the supported version and the rejected/deprecated prefixes

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ To get a full understanding of the project, please review the following document
 - [**Local Model Training**](local_model_training.md)**:** Provenance requirements, trust boundaries, and audit expectations for local training and fine-tuning datasets.
 - [**Prompt Router**](prompt_router.md)**:** Explains how LLM requests are routed between local containers and the cloud.
 - [**Inter-Service Authentication**](inter_service_auth.md)**:** Defines the current shared-key contract for internal HTTP calls.
+- [**API Versioning Policy**](api_versioning.md)**:** Defines the current `unversioned-v1` contract, route classes, and deprecation expectations.
 - [**Monitoring Stack**](monitoring_stack.md)**:** Using Prometheus, Grafana, and Watchtower for observability and automatic updates.
 - [**Release Checklist**](release_checklist.md)**:** Practical validation steps before cutting a tagged release.
 - [**Release Artifacts**](release_artifacts.md)**:** Semver tags, GHCR image publication, signatures, and provenance policy.

--- a/src/shared/middleware.py
+++ b/src/shared/middleware.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -23,6 +24,7 @@ from .observability import ObservabilitySettings, configure_observability
 from .request_identity import resolve_request_identity, resolve_request_scheme
 
 logger = logging.getLogger(__name__)
+UNSUPPORTED_VERSION_PREFIX = re.compile(r"^/(?:api/)?v(?P<version>[0-9]+)(?:/|$)")
 
 
 @dataclass(frozen=True)
@@ -99,6 +101,25 @@ def _parse_host_list(name: str) -> list[str]:
             seen.add(host)
             unique.append(host)
     return unique
+
+
+def _version_prefix_error(path: str) -> JSONResponse | None:
+    """Reject explicit API version prefixes until a versioned surface exists."""
+
+    match = UNSUPPORTED_VERSION_PREFIX.match(path)
+    if match is None:
+        return None
+    version = match.group("version")
+    return JSONResponse(
+        status_code=404,
+        content={
+            "detail": (
+                f"Explicit API version prefix v{version} is not supported. "
+                "Use the documented unversioned-v1 routes."
+            ),
+            "supported_versioning": "unversioned-v1",
+        },
+    )
 
 
 class RequestTargetLimitMiddleware(BaseHTTPMiddleware):
@@ -275,6 +296,13 @@ def add_security_middleware(
     app: FastAPI, security_settings: SecuritySettings | None = None
 ) -> SecuritySettings:
     settings = security_settings or _load_security_settings()
+
+    @app.middleware("http")
+    async def _reject_unsupported_version_prefixes(request, call_next):
+        version_error = _version_prefix_error(request.url.path)
+        if version_error is not None:
+            return version_error
+        return await call_next(request)
 
     # Add GDPR compliance middleware first (innermost)
     gdpr_enabled = os.getenv("GDPR_ENABLED", "true").lower() == "true"

--- a/test/test_security_middleware.py
+++ b/test/test_security_middleware.py
@@ -55,6 +55,42 @@ def test_security_headers_skip_hsts_when_disabled():
     assert "Strict-Transport-Security" not in response.headers
 
 
+def test_explicit_api_version_prefix_is_rejected():
+    settings = SecuritySettings(
+        rate_limit_requests=5,
+        rate_limit_window=60,
+        max_body_size=1024,
+        enable_https=False,
+    )
+    client = TestClient(_build_app(settings))
+
+    response = client.get("/v2/ping")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "detail": (
+            "Explicit API version prefix v2 is not supported. "
+            "Use the documented unversioned-v1 routes."
+        ),
+        "supported_versioning": "unversioned-v1",
+    }
+
+
+def test_api_namespace_version_prefix_is_rejected():
+    settings = SecuritySettings(
+        rate_limit_requests=5,
+        rate_limit_window=60,
+        max_body_size=1024,
+        enable_https=False,
+    )
+    client = TestClient(_build_app(settings))
+
+    response = client.get("/api/v3/ping")
+
+    assert response.status_code == 404
+    assert response.json()["supported_versioning"] == "unversioned-v1"
+
+
 def test_rate_limiting_blocks_after_threshold():
     settings = SecuritySettings(
         rate_limit_requests=2,


### PR DESCRIPTION
## Summary
- add a shared guard for unsupported explicit API version prefixes
- document the current unversioned-v1 contract and route classifications
- add middleware tests covering unsupported /vN and /api/vN paths

## Testing
- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files src/shared/middleware.py test/test_security_middleware.py docs/api_versioning.md docs/index.md
- /home/rich/dev/ai-scraping-defense/.venv/bin/python -m pytest -q
