### PR TITLE
Define engineering quality baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,17 @@ We welcome meaningful contributions, including but not limited to:
 8. **Push to Your Fork:** `git push origin feature/your-new-feature`
 9. **Submit a Pull Request:** Open a PR against the `main` branch of the original repository. Fill out the PR template clearly.
 
+## Engineering Quality Baseline
+
+Contributions should meet the engineering-quality baseline in [docs/engineering_quality_baseline.md](docs/engineering_quality_baseline.md). In practice, that means:
+
+- run `pre-commit` on the files you changed
+- run the relevant test suite for the code path you touched
+- update docs when config, deployment, API, or operator behavior changes
+- avoid mixing unrelated refactors into security or behavior fixes
+
+The baseline document also explains how local validation maps to the repository CI and release gates.
+
 ## Code Style (Example)
 
 - Follow PEP 8 for Python.

--- a/docs/engineering_quality_baseline.md
+++ b/docs/engineering_quality_baseline.md
@@ -1,0 +1,85 @@
+# Engineering Quality Baseline
+
+This document defines the current engineering-quality baseline for the AI Scraping Defense Stack. It is intended to turn broad "code quality" goals into concrete expectations that contributors, reviewers, and release owners can verify.
+
+## Goals
+
+The baseline exists to keep the stack:
+
+- maintainable across multiple Python services and support scripts
+- testable on Linux, Windows, and macOS
+- predictable under CI and release workflows
+- safe to evolve without weakening security, observability, or deployment behavior
+
+## Contributor Expectations
+
+Before opening a pull request, contributors should:
+
+- run `pre-commit` on changed files
+- run the relevant test suite for the area they changed
+- keep changes small enough for focused review when possible
+- update docs when behavior, configuration, or deployment expectations change
+- avoid mixing unrelated refactors with behavioral fixes
+
+For broad setup instructions, see [../CONTRIBUTING.md](../CONTRIBUTING.md). For scanning-specific workflows, see [code_scanning_process.md](code_scanning_process.md).
+
+## Required Validation
+
+The minimum local validation depends on the change:
+
+- Python code or tests: `python -m pytest -q test`
+- shell scripts: `pre-commit` and syntax validation where applicable
+- PowerShell scripts: `pre-commit` and script-analyzer compatibility
+- Docker, NGINX, or deployment config: `docker compose config` and the relevant config validation path
+- release-facing performance or security changes: update the supporting evidence called out in the release and assurance docs
+
+Contributors should prefer the narrowest useful command while iterating, then run the broader suite before merge if the change can affect shared behavior.
+
+## CI Baseline
+
+The repository's baseline quality gate is the `CI Tests (Linux, Windows, macOS)` workflow in `.github/workflows/ci-tests.yml`. It currently enforces:
+
+- Python test execution on Linux, Windows, and macOS
+- Rust test, formatting, and clippy coverage for tracked crates
+- Node test execution when frontend packages are present
+- shell linting with ShellCheck
+- Lua linting with `luacheck`
+- NGINX syntax validation using the hardened OpenResty configuration
+- Helm and Kubernetes manifest validation where chart content exists
+
+Additional targeted workflows cover release images, attack-regression checks, code scanning, and security automation. Those workflows complement the baseline; they do not replace it.
+
+## Engineering Rules
+
+Changes should preserve or improve the following properties:
+
+- Inputs are validated before they influence routing, shell execution, persistence, or outbound requests.
+- Outputs are encoded or constrained appropriately for HTML, JSON, shell, and config contexts.
+- Exceptions fail safely, emit useful logs, and do not leak secrets or internal-only details.
+- Shared utilities are reused instead of reimplementing auth, secret loading, request identity, or Redis access ad hoc in each service.
+- Long-lived resources such as HTTP clients, database handles, and Redis connections are reused or cleaned up explicitly.
+- New dependencies are justified, pinned through the repo's dependency management flow, and covered by the existing audit path.
+- Tests cover both the intended success path and at least the key failure or abuse path for the change.
+
+## Review Expectations
+
+Reviewers should look for:
+
+- behavioral regressions in request handling, auth, persistence, and operator workflows
+- missing tests or docs for new config, deployment, or API behavior
+- duplicate logic that should move into shared modules
+- weak error handling, silent failure, or misleading logging
+- hidden runtime costs such as per-request client creation, blocking I/O on hot paths, or repeated config parsing
+
+## Release Evidence
+
+Release candidates should have objective evidence that the baseline still holds:
+
+- CI is green on the release commit
+- release checklist items in [release_checklist.md](release_checklist.md) are complete
+- performance evidence in [performance_validation.md](performance_validation.md) is current when request-path behavior changed
+- security evidence in [security_assurance_program.md](security_assurance_program.md) is current when trust boundaries, auth, or attack handling changed
+
+## Out of Scope
+
+This baseline is intentionally practical. It does not attempt to encode speculative research work, experimental architecture ideas, or culture goals. Those belong in roadmap issues and design work, not in the required merge gate for everyday changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ To get a full understanding of the project, please review the following document
 - [**Monitoring Stack**](monitoring_stack.md)**:** Using Prometheus, Grafana, and Watchtower for observability and automatic updates.
 - [**Performance Validation**](performance_validation.md)**:** Release-facing load, latency, and regression evidence for the stack.
 - [**Runtime Performance Baseline**](runtime_performance_baseline.md)**:** Service expectations, capacity signals, and scaling guidance for operators.
+- [**Engineering Quality Baseline**](engineering_quality_baseline.md)**:** Contributor, reviewer, CI, and release expectations for maintainable, testable changes.
 - [**Release Checklist**](release_checklist.md)**:** Practical validation steps before cutting a tagged release.
 - [**Release Artifacts**](release_artifacts.md)**:** Semver tags, GHCR image publication, signatures, and provenance policy.
 - [**Kubernetes Deployment**](kubernetes_deployment.md)**:** A step-by-step guide for deploying the entire application stack to a production-ready Kubernetes cluster.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -9,6 +9,7 @@ Use this checklist before cutting a tagged release.
 - `docker build -t ai-scraping-defense:test .`
 - `docker compose config`
 - any Rust crates used in production paths pass `cargo test`
+- engineering-quality evidence from `docs/engineering_quality_baseline.md` is satisfied for the release commit: contributor checks, CI baseline, and review expectations are all covered by the shipped change set
 
 ## Runtime Validation
 


### PR DESCRIPTION
## Summary\n- add a concrete engineering-quality baseline for contributors, reviewers, CI, and release owners\n- link the new baseline from the contributor guide and docs index\n- require engineering-quality evidence in the release checklist\n\n## Testing\n- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files CONTRIBUTING.md docs/engineering_quality_baseline.md docs/index.md docs/release_checklist.md\n\nCloses #1709