### PR TITLE
Add community health templates and policies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible defect or regression
+title: "[Bug]: "
+labels: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve the project. Do not include credentials, private data, or unredacted production logs. Report vulnerabilities through the private security link instead.
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Provide the release, image tag, or commit SHA where the problem occurs.
+      placeholder: v1.2.3 or abc1234
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Runtime or core logic
+        - API or user interface
+        - Deployment or packaging
+        - Configuration or integration
+        - CI or developer tooling
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the operating system, runtime versions, deployment method, and relevant sanitized configuration.
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what impact did it have?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable sequence that demonstrates the problem.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Sanitized logs or other evidence
+      description: Remove secrets, tokens, personal data, internal hostnames, and sensitive IP addresses.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed secrets and sensitive data from this report.
+          required: true
+        - label: This is not a privately reportable security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/rhamenator/ai-scraping-defense/security/advisories/new
+    about: Do not disclose vulnerabilities in a public issue.
+  - name: Read the support policy
+    url: https://github.com/rhamenator/ai-scraping-defense/blob/main/SUPPORT.md
+    about: Review supported and unsupported requests before opening an issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,34 @@
+name: Documentation improvement
+description: Report missing, incorrect, or unclear documentation
+title: "[Docs]: "
+labels: []
+assignees: []
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link to or name the file, page, command help, or code comment.
+      placeholder: README.md, docs/USAGE.md, or a URL
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear or incorrect?
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Suggested improvement
+      description: Describe the information, example, or wording that would resolve the problem.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I checked the current default branch for an existing correction.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a new capability or meaningful improvement
+title: "[Feature]: "
+labels: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: Explain the user or operator problem before prescribing an implementation.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Who is affected, and what can they not do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed outcome
+      description: Describe the desired behavior, including an example if useful.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include workarounds or other designs you evaluated.
+  - type: textarea
+    id: impact
+    attributes:
+      label: Compatibility and operational impact
+      description: Note configuration, API, migration, performance, privacy, or security implications.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and did not find an equivalent request.
+          required: true
+        - label: I am willing to help test or implement this change.
+          required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,36 @@
+name: Question or support request
+description: Ask for help using or operating the project
+title: "[Question]: "
+labels: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: Support is provided on a best-effort basis. See SUPPORT.md before submitting. Do not post secrets or vulnerability details.
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: attempted
+    attributes:
+      label: What have you tried?
+      description: Include relevant documentation and sanitized commands or configuration.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include versions and deployment method when relevant.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I read the relevant documentation and searched existing issues.
+          required: true
+        - label: I removed credentials and sensitive data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,49 +1,38 @@
-## Description
+## Summary
 
-Please include a summary of the change and which issue is fixed or which feature is added. Please also include relevant motivation and context. List any dependencies that are required for this change.
+<!-- Explain what changed and why. Focus on behavior and outcomes. -->
 
-Closes # (issue number)
+## Related issue
+
+<!-- Use "Closes #123" when this PR should close an issue. -->
 
 ## Type of change
 
-Please delete options that are not relevant.
+- [ ] Bug fix
+- [ ] Feature or enhancement
+- [ ] Documentation
+- [ ] Refactor or maintenance
+- [ ] Security hardening
+- [ ] Dependency or CI update
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-- [ ] Refactoring / Code cleanup
-- [ ] Build / CI / Configuration change
-- [ ] Other (please describe):
+## Validation
 
-## How Has This Been Tested?
+<!-- List exact commands and results. Explain anything not run. -->
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+```text
+command -> result
+```
 
-- [ ] Manual Test (describe steps)
-- [ ] Unit Test (add new or update existing)
-- [ ] Integration Test (add new or update existing)
-- [ ] Tested locally using `docker-compose up`
+## Operational impact
 
-**Test Configuration Details:**
-
-- OS:
-- Docker Version:
-- Browser (if applicable):
+<!-- Note configuration, API, deployment, migration, performance, privacy, or security effects. Write "None" when not applicable. -->
 
 ## Checklist
 
-- [ ] My code follows the style guidelines of this project (e.g., PEP 8).
-- [ ] I have performed a self-review of my own code.
-- [ ] I have commented my code, particularly in hard-to-understand areas.
-- [ ] I have made corresponding changes to the documentation.
-- [ ] My changes generate no new warnings.
-- [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] New and existing unit tests pass locally with my changes.
-- [ ] Any dependent changes have been merged and published in downstream modules.
-- [ ] I have checked my changes haven't introduced sensitive information.
-- [ ] I have updated the `CHANGELOG.md` if applicable.
-
-## Screenshots (if applicable)
-
-Add any relevant screenshots demonstrating the change or fix.
+- [ ] The change is focused and does not include unrelated edits.
+- [ ] Tests cover new or changed behavior where practical.
+- [ ] Relevant formatters, linters, and security checks pass.
+- [ ] Documentation and examples are updated for user-visible changes.
+- [ ] No secrets, credentials, private data, or generated artifacts are committed.
+- [ ] Breaking changes and migration steps are clearly identified.
+- [ ] I followed `CONTRIBUTING.md` and the repository-specific validation guidance.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+## Our commitment
+
+We are committed to a respectful, inclusive, and technically constructive project community. Participation should remain welcoming regardless of experience, identity, background, or viewpoint.
+
+## Expected behavior
+
+- Be respectful and assume good intent while discussing ideas.
+- Give actionable, evidence-based feedback about the work rather than the person.
+- Respect privacy, confidentiality, and responsible disclosure requirements.
+- Accept maintainer decisions and disengage when a discussion is closed.
+- Help keep issues and pull requests focused and accessible.
+
+## Unacceptable behavior
+
+Harassment, discrimination, threats, personal attacks, deliberate disruption, sexualized content, publishing private information, or other conduct that would reasonably make participation unsafe is not acceptable.
+
+## Scope and enforcement
+
+This policy applies in repository discussions, issues, pull requests, reviews, and other project spaces. Maintainers may edit or remove content, close or lock discussions, reject contributions, or temporarily or permanently restrict participation when necessary.
+
+Report conduct concerns privately using a contact method in [SECURITY.md](SECURITY.md). Do not include sensitive personal information in a public issue. If the concern involves the repository owner or violates GitHub policy, use GitHub's platform reporting tools.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,13 @@
 
 Thank you for considering contributing to this project! We aim to build a robust, ethical, and effective defense against unwanted AI scraping, and community contributions are vital.
 
+## Choose the Right Channel
+
+- Use the structured bug, feature, documentation, or support form when opening an issue.
+- Read [SUPPORT.md](SUPPORT.md) before requesting usage help.
+- Report vulnerabilities privately according to [SECURITY.md](SECURITY.md); never put vulnerability details in a public issue.
+- Follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) in all project interactions.
+
 ## Attribution
 
 If you use this project or its components in your own work (open-source or commercial), you must:
@@ -45,6 +52,13 @@ Contributions should meet the engineering-quality baseline in [docs/engineering_
 - avoid mixing unrelated refactors into security or behavior fixes
 
 The baseline document also explains how local validation maps to the repository CI and release gates.
+
+For typical Python changes, run:
+
+```bash
+pre-commit run --files <changed-file> [<changed-file> ...]
+python -m pytest -q test
+```
 
 ## Code Style (Example)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ We encourage users to stay on the latest stable release for the most up-to-date 
 We appreciate responsible disclosure of security vulnerabilities. If you discover a potential security issue in this project:
 
 1. **Do NOT open a public GitHub issue.** Public disclosure could put users at risk before a fix is available.
-2. **Email us directly** at **[rhamenator@gmail.com]**.
+2. **Preferred:** Open a [private GitHub security advisory](https://github.com/rhamenator/ai-scraping-defense/security/advisories/new). If private reporting is unavailable, email **rhamenator@gmail.com**.
 3. **Provide detailed information** in your report, including:
     * A clear description of the vulnerability.
     * Steps to reproduce the issue (code snippets, configurations, or sequences of requests are helpful).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# Support
+
+Support for this open-source project is provided on a best-effort basis.
+
+## Before requesting help
+
+1. Read the project README and relevant files under `docs/`.
+2. Search existing issues for the error message or behavior.
+3. Reproduce the problem with the latest supported release or default branch when practical.
+4. Remove credentials, private data, internal hostnames, and other sensitive information.
+
+Use the structured **Question or support request** issue form for usage help. Use the **Bug report** form only for reproducible defects, and the **Feature request** form for proposed behavior.
+
+## Scope
+
+Maintainers can help clarify documented behavior, evaluate reproducible project defects, and consider broadly useful enhancements. Bespoke deployment design, incident response, infrastructure administration, and debugging heavily modified forks may be outside the available support capacity.
+
+## Security
+
+Do not disclose vulnerabilities publicly. Follow [SECURITY.md](SECURITY.md) and use GitHub's private vulnerability reporting channel.


### PR DESCRIPTION
## Summary

- Added structured bug, feature, documentation, and support issue forms.
- Added a locked-down issue chooser with private security reporting and support links.
- Added or refreshed the pull request template.
- Updated the existing contribution, security, and pull request guidance.

## Validation

- Issue-form YAML parsing and schema assertions: passed
- Relative Markdown link check: passed
- `git diff --cached --check`: passed
- EOF and mixed-line-ending check: passed
- `pre-commit run --files ...`: blocked before hooks ran by a Git-for-Windows `dofork` failure while initializing Black; the applicable file checks were run directly
- Code tests not run (Markdown and GitHub configuration only)

## Operational impact

Contributor-facing files only; no runtime behavior changes.