### PR TITLE
Clarify security runner contracts and Regression E2E targets

### DIFF
--- a/.github/workflows/kali-security-sweep.yml
+++ b/.github/workflows/kali-security-sweep.yml
@@ -6,7 +6,7 @@ on:
         description: "Target host or IP for network-oriented scans"
         required: false
       web_url:
-        description: "Public base URL to probe"
+        description: "Approved base URL to probe from the self-hosted Kali runner"
         required: false
       docker_image:
         description: "Optional container image to scan"
@@ -15,6 +15,9 @@ on:
         description: "Source directory for static scans"
         required: false
         default: "."
+      report_subdir:
+        description: "Optional report folder suffix under reports/"
+        required: false
   schedule:
     - cron: "20 6 * * *"
 permissions:
@@ -24,13 +27,14 @@ concurrency:
   cancel-in-progress: false
 jobs:
   kali-sweep:
-    runs-on: [self-hosted, linux, kali]
+    runs-on: [self-hosted, linux, kali, security-scan]
     timeout-minutes: 120
     env:
       TARGET: ${{ inputs.target || secrets.SECURITY_SCAN_TARGET || '' }}
       WEB_URL: ${{ inputs.web_url || secrets.SECURITY_SCAN_WEB_URL || '' }}
       DOCKER_IMAGE: ${{ inputs.docker_image || secrets.SECURITY_SCAN_DOCKER_IMAGE || '' }}
       CODE_DIR: ${{ inputs.code_dir || '.' }}
+      REPORT_SUBDIR: ${{ inputs.report_subdir || github.run_id }}
       SQLMAP_URL: ${{ secrets.SECURITY_SCAN_SQLMAP_URL || '' }}
       API_BASE_URL: ${{ secrets.SECURITY_SCAN_API_BASE_URL || '' }}
       OPENAPI_SPEC_URL: ${{ secrets.SECURITY_SCAN_OPENAPI_SPEC_URL || '' }}
@@ -38,8 +42,9 @@ jobs:
       LLM_AUTH_TOKEN: ${{ secrets.SECURITY_SCAN_LLM_AUTH_TOKEN || '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Validate scan target
+      - name: Validate self-hosted Kali sweep contract
         run: |
+          set -euo pipefail
           if [ -z "$TARGET" ]; then
             echo "TARGET is required. Provide workflow input 'target' or SECURITY_SCAN_TARGET."
             exit 1
@@ -48,9 +53,12 @@ jobs:
             echo "WEB_URL is required. Provide workflow input 'web_url' or SECURITY_SCAN_WEB_URL."
             exit 1
           fi
+          echo "Self-hosted Kali sweeps are intended for approved staging, preview, or release-candidate targets."
+          echo "Use the GitHub-hosted Security Attack Regression workflow for required PR-time compose validation."
       - name: Run Kali security sweep
         run: |
-          mkdir -p reports
+          export REPORT_DIR="$GITHUB_WORKSPACE/reports/$REPORT_SUBDIR"
+          mkdir -p "$REPORT_DIR"
           bash ./scripts/linux/security_scan.sh \
             "$TARGET" \
             "$WEB_URL" \

--- a/.github/workflows/regression-e2e.yml
+++ b/.github/workflows/regression-e2e.yml
@@ -5,6 +5,9 @@ on:
       environment:
         description: "Target environment (staging|production|preview)"
         required: false
+      base_url:
+        description: "Explicit E2E base URL. Required for preview targets and recommended for ad hoc runs."
+        required: false
       ref:
         description: "Git ref to run against"
         required: false
@@ -14,7 +17,70 @@ concurrency:
   group: ${{ github.workflow }}-${{ inputs.environment || github.ref }}
   cancel-in-progress: true
 jobs:
+  resolve-target:
+    runs-on: ubuntu-latest
+    outputs:
+      base_url: ${{ steps.resolve.outputs.base_url }}
+      target_source: ${{ steps.resolve.outputs.target_source }}
+    steps:
+      - name: Resolve E2E target
+        id: resolve
+        shell: bash
+        env:
+          INPUT_BASE_URL: ${{ inputs.base_url || '' }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment || '' }}
+          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL || '' }}
+          PROD_BASE_URL: ${{ secrets.PROD_BASE_URL || '' }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_BASE_URL" ]; then
+            base_url="$INPUT_BASE_URL"
+            target_source="workflow input"
+          else
+            case "$INPUT_ENVIRONMENT" in
+              production)
+                base_url="$PROD_BASE_URL"
+                target_source="PROD_BASE_URL secret"
+                ;;
+              preview)
+                echo "Preview E2E runs require workflow_dispatch input 'base_url'." >&2
+                echo "Regression E2E is an external-target workflow. For preview environments, pass an explicit preview URL." >> "$GITHUB_STEP_SUMMARY"
+                exit 1
+                ;;
+              ""|staging)
+                base_url="$STAGING_BASE_URL"
+                target_source="STAGING_BASE_URL secret"
+                ;;
+              *)
+                echo "Unsupported environment '$INPUT_ENVIRONMENT'. Use staging, production, or preview." >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          if [ -z "$base_url" ]; then
+            cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+Regression E2E needs an explicit external target.
+
+- For staging runs, set the `STAGING_BASE_URL` repository secret.
+- For production runs, set the `PROD_BASE_URL` repository secret and pass `environment=production`.
+- For preview or ad hoc runs, pass the `base_url` workflow_dispatch input.
+EOF
+            echo "No usable base URL was provided for Regression E2E." >&2
+            exit 1
+          fi
+
+          echo "base_url=$base_url" >> "$GITHUB_OUTPUT"
+          echo "target_source=$target_source" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Regression E2E target"
+            echo
+            echo "- Base URL: \`$base_url\`"
+            echo "- Source: $target_source"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   e2e-linux:
+    needs: resolve-target
     permissions:
       contents: read
       checks: write
@@ -22,10 +88,6 @@ jobs:
     timeout-minutes: 70
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Determine base URL
-        id: base
-        run: |
-          [ -n "${{ secrets.STAGING_BASE_URL }}" ] && echo "url=${{ secrets.STAGING_BASE_URL }}" >> $GITHUB_OUTPUT || (echo "No STAGING_BASE_URL"; exit 1)
       - name: Python env for e2e
         run: |
           python3 -m venv .venv; . .venv/bin/activate
@@ -39,15 +101,15 @@ jobs:
           mkdir -p artifacts/performance
           k6 run \
             --summary-export artifacts/performance/k6-linux-summary.json \
-            -e BASE_URL="${{ steps.base.outputs.url }}" \
+            -e BASE_URL="${{ needs.resolve-target.outputs.base_url }}" \
             .github/tools/e2e/k6-rich.js
       - name: pytest e2e (Linux)
         run: |
           . .venv/bin/activate
-          BASE_URL="${{ steps.base.outputs.url }}" pytest -q .github/tools/e2e/tests
+          BASE_URL="${{ needs.resolve-target.outputs.base_url }}" pytest -q .github/tools/e2e/tests
       - name: Run user shell scripts
         run: |
-          export BASE_URL="${{ steps.base.outputs.url }}"
+          export BASE_URL="${{ needs.resolve-target.outputs.base_url }}"
           [ -f "./security_test.sh" ] && bash ./security_test.sh || true
           [ -f "./scripts/security_test.sh" ] && bash ./scripts/security_test.sh || true
           [ -f "./stress_test.sh" ] && bash ./stress_test.sh || true
@@ -60,6 +122,7 @@ jobs:
           path: artifacts/performance/
           if-no-files-found: ignore
   e2e-windows:
+    needs: resolve-target
     permissions:
       contents: read
       checks: write
@@ -67,11 +130,6 @@ jobs:
     timeout-minutes: 70
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Determine base URL
-        id: base
-        shell: pwsh
-        run: |
-          if ($env:STAGING_BASE_URL) { "url=$($env:STAGING_BASE_URL)" >> $env:GITHUB_OUTPUT } else { Write-Host "Set STAGING_BASE_URL"; exit 1 }
       - name: Python env for e2e (Windows)
         shell: pwsh
         run: |
@@ -88,15 +146,15 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/performance | Out-Null
-          & "${{ env.K6_EXE }}" run --summary-export artifacts/performance/k6-windows-summary.json -e BASE_URL="${{ steps.base.outputs.url }}" .github/tools/e2e/k6-rich.js
+          & "${{ env.K6_EXE }}" run --summary-export artifacts/performance/k6-windows-summary.json -e BASE_URL="${{ needs.resolve-target.outputs.base_url }}" .github/tools/e2e/k6-rich.js
       - name: pytest e2e (Windows)
         shell: pwsh
         run: |
-          $env:BASE_URL = "${{ steps.base.outputs.url }}"; python -m pytest -q .github/tools/e2e/tests
+          $env:BASE_URL = "${{ needs.resolve-target.outputs.base_url }}"; python -m pytest -q .github/tools/e2e/tests
       - name: Run PowerShell scripts
         shell: pwsh
         run: |
-          $env:BASE_URL = "${{ steps.base.outputs.url }}"
+          $env:BASE_URL = "${{ needs.resolve-target.outputs.base_url }}"
           if (Test-Path "./security_test.ps1") { ./security_test.ps1 -ErrorAction Continue }
           if (Test-Path "./scripts/security_test.ps1") { ./scripts/security_test.ps1 -ErrorAction Continue }
           if (Test-Path "./stress_test.ps1") { ./stress_test.ps1 -ErrorAction Continue }
@@ -109,6 +167,7 @@ jobs:
           path: artifacts/performance/
           if-no-files-found: ignore
   e2e-macos:
+    needs: resolve-target
     permissions:
       contents: read
       checks: write
@@ -116,18 +175,14 @@ jobs:
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Determine base URL
-        id: base
-        run: |
-          [ -n "${{ secrets.STAGING_BASE_URL }}" ] && echo "url=${{ secrets.STAGING_BASE_URL }}" >> $GITHUB_OUTPUT || (echo "No STAGING_BASE_URL"; exit 1)
       - name: pytest e2e (macOS)
         run: |
           python3 -m pip install --upgrade pip
           pip3 install -r .github/tools/e2e/requirements.txt
-          BASE_URL="${{ steps.base.outputs.url }}" pytest -q .github/tools/e2e/tests
+          BASE_URL="${{ needs.resolve-target.outputs.base_url }}" pytest -q .github/tools/e2e/tests
       - name: Run macOS helper scripts (zsh)
         shell: zsh {0}
         run: |
-          export BASE_URL="${{ steps.base.outputs.url }}"
+          export BASE_URL="${{ needs.resolve-target.outputs.base_url }}"
           [ -f "./scripts/macos/setup.zsh" ] && zsh ./scripts/macos/setup.zsh || true
           [ -f "./scripts/macos/test.zsh" ] && zsh ./scripts/macos/test.zsh || true

--- a/.github/workflows/security-attack-regression.yml
+++ b/.github/workflows/security-attack-regression.yml
@@ -1,6 +1,27 @@
 name: Security Attack Regression
 on:
   workflow_dispatch:
+    inputs:
+      profile:
+        description: "Hosted attack-regression mode"
+        required: true
+        default: compose-v1
+        type: choice
+        options:
+          - compose-v1
+          - staging-v1
+      target_nginx_http_base:
+        description: "Required for staging-v1. Example: http://staging.example.test"
+        required: false
+        type: string
+      target_nginx_https_base:
+        description: "Required for staging-v1. Example: https://staging.example.test"
+        required: false
+        type: string
+      target_admin_ui_base:
+        description: "Required for staging-v1. Example: https://admin.example.test"
+        required: false
+        type: string
   push:
     branches: ["main"]
     paths:
@@ -34,6 +55,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   compose-attack-regression:
+    if: github.event_name != 'workflow_dispatch' || inputs.profile == 'compose-v1'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -145,3 +167,73 @@ jobs:
         if: always()
         run: |
           docker compose -f docker-compose.yaml down -v --remove-orphans
+
+  hosted-staging-attack-regression:
+    if: github.event_name == 'workflow_dispatch' && inputs.profile == 'staging-v1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+      - name: Validate hosted staging target contract
+        run: |
+          set -euo pipefail
+          for var_name in \
+            TARGET_NGINX_HTTP_BASE \
+            TARGET_NGINX_HTTPS_BASE \
+            TARGET_ADMIN_UI_BASE
+          do
+            value="${!var_name:-}"
+            if [ -z "$value" ]; then
+              echo "Missing required workflow_dispatch input for staging-v1: ${var_name,,}" >&2
+              exit 1
+            fi
+          done
+        env:
+          TARGET_NGINX_HTTP_BASE: ${{ inputs.target_nginx_http_base }}
+          TARGET_NGINX_HTTPS_BASE: ${{ inputs.target_nginx_https_base }}
+          TARGET_ADMIN_UI_BASE: ${{ inputs.target_admin_ui_base }}
+      - name: Run hosted staging attack regression
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          mapfile -t allow_hosts < <(
+            python - <<'PY' \
+              "${{ inputs.target_nginx_http_base }}" \
+              "${{ inputs.target_nginx_https_base }}" \
+              "${{ inputs.target_admin_ui_base }}"
+import sys
+from urllib.parse import urlparse
+
+hosts = []
+for value in sys.argv[1:]:
+    host = urlparse(value).hostname
+    if host and host not in hosts:
+        hosts.append(host)
+for host in hosts:
+    print(host)
+PY
+          )
+          args=()
+          for host in "${allow_hosts[@]}"; do
+            args+=(--allow-host "$host")
+          done
+          python scripts/security/attack_regression.py \
+            --profile "staging-v1" \
+            --nginx-http-base "${{ inputs.target_nginx_http_base }}" \
+            --nginx-https-base "${{ inputs.target_nginx_https_base }}" \
+            --admin-ui-base "${{ inputs.target_admin_ui_base }}" \
+            "${args[@]}" \
+            --output-path artifacts/attack-regression.json \
+            --json | tee artifacts/attack-regression.stdout.json
+      - name: Upload hosted staging artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: security-attack-regression-staging-artifacts
+          path: artifacts/
+          if-no-files-found: ignore

--- a/docs/attack_simulation_profiles.md
+++ b/docs/attack_simulation_profiles.md
@@ -75,3 +75,5 @@ python scripts/security/attack_regression.py \
 - Increase `--max-requests` only when a specific profile requires it.
 - Keep this tool focused on defensive validation. Broader recon and
   opportunistic scanning remain in the separate Kali security sweep workflow.
+- Use GitHub-hosted Linux runners for `compose-v1` and bounded `staging-v1`
+  validation. Use the self-hosted Kali sweep for broader tool-driven scanning.

--- a/docs/ci-security-regression.md
+++ b/docs/ci-security-regression.md
@@ -4,10 +4,19 @@
 - CI Tests (Linux/Windows/macOS): unit tests + linters; NGINX syntax; Helm/Kubeconform validation.
 - Security Audit: CodeQL, Semgrep, Trivy (fs+config), Bandit, pip-audit, npm/yarn audit, gosec/govulncheck, cargo-audit, hadolint, shellcheck, luacheck, md/yaml lint → roll-up to `reports/summary.json`.
 - Security Autofix: creates a PR with safe formatting/lint fixes (ruff/black/isort, eslint/prettier, luacheck/stylua, shfmt, hadolint, kubeconform).
-- Regression E2E: k6 + pytest across OSes; also runs your `security_test.*` and `stress_test.*` scripts if present.
+- Security Attack Regression: required GitHub-hosted Linux security gate. PR and `main` runs use a self-contained local Compose stack; manual runs can also target an approved external staging URL with the bounded `staging-v1` profile.
+- Kali Security Sweep: self-hosted Linux/Kali workflow for broader tool-heavy validation against approved staging, preview, or release-candidate targets.
+- Regression E2E: k6 + pytest across OSes against an explicit external target; also runs your `security_test.*` and `stress_test.*` scripts if present.
 - Windows IIS (self-hosted): ARR/URL Rewrite install + smoke + k6.
 - Deploy Staging: builds only contexts that have `Dockerfile` (repo root, `proxy/`, `prompt-router/`, `cloud-proxy/`) and deploys with Helm.
 - Deploy Production: manual or `v*` tags; environment-gated.
 - Promote on Green: auto prod deploy when staging E2E passes (still requires production env approval).
 - PR Previews: per-PR namespaces & URLs, auto cleanup.
 - Canary Shift: adjust NGINX canary weight (0–100).
+
+## Runner Topology
+
+- Use GitHub-hosted `ubuntu-latest` for deterministic required security regression gates.
+- Use a self-hosted runner labeled `linux`, `kali`, and `security-scan` for broader sweeps that need heavier offensive tooling.
+- WSL-based Kali is acceptable for manual or ad hoc operator-driven scans.
+- A dedicated Kali VM is preferred for scheduled self-hosted sweeps because it is easier to keep stable as a long-lived runner.

--- a/docs/environments-and-previews.md
+++ b/docs/environments-and-previews.md
@@ -3,6 +3,9 @@
 Create **staging** and **production** in Settings → Environments.
 - `staging`: set `STAGING_BASE_URL`, plus GCP secrets.
 - `production`: add required reviewers; set `PROD_BASE_URL`, plus GCP secrets.
+- `preview`: use the `Regression E2E` workflow `base_url` input with the
+  preview URL you want to exercise. Preview runs do not infer a URL from
+  secrets automatically.
 
 DNS:
 - `staging.example.com` → ingress LB
@@ -11,3 +14,10 @@ DNS:
 PR Previews:
 - Tag images as `pr-<num>-<sha>`, namespace `pr-<num>`, helm release `ai-scraping-defense-pr-<num>`.
 - Host `https://pr-<num>.<staging-domain>/`, commented on the PR; namespace deleted on close.
+
+Regression E2E target resolution:
+
+- `workflow_dispatch` with `base_url` set: uses that explicit URL
+- `environment=staging` or blank: uses `STAGING_BASE_URL`
+- `environment=production`: uses `PROD_BASE_URL`
+- `environment=preview`: requires explicit `base_url`

--- a/docs/security_assurance_program.md
+++ b/docs/security_assurance_program.md
@@ -19,7 +19,14 @@ Each release candidate should have evidence for all of the following:
    - results are retained as artifacts for release review
    - failures block the release until triaged or explicitly accepted
 
-3. **External/Kali validation**
+3. **Cross-platform external regression**
+   - the Regression E2E workflow runs against an explicit staging, preview, or
+     production-like URL
+   - the target source is documented by workflow input or repository secret
+   - failures are triaged as either product regressions or evidence-contract
+     problems
+
+4. **External/Kali validation**
    - the self-hosted Kali security sweep runs against an approved staging,
      preview, or release-candidate target
    - findings are attached to the release review, even when the run is
@@ -27,14 +34,14 @@ Each release candidate should have evidence for all of the following:
    - any high-severity findings must be converted into tracked issues before
      release
 
-4. **Operator readiness**
+5. **Operator readiness**
    - monitoring and response runbooks reflect the shipped behavior
    - the release includes operator-facing notes for auth, secrets, backups, and
      incident handling changes
    - at least one operator validates the relevant paths in a staging or lab
      environment
 
-5. **Third-party integration review**
+6. **Third-party integration review**
    - newly introduced vendors or hosted services are documented
    - each optional integration has a clear auth/secret model and transport
      expectation
@@ -54,6 +61,16 @@ Expected evidence:
 - stored JSON artifact
 - pass/fail summary for the active profile
 
+### Cross-platform external E2E
+
+Use `.github/workflows/regression-e2e.yml` against an explicit external target.
+
+Expected evidence:
+
+- workflow run URL
+- target source (`base_url` input, `STAGING_BASE_URL`, or `PROD_BASE_URL`)
+- k6 and pytest artifact/result set for the chosen target
+
 ### Self-hosted Kali sweep
 
 Use `.github/workflows/kali-security-sweep.yml` or the operator-run
@@ -64,6 +81,7 @@ Expected evidence:
 - target name and approval record
 - report bundle location
 - triage summary for high/critical findings
+- runner identity (self-hosted Kali, WSL, or VM)
 
 ## Third-Party Review Expectations
 

--- a/scripts/linux/security_scan.sh
+++ b/scripts/linux/security_scan.sh
@@ -2,7 +2,7 @@
 # security_scan.sh - Advanced security testing helper
 #
 
-# Usage: sudo ./security_scan.sh <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url] [api_base_url] [openapi_spec_url] [llm_endpoint] [llm_auth_token]
+# Usage: ./security_scan.sh <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url] [api_base_url] [openapi_spec_url] [llm_endpoint] [llm_auth_token]
 # - target_host_or_ip: IP or hostname for network scans
 # - web_url_for_nikto: full URL to scan with Nikto and ZAP (defaults to http://<target>)
 # - docker_image: optional container image to scan with Trivy
@@ -57,11 +57,20 @@ if [[ -n "$IMAGE" ]]; then
 fi
 
 if [[ -z "$TARGET" ]]; then
-    echo "Usage: sudo $0 <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url] [api_base_url] [openapi_spec_url] [llm_endpoint] [llm_auth_token]"
+    echo "Usage: $0 <target_host_or_ip> [web_url_for_nikto] [docker_image] [code_dir] [sqlmap_url] [api_base_url] [openapi_spec_url] [llm_endpoint] [llm_auth_token]"
     exit 1
 fi
 
-mkdir -p reports
+REPORT_DIR="${REPORT_DIR:-reports}"
+mkdir -p "$REPORT_DIR"
+if [[ "$REPORT_DIR" != "reports" ]]; then
+    if [[ -e reports && ! -L reports ]]; then
+        echo "reports path already exists and is not a symlink; refusing to replace it." >&2
+        exit 1
+    fi
+    rm -f reports
+    ln -s "$REPORT_DIR" reports
+fi
 
 echo "=== 0. HTTP Stack Probe (quick regression checks) ==="
 if command -v python3 >/dev/null 2>&1 && [[ -f "scripts/security/stack_probe.py" ]]; then
@@ -405,4 +414,4 @@ else
     echo "python3 or ai_driven_security_test.py missing. Skipping AI analysis."
 fi
 
-echo "Reports saved in the 'reports' directory. Review them for potential issues."
+echo "Reports saved in '$REPORT_DIR'. Review them for potential issues."


### PR DESCRIPTION
## Summary
- close #1720 by making Regression E2E resolve its target once with explicit input/secret guidance instead of failing opaquely in every matrix job
- clarify the GitHub-hosted vs self-hosted Kali security workflow split and add a hosted `staging-v1` attack-regression path
- let the Kali sweep write reports to an explicit runner-controlled report directory while keeping artifact upload stable

## Validation
- /home/rich/dev/ai-scraping-defense/.venv/bin/pre-commit run --files .github/workflows/security-attack-regression.yml .github/workflows/kali-security-sweep.yml .github/workflows/regression-e2e.yml scripts/linux/security_scan.sh docs/ci-security-regression.md docs/security_assurance_program.md docs/attack_simulation_profiles.md docs/environments-and-previews.md
- bash -n scripts/linux/security_scan.sh
- git diff --check

## Notes
- GitHub-hosted Linux remains the required deterministic security gate
- self-hosted Kali remains the broader tool-heavy sweep path
- preview E2E runs now require an explicit `base_url` input instead of silently assuming `STAGING_BASE_URL`
