### PR TITLE
Audit API trust boundaries

### DIFF
--- a/docs/api_trust_boundaries.md
+++ b/docs/api_trust_boundaries.md
@@ -1,0 +1,42 @@
+# API Trust Boundaries
+
+This document defines the supported authentication, authorization, and object-scope
+baseline for the current release.
+
+## Endpoint Inventory
+
+| Surface | Paths | Authn | Authz / object scope | Notes |
+| --- | --- | --- | --- | --- |
+| Admin UI | `/`, `/settings`, `/logs`, `/plugins`, `/gdpr/*`, `/metrics`, `/ws/metrics` | HTTP Basic or SSO session, MFA by default | `require_auth` for read surfaces, `require_admin` for state-changing routes | Sessions are Redis-backed; MFA can only be disabled explicitly for lab scenarios. |
+| Admin passkey / WebAuthn | `/passkey/*`, `/mfa/*`, `/webauthn/*` | Existing authenticated admin session for registration flows; username-bound challenge/token for login flows | User-bound challenge and token consumption | Tokens and challenges are single-use, username-scoped objects. |
+| Escalation engine | `/escalate`, `/admin/reload_plugins` | JWT for protected routes | `escalate:write` / `engine:invoke` or admin roles | Metrics surface is operational, not public API. |
+| AI webhook service | `/webhook` | HMAC via `WEBHOOK_SHARED_SECRET` | Action payload validated; IP targets validated before mutation | Rate limited per resolved client IP. |
+| Prompt router | `/route` | Bearer shared secret | No object IDs; access is caller-wide | Client IP attribution only trusts configured proxy/CDN CIDRs. |
+| Cloud dashboard | `/register`, `/metrics`, `/metrics/{installation_id}`, `/ws/{installation_id}` | `X-API-Key` when `CLOUD_DASHBOARD_API_KEY` is configured; required in production | Metrics and websocket access are installation-scoped | Websocket access also requires prior installation registration. |
+| Config recommender | `/recommendations` | `X-API-Key` when `RECOMMENDER_API_KEY` is configured; required in production | Read-only operational output | Production should not expose recommendation output anonymously. |
+| Public blocklist | `/list`, `/list/auth`, `/report` | `/report` and `/list/auth` require `X-API-Key`; `/list` is intentionally public | Report path validates IP objects | Public list endpoint is intentionally community-readable. |
+| Pay-per-crawl | `/register-crawler`, `/pay`, `/{full_path}` | Crawler token via `X-API-Key` for proxy path | Token-scoped crawler record | Register/pay endpoints are product API surface, not admin endpoints. |
+| CAPTCHA services | `/verify`, `/challenge`, `/solve` | Challenge/secret validation, not admin auth | Token-scoped challenge validation | Public by design. |
+| Tarpit | `/`, `/health`, `/tarpit/{path}` | None | None | Public deception surface by design. |
+| IIS gateway | catch-all ingress route | None at edge; relies on middleware and downstream services | No object IDs | Trusts forwarded identity only through configured proxy/CDN CIDRs. |
+
+## Production Baseline
+
+- `INTERNAL_AUTH_MODE=shared_key` remains the supported internal-service auth mode.
+- `SHARED_SECRET`, `PROXY_KEY`, `ESCALATION_API_KEY`, and `WEBHOOK_SHARED_SECRET`
+  are required in production.
+- `CLOUD_DASHBOARD_API_KEY` is required in production.
+- `RECOMMENDER_API_KEY` is required in production.
+- Proxy and CDN client IP headers are only trusted when the immediate peer is in
+  `SECURITY_TRUSTED_PROXY_CIDRS` or `SECURITY_CDN_TRUSTED_PROXY_CIDRS`.
+
+## Intentional Public Surfaces
+
+The following endpoints remain public by design and should be protected by edge
+policy, rate limiting, or product-specific contracts rather than admin auth:
+
+- tarpit routes
+- public blocklist `GET /list`
+- CAPTCHA challenge / verification flows
+- public-facing ingress routes through `iis_gateway`
+- pay-per-crawl product routes using crawler tokens rather than operator credentials

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,7 @@ To get a full understanding of the project, please review the following document
 - [License Summary](../license_summary.md)
 - [Third-Party Licenses](third_party_licenses.md)
 - [Privacy Policy](privacy_policy.md)
+- [API Trust Boundaries](api_trust_boundaries.md)
 - [Security Disclosure Policy](../SECURITY.md)
 - [Compliance Checklist](legal_compliance.md)
 

--- a/prompt-router/main.py
+++ b/prompt-router/main.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException, Request, Response
 from src.shared.mcp_client import MCPClientError, call_mcp_tool
 from src.shared.middleware import SecuritySettings, create_app
 from src.shared.observability import ObservabilitySettings
+from src.shared.request_identity import resolve_request_identity
 from src.shared.request_utils import read_json_body
 from src.shared.service_identity import build_cloud_proxy_headers
 
@@ -33,11 +34,6 @@ if not SHARED_SECRET:
     )
 RATE_LIMIT_REQUESTS = int(os.getenv("RATE_LIMIT_REQUESTS", "60"))
 RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))
-TRUST_PROXY_HEADERS = os.getenv("TRUST_PROXY_HEADERS", "false").lower() in (
-    "1",
-    "true",
-    "yes",
-)
 
 
 def count_tokens(text: str) -> int:
@@ -89,14 +85,7 @@ async def _dispatch_prompt(target: str, payload: dict) -> dict:
 
 
 def get_client_ip(request: Request) -> str:
-    if TRUST_PROXY_HEADERS:
-        x_forwarded_for = request.headers.get("X-Forwarded-For")
-        if x_forwarded_for:
-            return x_forwarded_for.split(",")[0].strip()
-        x_real_ip = request.headers.get("X-Real-IP")
-        if x_real_ip:
-            return x_real_ip
-    return request.client.host if request.client else "unknown"
+    return resolve_request_identity(request).client_ip
 
 
 def calculate_window_reset(now: float, window: int = RATE_LIMIT_WINDOW) -> int:

--- a/src/shared/config_validator.py
+++ b/src/shared/config_validator.py
@@ -348,6 +348,15 @@ class ConfigLoader:
                         errors.append(
                             f"{secret_name} required when INTERNAL_AUTH_MODE=shared_key in production"
                         )
+            production_api_keys = {
+                "CLOUD_DASHBOARD_API_KEY": os.getenv("CLOUD_DASHBOARD_API_KEY"),
+                "RECOMMENDER_API_KEY": os.getenv("RECOMMENDER_API_KEY"),
+            }
+            for secret_name, value in production_api_keys.items():
+                if not value:
+                    errors.append(
+                        f"{secret_name} required for protected operational APIs in production"
+                    )
         if config.security.admin_ui_password_hash:
             match = BCRYPT_PATTERN.match(config.security.admin_ui_password_hash)
             if not match:

--- a/test/prompt_router/test_prompt_router.py
+++ b/test/prompt_router/test_prompt_router.py
@@ -140,7 +140,6 @@ class TestAuthAndRateLimit(unittest.IsolatedAsyncioTestCase):
                 "SHARED_SECRET": self.shared_secret,
                 "RATE_LIMIT_REQUESTS": "2",
                 "RATE_LIMIT_WINDOW": "10",
-                "TRUST_PROXY_HEADERS": "false",
             },
         )
         self.env.start()
@@ -237,7 +236,11 @@ class TestAuthAndRateLimit(unittest.IsolatedAsyncioTestCase):
 
     async def test_proxy_headers_used_when_trusted(self):
         with patch.dict(
-            os.environ, {"TRUST_PROXY_HEADERS": "true", "RATE_LIMIT_REQUESTS": "1"}
+            os.environ,
+            {
+                "SECURITY_TRUSTED_PROXY_CIDRS": "127.0.0.0/8",
+                "RATE_LIMIT_REQUESTS": "1",
+            },
         ):
             spec.loader.exec_module(pr_module)
             global app
@@ -256,6 +259,32 @@ class TestAuthAndRateLimit(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(resp1.status_code, 200)
         self.assertEqual(resp2.status_code, 200)
+
+    async def test_spoofed_proxy_headers_do_not_change_client_identity(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SECURITY_TRUSTED_PROXY_CIDRS": "10.0.0.0/8",
+                "RATE_LIMIT_REQUESTS": "1",
+            },
+        ):
+            spec.loader.exec_module(pr_module)
+            global app
+            app = pr_module.app
+            resp1 = await self._post(
+                headers={
+                    "Authorization": f"Bearer {self.shared_secret}",
+                    "X-Forwarded-For": "1.1.1.1",
+                }
+            )
+            resp2 = await self._post(
+                headers={
+                    "Authorization": f"Bearer {self.shared_secret}",
+                    "X-Forwarded-For": "2.2.2.2",
+                }
+            )
+        self.assertEqual(resp1.status_code, 200)
+        self.assertEqual(resp2.status_code, 429)
 
     async def test_cleanup_removes_old_ips(self):
         with patch.dict(

--- a/test/shared/test_config_validator.py
+++ b/test/shared/test_config_validator.py
@@ -342,12 +342,46 @@ class TestConfigLoader(unittest.TestCase):
                 "PROXY_KEY": "proxy-secret",
                 "ESCALATION_API_KEY": "escalation-secret",
                 "WEBHOOK_SHARED_SECRET": "webhook-secret",
+                "CLOUD_DASHBOARD_API_KEY": "dashboard-secret",
+                "RECOMMENDER_API_KEY": "recommender-secret",
             },
             clear=True,
         ):
             is_valid, errors = loader.validate_config(config)
 
         self.assertTrue(is_valid, errors)
+
+    def test_validate_production_requires_operational_api_keys(self):
+        env = self.minimal_env.copy()
+        env.update(
+            {
+                "APP_ENV": "production",
+                "DEBUG": "false",
+                "ENABLE_EXTERNAL_API_CLASSIFICATION": "false",
+                "ADMIN_UI_PASSWORD_HASH": "$2b$12$" + "." * 53,
+            }
+        )
+
+        loader = ConfigLoader(strict=False)
+        config = loader.load_from_env(env)
+
+        with patch.dict(
+            os.environ,
+            {
+                "MODEL_URI": env["MODEL_URI"],
+                "ENABLE_EXTERNAL_API_CLASSIFICATION": "false",
+                "SHARED_SECRET": "shared-secret",
+                "PROXY_KEY": "proxy-secret",
+                "ESCALATION_API_KEY": "escalation-secret",
+                "WEBHOOK_SHARED_SECRET": "webhook-secret",
+            },
+            clear=True,
+        ):
+            is_valid, errors = loader.validate_config(config)
+
+        self.assertFalse(is_valid)
+        self.assertTrue(any("CLOUD_DASHBOARD_API_KEY required" in e for e in errors))
+        self.assertTrue(any("RECOMMENDER_API_KEY required" in e for e in errors))
 
     def test_validate_captcha_config(self):
         """Test CAPTCHA configuration validation."""


### PR DESCRIPTION
## Summary
- align prompt-router client IP attribution with the shared trusted proxy/CDN resolver
- require API keys for operational dashboard/recommender surfaces in production validation
- document the current endpoint trust-boundary and object-scope baseline

## Testing
- ./.venv/bin/pre-commit run --files prompt-router/main.py src/shared/config_validator.py test/prompt_router/test_prompt_router.py test/shared/test_config_validator.py docs/api_trust_boundaries.md docs/index.md
- ./.venv/bin/python -m pytest -q test/prompt_router/test_prompt_router.py test/shared/test_config_validator.py
- ./.venv/bin/python -m pytest -q

## Closes
- Closes #1688
