### PR TITLE
Align upstream release metadata and deployment docs

### DIFF
--- a/.github/workflows/release-bundles.yml
+++ b/.github/workflows/release-bundles.yml
@@ -25,10 +25,15 @@ jobs:
 
           ref_name="${GITHUB_REF_NAME}"
           version="${ref_name#v}"
+          prerelease="false"
 
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
             echo "Release tags must follow v<semver>; received '$ref_name'." >&2
             exit 1
+          fi
+
+          if [[ "$version" == *-* ]]; then
+            prerelease="true"
           fi
 
           prefix="ai-scraping-defense-${version}"
@@ -37,6 +42,7 @@ jobs:
 
           {
             echo "version=${version}"
+            echo "prerelease=${prerelease}"
             echo "prefix=${prefix}"
             echo "zip_name=${zip_name}"
             echo "tar_name=${tar_name}"
@@ -106,11 +112,26 @@ jobs:
               artifacts/release-bundles/release-notes-fragment.md \
               artifacts/release-bundles/release-notes.md
 
-            gh release edit "$GITHUB_REF_NAME" --notes-file artifacts/release-bundles/release-notes.md
+            edit_args=(
+              "$GITHUB_REF_NAME"
+              --notes-file artifacts/release-bundles/release-notes.md
+            )
+            if [[ "${{ steps.refs.outputs.prerelease }}" == "true" ]]; then
+              edit_args+=(--prerelease)
+            else
+              edit_args+=(--latest)
+            fi
+            gh release edit "${edit_args[@]}"
           else
-            gh release create "$GITHUB_REF_NAME" \
-              --title "$GITHUB_REF_NAME" \
+            create_args=(
+              "$GITHUB_REF_NAME"
+              --title "$GITHUB_REF_NAME"
               --notes-file artifacts/release-bundles/release-notes-fragment.md
+            )
+            if [[ "${{ steps.refs.outputs.prerelease }}" == "true" ]]; then
+              create_args+=(--prerelease)
+            fi
+            gh release create "${create_args[@]}"
           fi
 
       - name: Upload Workflow Artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.6-rc.4] - 2026-03-17
 ### Added
 * **Threat Model Document:** Added docs/threat_model.md and linked from the README.
 * **Automated Dependency Scanning:** Added Dependabot configuration and pip-audit workflow.
 * **Release Artifact Policy:** Added a tagged container-image release workflow plus release artifact and checklist documentation.
 * **Installer Release Bundles:** Added a tagged release workflow that publishes versioned `.zip` and `.tar.gz` repository bundles with SHA-256 checksums for the existing Linux, Windows, and macOS installers.
+* **Release Baseline Documents:** Added explicit release-facing documents for engineering quality, architecture modernization, runtime performance, data protection, platform runtime security, and security assurance.
+* **Release Evidence Workflows:** Added the attack-regression, regression-E2E, and Kali sweep workflow contracts to the documented release path.
 
 
 ### Changed
 
 * **Release Notes Preservation:** Updated the installer-bundle release workflow so reruns replace only an auto-managed installer bundle section and keep manual GitHub Release notes intact.
+* **Release Metadata Semantics:** Release-candidate tags are now treated as prereleases by the release bundle workflow instead of being published like stable latest releases.
 
 * **Markov Training Utility:** Removed `rag/train_markov_postgres.py` and now build the Markov model using the Rust `markov-train-rs` crate via `train_from_corpus_rs`.
 * **Environment Variables:** Replaced deprecated `TARPIT_MAX_HOPS` and `TARPIT_HOP_WINDOW_SECONDS` with `TAR_PIT_MAX_HOPS` and `TAR_PIT_HOP_WINDOW_SECONDS`.
 * **Documentation:** Updated repository references to highlight `src/`, `scripts/`, and `rag/` directories.
 * **CI Test Scope:** Consolidated the main cross-platform test path into `ci-tests.yml` and repurposed `tests.yml` into a dedicated Rust nightly smoke workflow to avoid redundant PR checks.
 * **Generated Artifacts:** Stopped tracking generated IIS `.NET` NuGet files from `iis/DefenseModule/obj/`.
+* **Operator Documentation:** Corrected stale local/prod deployment examples, script paths, and port references so the README and setup docs match the current Compose and installer defaults.
 
 ## **[0.0.5] - 2025-05-25**
 

--- a/README.md
+++ b/README.md
@@ -552,14 +552,14 @@ The script applies all manifests using `kubectl`; it does not generate secrets.
 
 ## Manual Kubernetes Deployment
 
-For a detailed, step-by-step guide see [docs/kubernetes_deployment.md](docs/kubernetes_deployment.md). The `deploy.sh` and `deploy.ps1` scripts provide a manual approach if you need more control.
+For a detailed, step-by-step guide see [docs/kubernetes_deployment.md](docs/kubernetes_deployment.md). The `scripts/linux/deploy.sh` and `scripts/windows/deploy.ps1` scripts provide a manual approach if you need more control.
 
 ## Cloud Deployment (GKE Example)
 
 To deploy the stack to a managed Kubernetes service such as Google Kubernetes Engine, follow the instructions in [docs/cloud_provider_deployment.md](docs/cloud_provider_deployment.md). Convenience scripts are provided for automation:
 
 ```bash
-./gke_deploy.sh       # or .\gke_deploy.ps1 on Windows
+./scripts/linux/gke_deploy.sh       # or .\scripts\windows\gke_deploy.ps1 on Windows
 ```
 
 ### GitHub Actions Runner Deployment
@@ -580,11 +580,11 @@ It installs common open-source tools such as **wrk**, **siege**, **ab**, **k6**,
 After installing the tools, you can run a basic stress test using the provided scripts:
 
 ```powershell
-./stress_test.ps1 -Target http://your-linux-host:8080 -VUs 50 -DurationSeconds 30
+./stress_test.ps1 -Target http://your-linux-host:8088 -VUs 50 -DurationSeconds 30
 ```
 
 ```bash
-./stress_test.sh http://your-linux-host:8080
+./stress_test.sh http://your-linux-host:8088
 ```
 
 ## Security Scan Helper

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # **Roadmap**
 
-## **Current Version: v1.0 (Stable)**
+## **Current Version: v0.0.6-rc.4 (Release Candidate)**
 
-The AI Scraping Defense Stack now provides a stable, containerized defense system with real-time filtering, tarpitting, behavioral analysis, and AI-driven threat assessment.
+The AI Scraping Defense Stack currently ships as a release candidate with a stable core feature set and an explicit release-hardening path around evidence, documentation, and operator readiness.
 
 ## **Short-Term Goals (Next 3-6 Months)**
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -149,7 +149,7 @@ With the configuration and secrets in place, you can now build and start all the
 
 ``` bash
 # On Linux or macOS
-docker-compose up --build -d
+docker compose up --build -d
 ```
 
 If you are running Docker from a snap-packaged Linux install and the Python
@@ -162,7 +162,7 @@ docker compose -f docker-compose.yaml -f docker-compose.local.yaml up --build -d
 
 ``` PowerShell
 # On Windows (in a PowerShell terminal)
-docker-compose up --build -d
+docker compose up --build -d
 ```
 
 * --build: This tells Docker Compose to build the Python service image using the Dockerfile.
@@ -173,7 +173,8 @@ docker-compose up --build -d
 Once the containers are running, you can access the key services in your web browser:
 
 * **Admin UI:** [http://localhost:5002](http://localhost:5002)
-* **Your Application (via Nginx Proxy):** [http://localhost:8080](http://localhost:8080)
+* **Your Application (via Nginx Proxy):** [http://localhost:8088](http://localhost:8088)
+* **TLS Test Path (via Nginx Proxy):** [https://localhost:8443](https://localhost:8443)
 * **MailHog (Email Catcher):** [http://localhost:8025](http://localhost:8025)
 * **Redis (for blocklist management):** [http://localhost:6379](http://localhost:6379) (not directly accessible via a web interface, but can be managed using Redis CLI or GUI tools).
 * **Blocklist Sync Daemon:** runs automatically to pull updates from the community blocklist service.
@@ -202,7 +203,7 @@ If you want to see how the defense stack performs in front of a real CMS, a help
 ./setup_wordpress_website.sh (or ./setup_wordpress_website.ps1 on Windows)
 ```
 
-The script starts the Docker Compose stack (if it is not already running) and then launches WordPress and its MariaDB database on the same `defense_network`. Traffic allowed by the proxy will reach WordPress via `REAL_BACKEND_HOSTS` (or `REAL_BACKEND_HOST`). The helper sets this value in `.env` for you, and `setup_fake_website.sh` does the same when launching a simple nginx site. Once started you can visit the site directly at [http://localhost:8082](http://localhost:8082) or through the defense stack at [http://localhost:8080](http://localhost:8080).
+The script starts the Docker Compose stack (if it is not already running) and then launches WordPress and its MariaDB database on the same `defense_network`. Traffic allowed by the proxy will reach WordPress via `REAL_BACKEND_HOSTS` (or `REAL_BACKEND_HOST`). The helper sets this value in `.env` for you, and `setup_fake_website.sh` does the same when launching a simple nginx site. Once started you can visit the site directly at [http://localhost:8082](http://localhost:8082) or through the defense stack at [http://localhost:8088](http://localhost:8088).
 
 ### **7. Stopping the Application**
 
@@ -210,12 +211,12 @@ To stop the application stack, you can run:
 
 ``` bash
 # On Linux or macOS
-docker-compose down
+docker compose down
 ```
 
 ``` PowerShell
 # On Windows (in a PowerShell terminal)
-docker-compose down
+docker compose down
 ```
 
 This will stop and remove all the containers defined in your docker-compose.yml file.
@@ -231,9 +232,9 @@ For load and performance experiments, a helper script installs several open-sour
 The script installs utilities like **wrk**, **siege**, **ab**, **k6**, and **locust**. After installation, you can try commands such as:
 
 ```bash
-wrk -t4 -c100 -d30s http://localhost:8080
-siege -c50 -t1m http://localhost:8080
-ab -n 1000 -c100 http://localhost:8080/
+wrk -t4 -c100 -d30s http://localhost:8088
+siege -c50 -t1m http://localhost:8088
+ab -n 1000 -c100 http://localhost:8088/
 ```
 
 Use these programs only against systems you own or have explicit permission to test.
@@ -291,7 +292,7 @@ CLOUDFLARE_TUNNEL_TOKEN=<your_tunnel_token> ./scripts/linux/start_cloudflare_tun
 By default the tunnel forwards to `http://localhost:${NGINX_HTTP_PORT}`. Override with:
 
 ```bash
-CLOUDFLARE_TUNNEL_TARGET_URL=http://localhost:8080 ./scripts/linux/start_cloudflare_tunnel.sh
+CLOUDFLARE_TUNNEL_TARGET_URL=http://localhost:8088 ./scripts/linux/start_cloudflare_tunnel.sh
 ```
 
 ## **Running Local LLM Containers**
@@ -321,7 +322,7 @@ This script generates the required secrets and applies all manifests using `kube
 
 ## **Manual Kubernetes Deployment**
 
-For a detailed walkthrough see [kubernetes_deployment.md](kubernetes_deployment.md). The `deploy.sh` and `deploy.ps1` scripts allow you to apply the manifests manually when you need more control over the process.
+For a detailed walkthrough see [kubernetes_deployment.md](kubernetes_deployment.md). The `scripts/linux/deploy.sh` and `scripts/windows/deploy.ps1` scripts allow you to apply the manifests manually when you need more control over the process.
 
 ## **Running Multiple Tenants**
 

--- a/docs/test_to_production.md
+++ b/docs/test_to_production.md
@@ -41,11 +41,11 @@ Follow these steps in your **Terminal (Mac/Linux)** or **PowerShell (Windows)**.
    ```
 
    *(If you ran git pull above, you can skip this step as you are already in the correct directory.)*
-3. **Run the Quick Deploy Script:** This is the easiest way to start the system locally. It will use test ports like 8080 to avoid conflicting with other services on your computer.
+3. **Run the Quick Deploy Script:** This is the easiest way to start the system locally. It uses the default development ports from `sample.env`, which are `8088` and `8443` for the proxy so it can coexist with other host web servers.
    * **Mac/Linux:** ```./scripts/linux/quick_deploy.sh```
    * **Windows:** ```./scripts/windows/quick_deploy.ps1```
 
-At this point, you can connect the system to a local or test website. The key thing to remember is that this local setup uses http://localhost:8080 for the website and http://localhost:8081 for the admin panel.
+At this point, you can connect the system to a local or test website. By default, this local setup uses `http://localhost:8088` for the proxied website, `https://localhost:8443` for TLS testing, and `http://localhost:5002` for the admin UI.
 
 ### **Part 2: Production Deployment**
 
@@ -102,18 +102,12 @@ This is the most important step. You need to edit two files: .env and docker-com
    * **DOMAIN_NAME**: Set this to your actual domain name (e.g., your-cool-site.com). This is required for obtaining an SSL certificate.
    * **CERTBOT_EMAIL**: Provide your email address. This is used by Let's Encrypt to notify you about your certificate.
    * **Set Strong Secrets:** Change all the default passwords and secrets in this file to secure, randomly generated values.
-2. Edit the docker-compose.yaml file:
-   We need to change the ports for the NGINX service so it listens on the standard web ports.
-   * Find the nginx service definition.
-   * Change the ports section from 8080:80 to listen on ports 80 and 443.
-
-**Change this:**  ports:
-    - "8080:80"
-    - "8081:81"
-**To this:**  ports:
-    - "80:80"
-    - "443:443"
-    - "8081:81" # Keep this for the admin panel, but consider securing it.
+2. Review the port values in `.env`:
+   We need the proxy to listen on the standard production ports.
+   * Set `NGINX_HTTP_PORT=80`
+   * Set `NGINX_HTTPS_PORT=443`
+   * Keep `ADMIN_UI_PORT=5002` on a private network or firewall it to trusted operator IPs
+   * If you use the optional Apache path, update `APACHE_HTTP_PORT` only if you actually enable that service
 
 #### **Step 4: Launch and Secure the System**
 
@@ -121,12 +115,12 @@ This is the most important step. You need to edit two files: .env and docker-com
    * **On your server's terminal:**
 
      ```
-     ./deploy.sh
+     ./scripts/linux/deploy.sh
      ```
 
 2. **Verify It's Working:**
    * Open a web browser and navigate to https://your-cool-site.com. You should see your website, now secured with an "https://" connection.
-   * You can access the admin panel at http://<your_server_ip>:8081. For production, you should lock this down to be accessible only from your IP address.
+   * You can access the admin panel at http://<your_server_ip>:5002. For production, restrict it to trusted operator networks.
 
 #### **Production Architecture Diagram**
 
@@ -147,5 +141,5 @@ graph TD
 Run this command from the project directory on your server:
 
 ```
-docker-compose down
+docker compose down
 ```


### PR DESCRIPTION
## Summary\n- treat RC tags as GitHub prereleases in the release bundle workflow\n- move the current release-candidate state into the changelog and roadmap docs\n- correct deployment docs that still referenced stale script paths and default ports\n\n## Validation\n- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files .github/workflows/release-bundles.yml CHANGELOG.md docs/ROADMAP.md docs/test_to_production.md README.md docs/getting_started.md\n- gh workflow run "Security Attack Regression"\n- gh workflow run "Regression E2E (Linux/Windows/macOS)"\n\n## Follow-up evidence state\n- Security Attack Regression on current main: success\n- Regression E2E on current main: failed immediately and needs separate workflow triage\n- Kali Security Sweep still depends on a self-hosted Kali runner