### PR TITLE
Fix CodeQL C# analysis and failure handling

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -44,7 +44,6 @@ jobs:
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
         if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
-        continue-on-error: true
         uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
@@ -64,6 +63,5 @@ jobs:
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@ce729e4d353d580e6cacd6a8cf2921b72e5e310a
         if: always() && hashFiles('results.sarif') != ''
-        continue-on-error: true
         with:
           sarif_file: results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,6 +86,9 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
+      env:
+        # Overlay databases do not support traced/manual builds.
+        CODEQL_OVERLAY_DATABASE_MODE: ${{ matrix.build-mode == 'manual' && 'none' || '' }}
       uses: github/codeql-action/init@ce729e4d353d580e6cacd6a8cf2921b72e5e310a
       with:
         languages: ${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'csharp' && 'windows-latest') || 'ubuntu-latest' }}
     permissions:
       # required for all workflows
       security-events: write
@@ -53,7 +53,7 @@ jobs:
         - language: actions
           build-mode: none
         - language: csharp
-          build-mode: none
+          build-mode: manual
         - language: javascript-typescript
           build-mode: none
         - language: python
@@ -71,6 +71,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+    - name: Set up .NET
+      if: matrix.language == 'csharp'
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
+      with:
+        dotnet-version: '8.0.x'
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -91,25 +97,14 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
+    - name: Build C# for CodeQL
+      if: matrix.language == 'csharp'
+      shell: pwsh
       run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+        dotnet restore ai-scraping-defense.sln
+        dotnet build ai-scraping-defense.sln --no-restore --configuration Release
 
     - name: Perform CodeQL Analysis
-      continue-on-error: true
       uses: github/codeql-action/analyze@ce729e4d353d580e6cacd6a8cf2921b72e5e310a
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -34,7 +34,6 @@ jobs:
 
       - name: Upload DevSkim scan results to GitHub Security tab
         if: always() && hashFiles('devskim-results.sarif') != ''
-        continue-on-error: true
         uses: github/codeql-action/upload-sarif@ce729e4d353d580e6cacd6a8cf2921b72e5e310a
         with:
           sarif_file: devskim-results.sarif

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -17,19 +17,11 @@ jobs:
   audit:
     permissions:
       contents: read
-      security-events: write
-      actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with: { fetch-depth: 0 }
-      - uses: github/codeql-action/init@ce729e4d353d580e6cacd6a8cf2921b72e5e310a
-        with:
-          languages: "javascript, typescript, python, go, ruby, java, cpp"
-      - uses: github/codeql-action/autobuild@ce729e4d353d580e6cacd6a8cf2921b72e5e310a
-      - uses: github/codeql-action/analyze@ce729e4d353d580e6cacd6a8cf2921b72e5e310a
-        with: { category: "/language:auto" }
       - name: Install scanners & deps
         run: |
           set -eux

--- a/iis/DefenseModule/DefenseModule.cs
+++ b/iis/DefenseModule/DefenseModule.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Configuration;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Runtime.Caching;
+using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using System.Web.Script.Serialization;
 using StackExchange.Redis;
 
 namespace AntiScrape.IIS
@@ -53,14 +56,14 @@ namespace AntiScrape.IIS
             if (isBlocked)
             {
                 ctx.Response.StatusCode = 403;
-                ctx.CompleteRequest();
+                app.CompleteRequest();
                 return;
             }
 
             if (await IsRateLimitedAsync(db, tenant, ip))
             {
                 ctx.Response.StatusCode = 429;
-                ctx.CompleteRequest();
+                app.CompleteRequest();
                 return;
             }
 
@@ -73,7 +76,7 @@ namespace AntiScrape.IIS
             {
                 await EscalateAsync(ip, "BadUA");
                 ctx.Response.StatusCode = 403;
-                ctx.CompleteRequest();
+                app.CompleteRequest();
                 return;
             }
 
@@ -109,11 +112,16 @@ namespace AntiScrape.IIS
         {
             var endpoint = ConfigurationManager.AppSettings["ESCALATION_ENDPOINT"];
             if (string.IsNullOrEmpty(endpoint)) return;
-            using (var client = new System.Net.Http.HttpClient())
+            using (var client = new HttpClient())
             {
                 try
                 {
-                    await client.PostAsJsonAsync(endpoint, new { ip, reason });
+                    var payload = new JavaScriptSerializer().Serialize(new { ip, reason });
+                    using (var content = new StringContent(payload, Encoding.UTF8, "application/json"))
+                    using (var response = await client.PostAsync(endpoint, content))
+                    {
+                        response.EnsureSuccessStatusCode();
+                    }
                     Logger.TraceEvent(TraceEventType.Information, 0, $"Escalated {ip} for {reason}");
                 }
                 catch

--- a/iis/DefenseModule/DefenseModule.csproj
+++ b/iis/DefenseModule/DefenseModule.csproj
@@ -5,4 +5,11 @@
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.6.66" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- build the .NET Framework IIS module on Windows during C# CodeQL analysis
- add the framework references and API fixes required for a clean C# build
- remove the redundant CodeQL configuration from the manual security audit
- make CodeQL, Codacy, and DevSkim analysis/upload failures fail their workflows

## Root cause
The primary CodeQL workflow used no-build extraction for C#, so the workflow could report success even though the IIS project did not compile and CodeQL logged unresolved types. The analyze step was also marked continue-on-error, which masked analysis failures. A second, outdated CodeQL configuration existed in the manual security audit.

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest on all four modified workflows
- dotnet restore ai-scraping-defense.sln
- dotnet build ai-scraping-defense.sln --no-restore --configuration Release (0 warnings, 0 errors)
- git diff --check
- direct mixed-line-ending, trailing-whitespace, and final-newline checks

The repository pre-commit command could not initialize Black because Git for Windows failed to fork git-submodule after the power interruption; it failed before examining the changed files. Equivalent file-hygiene checks were run directly.