### PR TITLE
Fix failing test: update assertion to match REPORT_DIR variable in security_scan.sh

### DIFF
--- a/test/test_security_scan_coverage.py
+++ b/test/test_security_scan_coverage.py
@@ -355,7 +355,8 @@ class TestSecurityScanCoverage:
         """Verify that security_scan.sh generates reports in a reports directory."""
         scan_script = _read_security_scan_sh()
 
-        assert "mkdir -p reports" in scan_script, "Reports directory not created"
+        assert ("mkdir -p reports" in scan_script or 'mkdir -p "$REPORT_DIR"' in scan_script), \
+            "Reports directory not created"
         assert (
             "reports/" in scan_script
         ), "Scan results not being written to reports directory"


### PR DESCRIPTION
Fixes a test assertion that was checking for the literal string `mkdir -p reports` but the script had been updated to use a configurable `$REPORT_DIR` variable (defaulting to `reports`).

## Root cause
`scripts/linux/security_scan.sh` was updated to support a `REPORT_DIR` environment variable override, but `test/test_security_scan_coverage.py::TestSecurityScanCoverage::test_security_scan_generates_reports` still asserted the old literal pattern.

## Fix
Allow either `mkdir -p reports` (old) or `mkdir -p "$REPORT_DIR"` (new) to satisfy the assertion.

## Test results
- Before: 1 failed, 730 passed
- After: 0 failed, 731 passed