### PR TITLE
Define performance validation flow

### DIFF
--- a/.github/workflows/regression-e2e.yml
+++ b/.github/workflows/regression-e2e.yml
@@ -35,7 +35,12 @@ jobs:
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2
         with: { version: v0.50.0 }
       - name: k6 rich scenarios
-        run: k6 run -e BASE_URL="${{ steps.base.outputs.url }}" .github/tools/e2e/k6-rich.js
+        run: |
+          mkdir -p artifacts/performance
+          k6 run \
+            --summary-export artifacts/performance/k6-linux-summary.json \
+            -e BASE_URL="${{ steps.base.outputs.url }}" \
+            .github/tools/e2e/k6-rich.js
       - name: pytest e2e (Linux)
         run: |
           . .venv/bin/activate
@@ -47,6 +52,13 @@ jobs:
           [ -f "./scripts/security_test.sh" ] && bash ./scripts/security_test.sh || true
           [ -f "./stress_test.sh" ] && bash ./stress_test.sh || true
           [ -f "./scripts/stress_test.sh" ] && bash ./scripts/stress_test.sh || true
+      - name: Upload Linux performance artifacts
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: regression-e2e-linux-performance
+          path: artifacts/performance/
+          if-no-files-found: ignore
   e2e-windows:
     permissions:
       contents: read
@@ -75,7 +87,8 @@ jobs:
       - name: k6 rich scenarios (Windows)
         shell: pwsh
         run: |
-          & "${{ env.K6_EXE }}" run -e BASE_URL="${{ steps.base.outputs.url }}" .github/tools/e2e/k6-rich.js
+          New-Item -ItemType Directory -Force -Path artifacts/performance | Out-Null
+          & "${{ env.K6_EXE }}" run --summary-export artifacts/performance/k6-windows-summary.json -e BASE_URL="${{ steps.base.outputs.url }}" .github/tools/e2e/k6-rich.js
       - name: pytest e2e (Windows)
         shell: pwsh
         run: |
@@ -88,6 +101,13 @@ jobs:
           if (Test-Path "./scripts/security_test.ps1") { ./scripts/security_test.ps1 -ErrorAction Continue }
           if (Test-Path "./stress_test.ps1") { ./stress_test.ps1 -ErrorAction Continue }
           if (Test-Path "./scripts/stress_test.ps1") { ./scripts/stress_test.ps1 -ErrorAction Continue }
+      - name: Upload Windows performance artifacts
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        with:
+          name: regression-e2e-windows-performance
+          path: artifacts/performance/
+          if-no-files-found: ignore
   e2e-macos:
     permissions:
       contents: read

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ To get a full understanding of the project, please review the following document
 - [**Inter-Service Authentication**](inter_service_auth.md)**:** Defines the current shared-key contract for internal HTTP calls.
 - [**API Versioning Policy**](api_versioning.md)**:** Defines the current `unversioned-v1` contract, route classes, and deprecation expectations.
 - [**Monitoring Stack**](monitoring_stack.md)**:** Using Prometheus, Grafana, and Watchtower for observability and automatic updates.
+- [**Performance Validation**](performance_validation.md)**:** Release-facing load, latency, and regression evidence for the stack.
 - [**Release Checklist**](release_checklist.md)**:** Practical validation steps before cutting a tagged release.
 - [**Release Artifacts**](release_artifacts.md)**:** Semver tags, GHCR image publication, signatures, and provenance policy.
 - [**Kubernetes Deployment**](kubernetes_deployment.md)**:** A step-by-step guide for deploying the entire application stack to a production-ready Kubernetes cluster.

--- a/docs/performance_validation.md
+++ b/docs/performance_validation.md
@@ -1,0 +1,77 @@
+# Performance Validation
+
+This document defines the supported performance-validation flow for release
+candidates and staging checks. It consolidates the existing scripts and
+workflows into one repeatable evidence path.
+
+## Validation Layers
+
+### 1. Runtime metrics and service health
+
+Verify the stack is stable before treating any load test as meaningful:
+
+- `/health`
+- `/metrics`
+- `/observability/performance/insights`
+- `/observability/performance/history`
+
+The stack should be healthy and free of obvious startup degradation before load
+tests are interpreted.
+
+### 2. Local and operator load testing
+
+For local experiments or staging smoke tests, use the existing helper tooling
+documented in `docs/getting_started.md`:
+
+- `wrk`
+- `siege`
+- `ab`
+- `k6`
+- `locust`
+
+These tools are suitable for comparative checks, not for proving production
+capacity on their own.
+
+### 3. CI regression validation
+
+The supported CI path is:
+
+- `.github/workflows/regression-e2e.yml`
+  - runs `k6` rich flows against the approved base URL
+  - runs Python E2E tests
+  - runs any repo-local stress/security helper scripts that exist
+- `.github/workflows/comprehensive-performance-audit.yml`
+  - collects static evidence about caching, pooling, async behavior, profiling,
+    and performance-oriented code paths
+
+The regression E2E workflow is the main release-facing performance evidence.
+The comprehensive audit is supporting analysis, not a substitute for load
+validation.
+
+## Required Release Evidence
+
+For a release candidate, capture:
+
+- workflow run URL for `regression-e2e`
+- retained `k6` summary artifact from that run
+- any staging or operator-run load-test notes if the release materially changes
+  traffic behavior
+- a brief note if performance expectations changed or remained stable
+
+## Recommended Review Questions
+
+- Did the request path complete without new 5xx or timeout behavior?
+- Did auth, rate limiting, and edge controls still function under load?
+- Did the release materially change latency-sensitive code paths?
+- Do Grafana/Prometheus metrics show new degradation signals?
+
+## Non-Goals
+
+This workflow does not claim:
+
+- formal capacity certification
+- low-level systems benchmarking
+- hardware-specific optimization proof
+
+Those concerns remain separate from the release baseline unless profiling data
+demonstrates a real bottleneck.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -16,6 +16,8 @@ Use this checklist before cutting a tagged release.
 - Admin UI login works with the configured auth mode
 - Redis, PostgreSQL, and NGINX dependencies start cleanly in compose
 - suspicious traffic can be blocked, tarpitted, and surfaced in the UI
+- `docs/performance_validation.md` evidence is assembled for the release:
+  regression-e2e run URL, retained k6 summary, and any staging load notes
 
 ## Security and Configuration
 


### PR DESCRIPTION
## Summary
- define the supported performance validation path for releases and staging
- retain k6 summaries from the regression E2E workflow as release evidence
- wire the new validation contract into the release checklist and docs index

## Testing
- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files .github/workflows/regression-e2e.yml docs/performance_validation.md docs/index.md docs/release_checklist.md

## Closes
- Closes #1694
