### PR TITLE
Define runtime performance baseline

### DIFF
--- a/docs/hardware_requirements.md
+++ b/docs/hardware_requirements.md
@@ -18,6 +18,9 @@ These are approximate values for local experimentation on Ubuntu Server. Enablin
 
 These values are rough guidelines. Heavier traffic or multiple tenants may require additional resources.
 
+For the broader operator-facing capacity and review model, see
+`docs/runtime_performance_baseline.md`.
+
 ## Local LLM Containers
 
 Running the optional `llama3` or `mixtral` containers requires significantly more horsepower:

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ To get a full understanding of the project, please review the following document
 - [**API Versioning Policy**](api_versioning.md)**:** Defines the current `unversioned-v1` contract, route classes, and deprecation expectations.
 - [**Monitoring Stack**](monitoring_stack.md)**:** Using Prometheus, Grafana, and Watchtower for observability and automatic updates.
 - [**Performance Validation**](performance_validation.md)**:** Release-facing load, latency, and regression evidence for the stack.
+- [**Runtime Performance Baseline**](runtime_performance_baseline.md)**:** Service expectations, capacity signals, and scaling guidance for operators.
 - [**Release Checklist**](release_checklist.md)**:** Practical validation steps before cutting a tagged release.
 - [**Release Artifacts**](release_artifacts.md)**:** Semver tags, GHCR image publication, signatures, and provenance policy.
 - [**Kubernetes Deployment**](kubernetes_deployment.md)**:** A step-by-step guide for deploying the entire application stack to a production-ready Kubernetes cluster.

--- a/docs/operations_playbooks.md
+++ b/docs/operations_playbooks.md
@@ -4,6 +4,9 @@ This document defines the service level objectives (SLOs), incident response
 workflows, and capacity management dashboards for the AI Scraping Defense
 platform.
 
+For the current consolidated operator baseline, see
+`docs/runtime_performance_baseline.md`.
+
 ## Service Level Objectives
 
 | Service             | SLO                                      | Measurement                            |

--- a/docs/runtime_performance_baseline.md
+++ b/docs/runtime_performance_baseline.md
@@ -1,0 +1,89 @@
+# Runtime Performance Baseline
+
+This document defines the current runtime performance baseline for the stack.
+It is not a promise of universal capacity; it is the supported operator-facing
+reference for what to watch, what to review, and how to interpret the current
+service-level guidance.
+
+## Core Service Expectations
+
+The current baseline inherits the SLO-oriented expectations already used in
+operations:
+
+| Service | Baseline expectation | Primary evidence |
+| --- | --- | --- |
+| Escalation Engine | 99.9% of requests under 1.5s | request latency metrics, health checks |
+| AI Service | 99.5% webhook latency under 500ms | latency histograms, audit flow stability |
+| Admin UI | 99% availability | `/health`, auth flow health |
+| Tarpit API | error rate under 0.5% | request/error counters |
+| Cloud Dashboard | metrics fanout under 2s | request latency and websocket behavior |
+
+These are operational review targets, not customer-facing contractual SLAs.
+
+## Capacity Review Signals
+
+The minimum signals to review are:
+
+- CPU usage by service
+- memory usage by service
+- request latency percentiles (`p50`, `p95`, `p99`)
+- queue/concurrency depth where exposed
+- Redis and PostgreSQL health under load
+- performance insights and degradation events from the shared observability layer
+
+If utilisation stays above 70% of allocated resources for multiple review
+windows, operators should plan scaling or workload redistribution.
+
+## Deployment Tiers
+
+### Development / evaluation
+
+- 4 CPU cores
+- 8 GB RAM
+- 10 GB free storage
+
+### Small deployment
+
+- 8 CPU cores
+- 16 GB RAM
+- 20 GB free storage
+
+### Larger deployment
+
+- 16+ CPU cores
+- 32+ GB RAM
+- 40+ GB free storage
+
+Optional local LLM containers materially change these requirements and should be
+treated as separate capacity tiers.
+
+## Scaling Guidance
+
+- scale stateless services horizontally before chasing speculative low-level
+  optimizations
+- use Prometheus/Grafana metrics and the performance analytics endpoints to
+  justify scaling decisions
+- cluster or externalize Redis/PostgreSQL when reliability or sustained load
+  demands it
+- use HPAs or equivalent autoscaling only after the target metrics and review
+  thresholds are understood
+
+## Review Cadence
+
+- during release validation: confirm the regression/load evidence from
+  `docs/performance_validation.md`
+- weekly: review capacity dashboards and recent degradation signals
+- after incidents or major traffic changes: compare current metrics against the
+  most recent stable release evidence
+
+## Non-Goals
+
+This baseline does not claim:
+
+- CPU micro-optimization
+- hardware-specific tuning
+- low-level kernel or memory subsystem tuning
+- guaranteed results across all infrastructure providers
+
+Those remain separate research or hotspot-audit work items unless profiling data
+proves they are necessary.


### PR DESCRIPTION
## Summary
- define the current runtime service/capacity baseline in one operator-facing document
- link the new baseline from the docs index and the existing operations/hardware docs
- consolidate the service-level performance guidance already present in the repo

## Testing
- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files docs/runtime_performance_baseline.md docs/index.md docs/operations_playbooks.md docs/hardware_requirements.md

## Closes
- Closes #1695
