### PR TITLE
Audit service runtime hotspots

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ To get a full understanding of the project, please review the following document
 - [**IIS Deployment**](iis_deployment.md)**:** Running the stack on Windows with IIS as the reverse proxy.
 - [**DevSecOps Integration**](devsecops.md)**:** How security workflows fit into CI/CD and how to extend them safely.
 - [**Guarded Attack Simulation Profiles**](attack_simulation_profiles.md)**:** Versioned, allowlisted attack-regression profiles for Compose, staging, and Kali validation.
+- [**Runtime Hotspots Audit**](runtime_hotspots.md)**:** Current request-path efficiency baselines and the hotspots already addressed.
 - [**Security Assurance Program**](security_assurance_program.md)**:** Release-facing security validation, Kali sweep evidence, operator readiness, and third-party review expectations.
 - [**Security Program Foundations**](security_program.md)**:** Culture, metrics, chaos engineering, and insider threat foundations.
 - [**Supply Chain Security**](security/supply_chain.md)**:** Dependency integrity checks, SBOMs, and CI controls.

--- a/docs/runtime_hotspots.md
+++ b/docs/runtime_hotspots.md
@@ -1,0 +1,19 @@
+# Runtime Hotspots Audit
+
+This audit captures the request-path hotspots that matter for release readiness and the efficiency patterns expected in the stack.
+
+## Baseline expectations
+
+- Request-path services should use the shared Redis connection helper in `src/shared/redis_client.py` instead of creating ad hoc clients.
+- Hot-path outbound HTTP should reuse a process-level client instead of creating a new connection pool per request.
+- SQLite-backed lightweight services should enable WAL mode and a bounded busy timeout to reduce lock churn during bursts.
+
+## Changes made in this pass
+
+- `src/iis_gateway/main.py` now uses the shared Redis helper and a reusable `httpx.AsyncClient` for both escalation calls and backend proxying.
+- `src/pay_per_crawl/db.py` now enables SQLite `WAL`, `synchronous=NORMAL`, and `busy_timeout=5000` to improve write behavior under concurrent activity.
+
+## Ongoing watch points
+
+- File-backed tarpit and local-training paths still do real disk I/O by design and should stay out of latency-sensitive request paths.
+- Operator and maintenance scripts under `scripts/` are not part of the request-path performance baseline and should be judged separately from service runtime behavior.

--- a/src/iis_gateway/main.py
+++ b/src/iis_gateway/main.py
@@ -8,10 +8,10 @@ when a custom HttpModule is not desired.
 import json
 import logging
 import os
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
 import httpx
-import redis
 from cachetools import TTLCache
 from fastapi import Request, Response
 from fastapi.responses import PlainTextResponse
@@ -24,6 +24,7 @@ from src.shared.observability import (
     register_health_check,
     trace_span,
 )
+from src.shared.redis_client import get_redis_connection
 
 
 @dataclass
@@ -53,13 +54,22 @@ BAD_BOTS = [
 
 logger = logging.getLogger("iis_gateway")
 
-app = create_app()
-redis_client = redis.Redis(
-    host=settings.REDIS_HOST,
-    port=settings.REDIS_PORT,
-    db=settings.REDIS_DB_BLOCKLIST,
-    decode_responses=True,
-)
+redis_client = get_redis_connection(db_number=settings.REDIS_DB_BLOCKLIST)
+_http_client: httpx.AsyncClient | None = None
+
+
+@asynccontextmanager
+async def _lifespan(_app):
+    try:
+        yield
+    finally:
+        global _http_client
+        if _http_client is not None:
+            await _http_client.aclose()
+            _http_client = None
+
+
+app = create_app(lifespan=_lifespan)
 
 BLOCK_CACHE = TTLCache(maxsize=10000, ttl=60)
 HOP_BY_HOP_HEADERS = {
@@ -84,6 +94,8 @@ FORWARDED_HEADER_NAMES = {
 
 @register_health_check(app, "iis_gateway_redis", critical=True)
 async def _redis_health() -> HealthCheckResult:
+    if redis_client is None:
+        return HealthCheckResult.unhealthy({"error": "Redis unavailable"})
     try:
         redis_client.ping()
     except RedisError as exc:  # pragma: no cover - external dependency
@@ -91,7 +103,16 @@ async def _redis_health() -> HealthCheckResult:
     return HealthCheckResult.healthy()
 
 
+async def get_http_client() -> httpx.AsyncClient:
+    global _http_client
+    if _http_client is None:
+        _http_client = httpx.AsyncClient(timeout=10.0)
+    return _http_client
+
+
 def ip_blocked(ip: str) -> bool:
+    if redis_client is None:
+        raise RedisError("Redis unavailable")
     if ip in BLOCK_CACHE:
         return BLOCK_CACHE[ip]
     key = f"{settings.TENANT_ID}:blocklist:ip:{ip}"
@@ -106,6 +127,8 @@ def ip_blocked(ip: str) -> bool:
 
 
 def get_ip_throttle_state(ip: str) -> dict | None:
+    if redis_client is None:
+        raise RedisError("Redis unavailable")
     key = f"{THROTTLE_KEY_PREFIX}{ip}"
     try:
         payload = redis_client.get(key)
@@ -139,6 +162,8 @@ async def rate_limited(
     limit = _effective_rate_limit(limit_override)
     if limit <= 0:
         return False, None
+    if redis_client is None:
+        raise RedisError("Redis unavailable")
     key = f"{settings.TENANT_ID}:ratelimit:{ip}"
     try:
         with trace_span(
@@ -164,20 +189,20 @@ async def rate_limited(
 async def escalate(ip: str, reason: str) -> None:
     if not settings.ESCALATION_ENDPOINT:
         return
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        try:
-            with trace_span(
-                "iis_gateway.escalate", attributes={"ip": ip, "reason": reason}
-            ):
-                await client.post(
-                    settings.ESCALATION_ENDPOINT,
-                    json={"ip": ip, "reason": reason},
-                )
-                logger.info("Escalated %s for %s", ip, reason)
-        except httpx.TimeoutException:
-            logger.exception("Escalation request timed out")
-        except httpx.HTTPError:
-            logger.exception("Escalation failed")
+    client = await get_http_client()
+    try:
+        with trace_span(
+            "iis_gateway.escalate", attributes={"ip": ip, "reason": reason}
+        ):
+            await client.post(
+                settings.ESCALATION_ENDPOINT,
+                json={"ip": ip, "reason": reason},
+            )
+            logger.info("Escalated %s for %s", ip, reason)
+    except httpx.TimeoutException:
+        logger.exception("Escalation request timed out")
+    except httpx.HTTPError:
+        logger.exception("Escalation failed")
 
 
 def _build_forward_headers(request: Request) -> dict[str, str]:
@@ -242,25 +267,25 @@ async def proxy(path: str, request: Request) -> Response:
         await escalate(client_ip, "SuspiciousAccept")
 
     url = f"{settings.BACKEND_URL.rstrip('/')}/{path}"
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        try:
-            with trace_span(
-                "iis_gateway.proxy_request",
-                attributes={"path": path, "method": request.method},
-            ):
-                resp = await client.request(
-                    request.method,
-                    url,
-                    headers=_build_forward_headers(request),
-                    content=request.stream(),
-                    params=request.query_params,
-                )
-        except httpx.TimeoutException:
-            logger.exception("Backend request timed out")
-            return PlainTextResponse("Gateway Timeout", status_code=504)
-        except httpx.HTTPError:
-            logger.exception("Backend request failed")
-            return PlainTextResponse("Bad Gateway", status_code=502)
+    client = await get_http_client()
+    try:
+        with trace_span(
+            "iis_gateway.proxy_request",
+            attributes={"path": path, "method": request.method},
+        ):
+            resp = await client.request(
+                request.method,
+                url,
+                headers=_build_forward_headers(request),
+                content=request.stream(),
+                params=request.query_params,
+            )
+    except httpx.TimeoutException:
+        logger.exception("Backend request timed out")
+        return PlainTextResponse("Gateway Timeout", status_code=504)
+    except httpx.HTTPError:
+        logger.exception("Backend request failed")
+        return PlainTextResponse("Bad Gateway", status_code=502)
 
     return Response(
         content=resp.content, status_code=resp.status_code, headers=resp.headers

--- a/src/pay_per_crawl/db.py
+++ b/src/pay_per_crawl/db.py
@@ -27,6 +27,9 @@ def init_db(db_path: str = DB_PATH) -> sqlite3.Connection:
             _CONNECTION = None
     if _CONNECTION is None:
         _CONNECTION = sqlite3.connect(db_path)
+        _CONNECTION.execute("PRAGMA journal_mode=WAL")
+        _CONNECTION.execute("PRAGMA synchronous=NORMAL")
+        _CONNECTION.execute("PRAGMA busy_timeout=5000")
         _CONNECTION.execute(
             "CREATE TABLE IF NOT EXISTS crawlers (token TEXT PRIMARY KEY, name TEXT, purpose TEXT, balance REAL DEFAULT 0)"
         )

--- a/test/iis_gateway/test_iis_gateway_app.py
+++ b/test/iis_gateway/test_iis_gateway_app.py
@@ -24,22 +24,25 @@ class TestIISGateway(unittest.TestCase):
 
         self.redis_mock = MagicMock()
         self.gateway.redis_client = self.redis_mock
+        self.gateway._http_client = None
         self.redis_mock.get.return_value = None
         self.redis_mock.ttl.return_value = 60
 
         self.escalate_patch = patch("src.iis_gateway.main.escalate", new=AsyncMock())
         self.escalate_patch.start()
 
-        async_client_instance = AsyncMock()
-        async_client_instance.request.return_value = MagicMock(
+        self.async_client_instance = AsyncMock()
+        self.async_client_instance.request.return_value = MagicMock(
             content=b"ok", status_code=200, headers={}
         )
-        self.async_client_instance = async_client_instance
-        self.httpx_patch = patch("src.iis_gateway.main.httpx.AsyncClient")
+        self.httpx_patch = patch(
+            "src.iis_gateway.main.httpx.AsyncClient",
+            return_value=self.async_client_instance,
+        )
         self.httpx_mock = self.httpx_patch.start()
-        self.httpx_mock.return_value.__aenter__.return_value = async_client_instance
 
     def tearDown(self):
+        self.gateway._http_client = None
         self.httpx_patch.stop()
         self.escalate_patch.stop()
         self.env.stop()
@@ -122,6 +125,18 @@ class TestIISGateway(unittest.TestCase):
         self.assertEqual(forwarded_headers["X-Real-IP"], "testclient")
         self.assertEqual(forwarded_headers["X-Forwarded-Proto"], "http")
         self.assertEqual(forwarded_headers["X-Forwarded-Port"], "80")
+
+    def test_proxy_reuses_single_http_client(self):
+        self.redis_mock.exists.return_value = False
+        self.redis_mock.incr.side_effect = [1, 1]
+        self.redis_mock.expire.return_value = True
+
+        first = self.client.get("/first")
+        second = self.client.get("/second")
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.httpx_mock.assert_called_once_with(timeout=10.0)
 
 
 if __name__ == "__main__":

--- a/test/pay_per_crawl/test_db.py
+++ b/test/pay_per_crawl/test_db.py
@@ -56,6 +56,17 @@ class TestCrawlerDB(unittest.TestCase):
         info: Optional[Dict[str, str]] = db.get_crawler("nope")
         self.assertIsNone(info)
 
+    def test_init_db_enables_sqlite_contention_pragmas(self) -> None:
+        conn = db.init_db(self.db_path)
+
+        journal_mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        synchronous = conn.execute("PRAGMA synchronous").fetchone()[0]
+        busy_timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+
+        self.assertEqual(str(journal_mode).lower(), "wal")
+        self.assertEqual(int(synchronous), 1)
+        self.assertEqual(int(busy_timeout), 5000)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reuse the shared Redis helper and a single process HTTP client in the IIS gateway hot path
- tune the pay-per-crawl SQLite connection for WAL mode and bounded busy timeout
- document the current runtime hotspot baseline and add regression coverage

## Testing
- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files src/iis_gateway/main.py src/pay_per_crawl/db.py test/iis_gateway/test_iis_gateway_app.py test/pay_per_crawl/test_db.py docs/runtime_hotspots.md docs/index.md
- /home/rich/dev/ai-scraping-defense/.venv/bin/python -m pytest -q test/iis_gateway/test_iis_gateway_app.py test/pay_per_crawl/test_db.py
- /home/rich/dev/ai-scraping-defense/.venv/bin/python -m pytest -q